### PR TITLE
package.jsonのscriptsに "lint:noapply": "rome check src" を追加

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -7,6 +7,7 @@
     "serve": "vite preview",
     "fmt": "rome format src --write",
     "lint": "rome check src --apply",
+    "lint:noapply": "rome check src",
     "lint:force": "rome check src --apply-unsafe",
     "typecheck": "tsc --noEmit",
     "ci": "rome ci src"


### PR DESCRIPTION
## なぜやるか
romeのバグで、yarn lint時に--applyがついている状況だとエラーの原因が出力されないため、--applyなしのlintを追加しておくことで確認できると思ったから

## やったこと
package.jsonのscriptsに "lint:noapply": "rome check src" を追加

## やらなかったこと

## 資料
https://q.trap.jp/messages/82a8ca7a-1521-4a96-aeeb-748d7fb695c6
