### PR TITLE
countAppsStatusの実装

### DIFF
--- a/dashboard/src/pages/apps.tsx
+++ b/dashboard/src/pages/apps.tsx
@@ -23,7 +23,7 @@ import { Radio, RadioItem } from '/@/components/Radio'
 import { client } from '/@/libs/api'
 import { Application } from '/@/api/neoshowcase/protobuf/apiserver_pb'
 import { RepositoryRow } from '/@/components/RepositoryRow'
-import { ApplicationState } from '/@/libs/application'
+import { applicationState, ApplicationState } from '/@/libs/application'
 
 const sortItems: RadioItem[] = [
   { value: 'desc', title: '最新順' },
@@ -36,14 +36,14 @@ interface StatusCheckboxProps {
   num: number
 }
 
-const StatusCheckbox = ({ state, title, num }: StatusCheckboxProps): JSX.Element => {
+const StatusCheckbox = (props: StatusCheckboxProps): JSX.Element => {
   return (
     <div class={statusCheckboxContainer}>
       <div class={statusCheckboxContainerLeft}>
-        <StatusIcon state={state} />
-        <div>{title}</div>
+        <StatusIcon state={props.state} />
+        <div>{props.title}</div>
       </div>
-      <div>{num}</div>
+      <div>{props.num}</div>
     </div>
   )
 }
@@ -60,6 +60,10 @@ export default () => {
       return acc
     }, {} as Record<string, Application[]>)
 
+  const countAppsStatus = (state: ApplicationState): number => {
+    return apps().applications.filter((app) => applicationState(app) === state).length
+  }
+
   return (
     <div class={container}>
       <Header />
@@ -70,16 +74,16 @@ export default () => {
             <div class={sidebarTitle}>Status</div>
             <div class={sidebarOptions}>
               <Checkbox>
-                <StatusCheckbox state={ApplicationState.Idle} title='Idle' num={7} />
+                <StatusCheckbox state={ApplicationState.Idle} title='Idle' num={loaded() && countAppsStatus(ApplicationState.Idle)} />
               </Checkbox>
               <Checkbox>
-                <StatusCheckbox state={ApplicationState.Deploying} title='Deploying' num={1} />
+                <StatusCheckbox state={ApplicationState.Deploying} title='Deploying' num={loaded() && countAppsStatus(ApplicationState.Deploying)} />
               </Checkbox>
               <Checkbox>
-                <StatusCheckbox state={ApplicationState.Running} title='Running' num={24} />
+                <StatusCheckbox state={ApplicationState.Running} title='Running' num={loaded() && countAppsStatus(ApplicationState.Running)} />
               </Checkbox>
               <Checkbox>
-                <StatusCheckbox state={ApplicationState.Static} title='Static' num={6} />
+                <StatusCheckbox state={ApplicationState.Static} title='Static' num={loaded() && countAppsStatus(ApplicationState.Static)} />
               </Checkbox>
             </div>
           </div>

--- a/dashboard/src/pages/apps.tsx
+++ b/dashboard/src/pages/apps.tsx
@@ -47,7 +47,6 @@ const StatusCheckbox = (props: StatusCheckboxProps): JSX.Element => {
         <StatusIcon state={props.state} />
         <div>{props.title}</div>
       </div>
-
       <div>{num()}</div>
     </div>
   )

--- a/dashboard/src/pages/apps.tsx
+++ b/dashboard/src/pages/apps.tsx
@@ -25,6 +25,10 @@ import { Application } from '/@/api/neoshowcase/protobuf/apiserver_pb'
 import { RepositoryRow } from '/@/components/RepositoryRow'
 import { applicationState, ApplicationState } from '/@/libs/application'
 
+const [repos] = createResource(() => client.getRepositories({}))
+const [apps] = createResource(() => client.getApplications({}))
+const loaded = () => !!(repos() && apps())
+
 const sortItems: RadioItem[] = [
   { value: 'desc', title: '最新順' },
   { value: 'asc', title: '古い順' },
@@ -33,25 +37,23 @@ const sortItems: RadioItem[] = [
 interface StatusCheckboxProps {
   state: ApplicationState
   title: string
-  num: number
 }
 
 const StatusCheckbox = (props: StatusCheckboxProps): JSX.Element => {
+  const num = () => loaded() && apps().applications.filter((app) => applicationState(app) === props.state).length
   return (
     <div class={statusCheckboxContainer}>
       <div class={statusCheckboxContainerLeft}>
         <StatusIcon state={props.state} />
         <div>{props.title}</div>
       </div>
-      <div>{props.num}</div>
+
+      <div>{num()}</div>
     </div>
   )
 }
 
 export default () => {
-  const [repos] = createResource(() => client.getRepositories({}))
-  const [apps] = createResource(() => client.getApplications({}))
-  const loaded = () => !!(repos() && apps())
   const appsByRepo = () =>
     loaded() &&
     apps().applications.reduce((acc, app) => {
@@ -59,10 +61,6 @@ export default () => {
       acc[app.repositoryId].push(app)
       return acc
     }, {} as Record<string, Application[]>)
-
-  const countAppsStatus = (state: ApplicationState): number => {
-    return apps().applications.filter((app) => applicationState(app) === state).length
-  }
 
   return (
     <div class={container}>
@@ -74,16 +72,16 @@ export default () => {
             <div class={sidebarTitle}>Status</div>
             <div class={sidebarOptions}>
               <Checkbox>
-                <StatusCheckbox state={ApplicationState.Idle} title='Idle' num={loaded() && countAppsStatus(ApplicationState.Idle)} />
+                <StatusCheckbox state={ApplicationState.Idle} title='Idle' />
               </Checkbox>
               <Checkbox>
-                <StatusCheckbox state={ApplicationState.Deploying} title='Deploying' num={loaded() && countAppsStatus(ApplicationState.Deploying)} />
+                <StatusCheckbox state={ApplicationState.Deploying} title='Deploying' />
               </Checkbox>
               <Checkbox>
-                <StatusCheckbox state={ApplicationState.Running} title='Running' num={loaded() && countAppsStatus(ApplicationState.Running)} />
+                <StatusCheckbox state={ApplicationState.Running} title='Running' />
               </Checkbox>
               <Checkbox>
-                <StatusCheckbox state={ApplicationState.Static} title='Static' num={loaded() && countAppsStatus(ApplicationState.Static)} />
+                <StatusCheckbox state={ApplicationState.Static} title='Static' />
               </Checkbox>
             </div>
           </div>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/17543997/229990059-6b679228-9941-437c-9ecc-cc9f1a3a3552.png)
赤で囲った部分の値がリアクティブに反映されるようになりました。

@motoki317 
![image](https://user-images.githubusercontent.com/17543997/229990428-15e27cfc-58f8-4ddf-8a98-ab7bef867a1e.png)
(https://docs.solidjs.com/guides/tutorials/getting-started-with-solid/building-ui-with-components の最後の部分)
![image](https://user-images.githubusercontent.com/17543997/229990544-77eb399f-ee4b-4628-a227-0bc30a8a2661.png)
``But destructuring props is usually a bad idea in Solid. ...... When we destructure our props object in the function signature, we immediately access the object's properties and lose reactivity.`` らしくて、リアクティブ性じゃなくなっちゃうみたいなのでSolid.jsで書くときはpropsで入れるようにしましょう。