### PR TITLE
コンテナマネージャーでコンテナの標準出力ログを取得可能にする

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@
 
 .idea/
 .vscode/
+.tool-versions

--- a/pkg/domain/backend.go
+++ b/pkg/domain/backend.go
@@ -42,6 +42,7 @@ type Backend interface {
 	RestartContainer(ctx context.Context, appID string, envID string) error
 	DestroyContainer(ctx context.Context, appID string, envID string) error
 	ListContainers(ctx context.Context) ([]Container, error)
+	GetContainerLog(ctx context.Context, appID string, envID string) (string, error)
 	RegisterIngress(ctx context.Context, appID string, envID string, host string, destination null.String, port null.Int) error
 	UnregisterIngress(ctx context.Context, appID string, envID string) error
 	Dispose(ctx context.Context) error

--- a/pkg/domain/backend.go
+++ b/pkg/domain/backend.go
@@ -42,7 +42,6 @@ type Backend interface {
 	RestartContainer(ctx context.Context, appID string, envID string) error
 	DestroyContainer(ctx context.Context, appID string, envID string) error
 	ListContainers(ctx context.Context) ([]Container, error)
-	GetContainerLog(ctx context.Context, appID string, envID string) (string, error)
 	RegisterIngress(ctx context.Context, appID string, envID string, host string, destination null.String, port null.Int) error
 	UnregisterIngress(ctx context.Context, appID string, envID string) error
 	Dispose(ctx context.Context) error

--- a/pkg/infrastructure/backend/dockerimpl/get_container_log.go
+++ b/pkg/infrastructure/backend/dockerimpl/get_container_log.go
@@ -1,0 +1,34 @@
+package dockerimpl
+
+import (
+	"bytes"
+	"context"
+
+	docker "github.com/fsouza/go-dockerclient"
+)
+
+type LogOptions struct {
+	Tail   string
+	Stdout bool
+	Stderr bool
+	Since  int64
+}
+
+func (d *dockerBackend) GetContainerLog(ctx context.Context, appID string, envID string, opt LogOptions) (string, error) {
+	str := &bytes.Buffer{}
+	logopts := docker.LogsOptions{
+		Context:      ctx,
+		Container:    containerName(appID, envID),
+		OutputStream: str,
+		Tail:         opt.Tail,
+		Stdout:       opt.Stdout,
+		Stderr:       opt.Stderr,
+		Since:        opt.Since,
+		RawTerminal:  true,
+	}
+	err := d.c.Logs(logopts)
+	if err != nil {
+		return "", err
+	}
+	return str.String(), nil
+}

--- a/pkg/infrastructure/backend/dockerimpl/get_container_log.go
+++ b/pkg/infrastructure/backend/dockerimpl/get_container_log.go
@@ -8,23 +8,19 @@ import (
 )
 
 type LogOptions struct {
-	Tail   string
-	Stdout bool
-	Stderr bool
-	Since  int64
+	Tail  string
+	Since int64
 }
 
-func (b *dockerBackend) GetContainerLog(ctx context.Context, appID string, envID string, opt LogOptions) (string, error) {
+func (b *dockerBackend) GetContainerStdOut(ctx context.Context, appID string, envID string, opt LogOptions) (string, error) {
 	str := &bytes.Buffer{}
 	logopts := docker.LogsOptions{
 		Context:      ctx,
 		Container:    containerName(appID, envID),
 		OutputStream: str,
 		Tail:         opt.Tail,
-		Stdout:       opt.Stdout,
-		Stderr:       opt.Stderr,
+		Stdout:       true,
 		Since:        opt.Since,
-		RawTerminal:  true,
 	}
 	err := b.c.Logs(logopts)
 	if err != nil {

--- a/pkg/infrastructure/backend/dockerimpl/get_container_log.go
+++ b/pkg/infrastructure/backend/dockerimpl/get_container_log.go
@@ -14,7 +14,7 @@ type LogOptions struct {
 	Since  int64
 }
 
-func (d *dockerBackend) GetContainerLog(ctx context.Context, appID string, envID string, opt LogOptions) (string, error) {
+func (b *dockerBackend) GetContainerLog(ctx context.Context, appID string, envID string, opt LogOptions) (string, error) {
 	str := &bytes.Buffer{}
 	logopts := docker.LogsOptions{
 		Context:      ctx,
@@ -26,7 +26,7 @@ func (d *dockerBackend) GetContainerLog(ctx context.Context, appID string, envID
 		Since:        opt.Since,
 		RawTerminal:  true,
 	}
-	err := d.c.Logs(logopts)
+	err := b.c.Logs(logopts)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/infrastructure/backend/dockerimpl/get_container_log.go
+++ b/pkg/infrastructure/backend/dockerimpl/get_container_log.go
@@ -7,12 +7,12 @@ import (
 	docker "github.com/fsouza/go-dockerclient"
 )
 
-type LogOptions struct {
+type LogsOptions struct {
 	Tail  string
 	Since int64
 }
 
-func (b *dockerBackend) GetContainerStdOut(ctx context.Context, appID string, envID string, opt LogOptions) (string, error) {
+func (b *dockerBackend) GetContainerStdOut(ctx context.Context, appID string, envID string, opt LogsOptions) (string, error) {
 	str := &bytes.Buffer{}
 	logopts := docker.LogsOptions{
 		Context:      ctx,

--- a/pkg/infrastructure/backend/dockerimpl/get_container_log_test.go
+++ b/pkg/infrastructure/backend/dockerimpl/get_container_log_test.go
@@ -32,11 +32,8 @@ func TestDockerBackend_GetContainerLog(t *testing.T) {
 				Force:         true,
 			})
 		})
-		opts := LogOptions{
-			Stdout: true,
-			Stderr: true,
-		}
-		result, err := m.GetContainerLog(context.Background(), appID, envID, opts)
+		opts := LogOptions{}
+		result, err := m.GetContainerStdOut(context.Background(), appID, envID, opts)
 		if assert.NoError(t, err) {
 			assert.NotEmpty(t, result)
 		}

--- a/pkg/infrastructure/backend/dockerimpl/get_container_log_test.go
+++ b/pkg/infrastructure/backend/dockerimpl/get_container_log_test.go
@@ -32,7 +32,7 @@ func TestDockerBackend_GetContainerLog(t *testing.T) {
 				Force:         true,
 			})
 		})
-		opts := LogOptions{}
+		opts := LogsOptions{}
 		result, err := m.GetContainerStdOut(context.Background(), appID, envID, opts)
 		if assert.NoError(t, err) {
 			assert.NotEmpty(t, result)

--- a/pkg/infrastructure/backend/dockerimpl/get_container_log_test.go
+++ b/pkg/infrastructure/backend/dockerimpl/get_container_log_test.go
@@ -1,0 +1,44 @@
+package dockerimpl
+
+import (
+	"context"
+	"testing"
+
+	docker "github.com/fsouza/go-dockerclient"
+	"github.com/leandro-lugaresi/hub"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/traPtitech/neoshowcase/pkg/domain"
+	"github.com/traPtitech/neoshowcase/pkg/infrastructure/eventbus"
+)
+
+func TestDockerBackend_GetContainerLog(t *testing.T) {
+	m, c := prepareManager(t, eventbus.NewLocal(hub.New()))
+
+	t.Run("正常", func(t *testing.T) {
+		image := "hello-world"
+		appID := "afiowjiodncx"
+		envID := "adhihpillomo"
+		err := m.CreateContainer(context.Background(), domain.ContainerCreateArgs{
+			ImageName:     image,
+			ApplicationID: appID,
+			EnvironmentID: envID,
+		})
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			_ = c.RemoveContainer(docker.RemoveContainerOptions{
+				ID:            containerName(appID, envID),
+				RemoveVolumes: true,
+				Force:         true,
+			})
+		})
+		opts := LogOptions{
+			Stdout: true,
+			Stderr: true,
+		}
+		result, err := m.GetContainerLog(context.Background(), appID, envID, opts)
+		if assert.NoError(t, err) {
+			assert.NotEmpty(t, result)
+		}
+	})
+}


### PR DESCRIPTION
https://github.com/traPtitech/NeoShowcase/issues/10

テストも書きましたが、admindbのところで`Unable to execute setup: exec: "mysql": executable file not found in $PATH`というエラーで落ちており、それ以降はスキップされてしまうため、正常に動くか試せていません。