### PR TITLE
#5 汎用ベースイメージの作成

### DIFF
--- a/img/Dockerfile
+++ b/img/Dockerfile
@@ -1,27 +1,28 @@
 FROM ubuntu:20.10
 
-ENV TZ=Asia/Tokyo 
-
 RUN apt-get update &&  \
     apt-get install -y --no-install-recommends tzdata && \
     apt-get install -y --no-install-recommends \
-    make git curl zip tar wget \
+    make git curl wget unzip \
     gcc \
     nodejs npm yarn \
     python3 python3-pip \
     php composer \
     openjdk-15-jdk &&\
-    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y &&\
+    curl -sSf https://sh.rustup.rs | sh -s -- -y &&\
     wget https://golang.org/dl/go1.15.6.linux-amd64.tar.gz && \
     tar -C /usr/local -xvf go1.15.6.linux-amd64.tar.gz && \
-    rm go1.15.6.linux-amd64.tar.gz &&\
     wget https://packages.microsoft.com/config/ubuntu/20.10/packages-microsoft-prod.deb -O packages-microsoft-prod.deb && \
     dpkg -i packages-microsoft-prod.deb &&\
     apt-get install -y --no-install-recommends apt-transport-https &&\
     apt-get update &&\
     apt-get install -y --no-install-recommends dotnet-sdk-5.0 aspnetcore-runtime-5.0 &&\
-    rm -rf /var/lib/apt/lists/*
+    wget https://services.gradle.org/distributions/gradle-6.7.1-bin.zip &&\
+    mkdir /opt/gradle &&\
+    unzip -d /opt/gradle gradle-6.7.1-bin.zip &&\
+    rm -rf /var/lib/apt/lists/* packages-microsoft-prod.deb gradle-6.7.1-bin.zip go1.15.6.linux-amd64.tar.gz
 
-ENV JAVA_HOME=/usr/lib/jvm/openjdk-15-jdk
+ENV JAVA_HOME=/usr/lib/jvm/java-15-openjdk-amd64
 ENV PATH=$PATH:$JAVA_HOME/bin
 ENV PATH=$PATH:/usr/local/go/bin
+ENV PATH=$PATH:/opt/gradle/gradle-6.7.1/bin

--- a/img/Dockerfile
+++ b/img/Dockerfile
@@ -1,0 +1,27 @@
+FROM ubuntu:20.10
+
+ENV TZ=Asia/Tokyo 
+
+RUN apt-get update &&  \
+    apt-get install -y --no-install-recommends tzdata && \
+    apt-get install -y --no-install-recommends \
+    make git curl zip tar wget \
+    gcc \
+    nodejs npm yarn \
+    python3 python3-pip \
+    php composer \
+    openjdk-15-jdk &&\
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y &&\
+    wget https://golang.org/dl/go1.15.6.linux-amd64.tar.gz && \
+    tar -C /usr/local -xvf go1.15.6.linux-amd64.tar.gz && \
+    rm go1.15.6.linux-amd64.tar.gz &&\
+    wget https://packages.microsoft.com/config/ubuntu/20.10/packages-microsoft-prod.deb -O packages-microsoft-prod.deb && \
+    dpkg -i packages-microsoft-prod.deb &&\
+    apt-get install -y --no-install-recommends apt-transport-https &&\
+    apt-get update &&\
+    apt-get install -y --no-install-recommends dotnet-sdk-5.0 aspnetcore-runtime-5.0 &&\
+    rm -rf /var/lib/apt/lists/*
+
+ENV JAVA_HOME=/usr/lib/jvm/openjdk-15-jdk
+ENV PATH=$PATH:$JAVA_HOME/bin
+ENV PATH=$PATH:/usr/local/go/bin


### PR DESCRIPTION
コンテナ環境
- ubuntu:20.10
- make,git,wget,unzip,curl
- nodejs
    - yarn
    - npm
- go:1.15.6
- python3
    - pip
- rust
    - cargo
- php
    - composer
- java:openjdk-15
    - gradle:6.7.1
- gcc 
- .NET 5
(:がついているものは直接バージョンを指定しているもの)
イメージサイズは大体2.8GBくらいです
unzip や curl等は使い終わったらアンインストールしておくべきでしょうか？
あとrustのdoc(.html)が400MBくらい使っているのですが、消したほうがいいのでしょうか？
あと結構読みにくいのですが、分けたほうがいいのでしょうか？