### PR TITLE
BuildのCancel処理ができないバグの修正

### DIFF
--- a/pkg/builder/task.go
+++ b/pkg/builder/task.go
@@ -288,7 +288,7 @@ ENTRYPOINT ./%s
 	})
 	eg.Go(func() error {
 		// ビルドログを収集
-		return progressui.DisplaySolveStatus(ctx, "", nil, logWriter, ch)
+		return progressui.DisplaySolveStatus(context.TODO(), "", nil, logWriter, ch)
 	})
 
 	return eg.Wait()
@@ -341,7 +341,7 @@ func (t *Task) buildStatic(s *Service) error {
 	})
 	eg.Go(func() error {
 		// ビルドログを収集
-		return progressui.DisplaySolveStatus(ctx, "", nil, logWriter, ch)
+		return progressui.DisplaySolveStatus(context.TODO(), "", nil, logWriter, ch)
 	})
 
 	return eg.Wait()


### PR DESCRIPTION
- `progressui.DisplaySolveStatus()`の引数のcontextを`ctx`から`context.TODO()`に変更
- エラーの場合分けに`errors.Is(err, status.FromContextError(context.Canceled).Err())`をORで追加

close #44