### PR TITLE
アプリコンテナの停止・再起動の実装

### DIFF
--- a/pkg/container/dockerimpl/manager.go
+++ b/pkg/container/dockerimpl/manager.go
@@ -3,6 +3,7 @@ package dockerimpl
 import (
 	"context"
 	"fmt"
+
 	docker "github.com/fsouza/go-dockerclient"
 	"github.com/leandro-lugaresi/hub"
 	log "github.com/sirupsen/logrus"
@@ -13,6 +14,7 @@ const (
 	appNetwork                     = "neoshowcase_apps"
 	appContainerLabel              = "neoshowcase.trap.jp/app"
 	appContainerApplicationIDLabel = "neoshowcase.trap.jp/appId"
+	timeout                        = 5
 )
 
 type Manager struct {

--- a/pkg/container/dockerimpl/restart.go
+++ b/pkg/container/dockerimpl/restart.go
@@ -1,0 +1,17 @@
+package dockerimpl
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/traPtitech/neoshowcase/pkg/container"
+)
+
+func (m *Manager) Restart(ctx context.Context, args container.RestartArgs) (*container.RestartResult, error) {
+	// コンテナを止めて5秒待ったのちkillし, コンテナを再起動
+	err := m.c.RestartContainer(containerName(args.ApplicationID), timeout)
+	if err != nil {
+		return nil, fmt.Errorf("failed to restart container: %w", err)
+	}
+	return &container.RestartResult{}, nil
+}

--- a/pkg/container/dockerimpl/stop.go
+++ b/pkg/container/dockerimpl/stop.go
@@ -1,0 +1,17 @@
+package dockerimpl
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/traPtitech/neoshowcase/pkg/container"
+)
+
+func (m *Manager) Stop(ctx context.Context, args container.StopArgs) (*container.StopResult, error) {
+	// コンテナを止めて5秒待ったのちkill
+	err := m.c.StopContainer(containerName(args.ApplicationID), timeout)
+	if err != nil {
+		return nil, fmt.Errorf("failed to stop container: %w", err)
+	}
+	return &container.StopResult{}, nil
+}

--- a/pkg/container/manager.go
+++ b/pkg/container/manager.go
@@ -7,8 +7,8 @@ import (
 type Manager interface {
 	Create(ctx context.Context, args CreateArgs) (*CreateResult, error)
 	// TODO Start(ctx context.Context, ) k8sではCreateと同じ
-	// TODO Stop(ctx context.Context, ) k8sではDestroyと同じ
-	// TODO Restart(ctx context.Context, ) k8sではCreateと同じ
+	Stop(ctx context.Context, args StopArgs) (*StopResult, error)          // k8sではDestroyと同じ
+	Restart(ctx context.Context, args RestartArgs) (*RestartResult, error) // k8sではCreateと同じ
 	Destroy(ctx context.Context, args DestroyArgs) (*DestroyResult, error)
 	List(ctx context.Context) (*ListResult, error)
 	Dispose(ctx context.Context) error
@@ -36,6 +36,20 @@ type DestroyArgs struct {
 }
 
 type DestroyResult struct {
+}
+
+type StopArgs struct {
+	ApplicationID string
+}
+
+type StopResult struct {
+}
+
+type RestartArgs struct {
+	ApplicationID string
+}
+
+type RestartResult struct {
 }
 
 type ListResult struct {


### PR DESCRIPTION
- `StopContainer()`関数や`RestartContainer()`関数を用いてコンテナの停止・再起動を実装
    - タイムアウトは5秒に設定、定数に追加

close #8 