### PR TITLE
コンテナへの環境変数の指定を実装

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -47,6 +47,9 @@ require (
 	google.golang.org/protobuf v1.25.0
 	gopkg.in/ini.v1 v1.61.0 // indirect
 	gopkg.in/yaml.v2 v2.3.0
+	k8s.io/api v0.19.0
+	k8s.io/apimachinery v0.19.0
+	k8s.io/client-go v0.19.0
 )
 
 replace github.com/jaguilar/vt100 => github.com/tonistiigi/vt100 v0.0.0-20190402012908-ad4c4a574305

--- a/pkg/container/dockerimpl/create.go
+++ b/pkg/container/dockerimpl/create.go
@@ -3,6 +3,7 @@ package dockerimpl
 import (
 	"context"
 	"fmt"
+
 	docker "github.com/fsouza/go-dockerclient"
 	"github.com/traPtitech/neoshowcase/pkg/container"
 	"github.com/traPtitech/neoshowcase/pkg/util"
@@ -37,6 +38,7 @@ func (m *Manager) Create(ctx context.Context, args container.CreateArgs) (*conta
 		Config: &docker.Config{
 			Image:  args.ImageName + ":" + args.ImageTag,
 			Labels: labels,
+			Env:    args.Envs,
 		},
 		HostConfig: &docker.HostConfig{
 			RestartPolicy: docker.RestartOnFailure(5),

--- a/pkg/container/dockerimpl/create.go
+++ b/pkg/container/dockerimpl/create.go
@@ -32,13 +32,19 @@ func (m *Manager) Create(ctx context.Context, args container.CreateArgs) (*conta
 		})
 	}
 
+	var envs []string
+
+	for name, value := range args.Envs {
+		envs = append(envs, name+"="+value)
+	}
+
 	// ビルドしたイメージのコンテナを作成
 	cont, err := m.c.CreateContainer(docker.CreateContainerOptions{
 		Name: containerName(args.ApplicationID),
 		Config: &docker.Config{
 			Image:  args.ImageName + ":" + args.ImageTag,
 			Labels: labels,
-			Env:    args.Envs,
+			Env:    envs,
 		},
 		HostConfig: &docker.HostConfig{
 			RestartPolicy: docker.RestartOnFailure(5),

--- a/pkg/container/k8simpl/create.go
+++ b/pkg/container/k8simpl/create.go
@@ -3,7 +3,6 @@ package k8simpl
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/traPtitech/neoshowcase/pkg/container"
 	"github.com/traPtitech/neoshowcase/pkg/util"
@@ -22,8 +21,8 @@ func (m *Manager) Create(ctx context.Context, args container.CreateArgs) (*conta
 
 	var envs []apiv1.EnvVar
 
-	for _, env := range args.Envs {
-		envs = append(envs, apiv1.EnvVar{Name: strings.SplitN(env, "=", 2)[0], Value: strings.SplitN(env, "=", 2)[1]})
+	for name, value := range args.Envs {
+		envs = append(envs, apiv1.EnvVar{Name: name, Value: value})
 	}
 
 	cont := apiv1.Container{

--- a/pkg/container/k8simpl/create.go
+++ b/pkg/container/k8simpl/create.go
@@ -23,7 +23,7 @@ func (m *Manager) Create(ctx context.Context, args container.CreateArgs) (*conta
 	var envs []apiv1.EnvVar
 
 	for _, env := range args.Envs {
-		envs = append(envs, apiv1.EnvVar{Name: strings.Split(env, "=")[0], Value: strings.Split(env, "=")[1]})
+		envs = append(envs, apiv1.EnvVar{Name: strings.SplitN(env, "=", 2)[0], Value: strings.SplitN(env, "=", 2)[1]})
 	}
 
 	cont := apiv1.Container{

--- a/pkg/container/k8simpl/create.go
+++ b/pkg/container/k8simpl/create.go
@@ -3,6 +3,8 @@ package k8simpl
 import (
 	"context"
 	"fmt"
+	"strings"
+
 	"github.com/traPtitech/neoshowcase/pkg/container"
 	"github.com/traPtitech/neoshowcase/pkg/util"
 	appsv1 "k8s.io/api/apps/v1"
@@ -18,9 +20,16 @@ func (m *Manager) Create(ctx context.Context, args container.CreateArgs) (*conta
 		appContainerApplicationIDLabel: args.ApplicationID,
 	})
 
+	var envs []apiv1.EnvVar
+
+	for _, env := range args.Envs {
+		envs = append(envs, apiv1.EnvVar{Name: strings.Split(env, "=")[0], Value: strings.Split(env, "=")[1]})
+	}
+
 	cont := apiv1.Container{
 		Name:  "app",
 		Image: args.ImageName + ":" + args.ImageTag,
+		Env:   envs,
 	}
 	if args.HTTPProxy != nil {
 		cont.Ports = []apiv1.ContainerPort{

--- a/pkg/container/manager.go
+++ b/pkg/container/manager.go
@@ -19,6 +19,7 @@ type CreateArgs struct {
 	ImageName     string
 	ImageTag      string
 	Labels        map[string]string
+	Envs          []string // ex.) ["VAR=value", ...]
 	HTTPProxy     *HTTPProxy
 	NoStart       bool
 }

--- a/pkg/container/manager.go
+++ b/pkg/container/manager.go
@@ -19,7 +19,7 @@ type CreateArgs struct {
 	ImageName     string
 	ImageTag      string
 	Labels        map[string]string
-	Envs          []string // ex.) ["VAR=value", ...]
+	Envs          map[string]string
 	HTTPProxy     *HTTPProxy
 	NoStart       bool
 }


### PR DESCRIPTION
### 変更内容
- `CreateArgs`に`Envs`フィールドを実装
- それぞれのコンテナの`Create`関数を環境変数を追加するように変更
- `go mod tidy`

close #14