### PR TITLE
Add/repository creation page

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -32,6 +32,7 @@
     "@solidjs/router": "0.8.2",
     "ansi-to-html": "0.7.2",
     "solid-icons": "1.0.4",
-    "solid-js": "1.7.5"
+    "solid-js": "1.7.5",
+    "solid-toast": "^0.5.0"
   }
 }

--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -1,10 +1,17 @@
 import { Router } from '@solidjs/router'
 import type { Component } from 'solid-js'
 import Routes from '/@/routes'
+import { Toaster } from 'solid-toast'
 
 const App: Component = () => {
   return (
     <>
+      <Toaster
+        toastOptions={{
+          duration: 10000,
+          position: 'bottom-right',
+        }}
+      />
       <Router>
         <Routes />
       </Router>

--- a/dashboard/src/components/RepositoryRow.tsx
+++ b/dashboard/src/components/RepositoryRow.tsx
@@ -137,13 +137,15 @@ export const RepositoryRow = (props: Props): JSXElement => {
   return (
     <Container>
       <Header>
-        <HeaderLeft>
-          {providerToIcon(provider)}
-          <RepoName>{props.repo.name}</RepoName>
-          <AppsCount>
-            {props.apps.length} {props.apps.length === 1 ? 'app' : 'apps'}
-          </AppsCount>
-        </HeaderLeft>
+        <A href={`/repos/${props.repo.id}`}>
+          <HeaderLeft>
+            {providerToIcon(provider)}
+            <RepoName>{props.repo.name}</RepoName>
+            <AppsCount>
+              {props.apps.length} {props.apps.length === 1 ? 'app' : 'apps'}
+            </AppsCount>
+          </HeaderLeft>
+        </A>
         <A href={`/apps/new?repositoryID=${props.repo.id}`}>
           <AddBranchButton>
             <div>New&nbsp;App</div>

--- a/dashboard/src/pages/repos/[id].tsx
+++ b/dashboard/src/pages/repos/[id].tsx
@@ -1,0 +1,76 @@
+import { createResource, Show } from 'solid-js'
+import { styled } from '@macaron-css/solid'
+import { useParams } from '@solidjs/router'
+import {
+  Card,
+  CardItem,
+  CardItemContent,
+  CardItems,
+  CardItemTitle,
+  CardsContainer,
+  CardTitle,
+} from '/@/components/Card'
+import { Header } from '/@/components/Header'
+import { URLText } from '/@/components/URLText'
+import { client } from '/@/libs/api'
+import { providerToIcon, repositoryURLToProvider } from '/@/libs/application'
+import { CenterInline, Container } from '/@/libs/layout'
+import { vars } from '/@/theme'
+
+// copy from AppTitleContainer in AppNav.tsx
+const RepoTitleContainer = styled('div', {
+  base: {
+    display: 'flex',
+    flexDirection: 'row',
+    gap: '14px',
+    alignContent: 'center',
+
+    marginTop: '48px',
+    fontSize: '32px',
+    fontWeight: 'bold',
+    color: vars.text.black1,
+  },
+})
+
+export default () => {
+  const params = useParams()
+  const [repo] = createResource(
+    () => params.id,
+    (id) => client.getRepository({ repositoryId: id }),
+  )
+
+  return (
+    <Container>
+      <Header />
+      <Show when={repo()}>
+        <RepoTitleContainer>
+          <CenterInline>{providerToIcon(repositoryURLToProvider(repo().url), 36)}</CenterInline>
+          {repo().name}
+        </RepoTitleContainer>
+        <CardsContainer>
+          <Card>
+            <CardTitle>Info</CardTitle>
+            <CardItems>
+              <CardItem>
+                <CardItemTitle>ID</CardItemTitle>
+                <CardItemContent>{repo().id}</CardItemContent>
+              </CardItem>
+              <CardItem>
+                <CardItemTitle>Name</CardItemTitle>
+                <CardItemContent>{repo().name}</CardItemContent>
+              </CardItem>
+              <CardItem>
+                <CardItemTitle>URL</CardItemTitle>
+                <CardItemContent>
+                  <URLText href={repo().url} target='_blank' rel='noreferrer'>
+                    {repo().url}
+                  </URLText>
+                </CardItemContent>
+              </CardItem>
+            </CardItems>
+          </Card>
+        </CardsContainer>
+      </Show>
+    </Container>
+  )
+}

--- a/dashboard/src/pages/repos/new.tsx
+++ b/dashboard/src/pages/repos/new.tsx
@@ -126,7 +126,7 @@ const SystemPublicKey = (): JSXElement => {
   return (
     <div>
       <SshDetails>
-        公開鍵を入力せずにSSH認証でリポジトリを登録する場合、以下のSSH公開鍵が認証に使用されます。
+        秘密鍵を入力せずにSSH認証でリポジトリを登録する場合、以下のSSH公開鍵が認証に使用されます。
       </SshDetails>
       <Switch>
         <Match when={systemPublicKey.loading}>
@@ -235,8 +235,8 @@ export default () => {
             </Match>
             <Match when={authMethod() === 'ssh'}>
               <Form
-                label='SSH公開鍵'
-                placeholder='ssh-ed25519 ******'
+                label='SSH秘密鍵'
+                placeholder=''
                 value={sshAuthConfig.sshKey}
                 onInput={(e) => setSshAuthConfig('sshKey', e.currentTarget.value)}
               />

--- a/dashboard/src/pages/repos/new.tsx
+++ b/dashboard/src/pages/repos/new.tsx
@@ -4,6 +4,7 @@ import toast from 'solid-toast'
 import { ConnectError } from '@bufbuild/connect'
 import { Empty } from '@bufbuild/protobuf'
 import { styled } from '@macaron-css/solid'
+import { useNavigate } from '@solidjs/router'
 import {
   CreateRepositoryAuth,
   CreateRepositoryAuthBasic,
@@ -125,6 +126,7 @@ const PublicKeyCode = styled('code', {
 })
 
 export default () => {
+  const navigate = useNavigate()
   // 認証方法 ("none" | "ssh" | "basic")
   type AuthMethod = CreateRepositoryAuth['auth']['case']
   const [authMethod, setAuthMethod] = createSignal<AuthMethod>('none')
@@ -166,6 +168,8 @@ export default () => {
       try {
         const res = await client.createRepository(requestConfig)
         toast.success('リポジトリを登録しました')
+        // リポジトリページに遷移
+        navigate(`/repos/${res.id}`)
       } catch (e) {
         console.error(e)
         // gRPCエラー

--- a/dashboard/src/pages/repos/new.tsx
+++ b/dashboard/src/pages/repos/new.tsx
@@ -173,21 +173,13 @@ export default () => {
             type='url'
             placeholder='https://example.com/my-app.git'
             value={requestConfig.url}
-            onInput={(e) =>
-              setRequestConfig({
-                url: e.currentTarget.value,
-              })
-            }
+            onInput={(e) => setRequestConfig('url', e.currentTarget.value)}
           />
           <Form
             label='リポジトリ名'
             placeholder='my-app'
             value={requestConfig.name}
-            onInput={(e) =>
-              setRequestConfig({
-                name: e.currentTarget.value,
-              })
-            }
+            onInput={(e) => setRequestConfig('name', e.currentTarget.value)}
           />
           <InputForm>
             <InputFormText>認証方法</InputFormText>

--- a/dashboard/src/pages/repos/new.tsx
+++ b/dashboard/src/pages/repos/new.tsx
@@ -131,22 +131,20 @@ export default () => {
   // 認証方法の切り替え時に情報を保持するために、storeを使用して3種類の認証情報を保持する
   const [authConfig, setAuthConfig] = createStore<{
     [K in AuthMethod]: Extract<CreateRepositoryAuth['auth'], { case: K }>
-  }>(
-    {
-      "none": {
-        case: "none",
-        value: new Empty(),
-      },
-      basic: {
-        case: "basic",
-        value: new CreateRepositoryAuthBasic(),
-      },
-      ssh: {
-        case: "ssh",
-        value: new CreateRepositoryAuthSSH(),
-      }
-    }
-  )
+  }>({
+    none: {
+      case: 'none',
+      value: new Empty(),
+    },
+    basic: {
+      case: 'basic',
+      value: new CreateRepositoryAuthBasic(),
+    },
+    ssh: {
+      case: 'ssh',
+      value: new CreateRepositoryAuthSSH(),
+    },
+  })
 
   const [requestConfig, setRequestConfig] = createStore(
     new CreateRepositoryRequest({
@@ -162,7 +160,7 @@ export default () => {
 
     // validate form
     if (formContainer.reportValidity()) {
-      setRequestConfig("auth", "auth", authConfig[authMethod()])
+      setRequestConfig('auth', 'auth', authConfig[authMethod()])
       const res = await client.createRepository(requestConfig)
       // TODO: navigate to repository page when success / show error message when failed
     }
@@ -217,20 +215,20 @@ export default () => {
               <Form
                 label='ユーザー名'
                 value={authConfig.basic.value.username}
-                onInput={(e) => setAuthConfig('basic', "value" , "username",e.currentTarget.value)}
+                onInput={(e) => setAuthConfig('basic', 'value', 'username', e.currentTarget.value)}
               />
               <Form
                 label='パスワード'
                 type='password'
                 value={authConfig.basic.value.password}
-                onInput={(e) => setAuthConfig('basic', "value" , "password", e.currentTarget.value)}
+                onInput={(e) => setAuthConfig('basic', 'value', 'password', e.currentTarget.value)}
               />
             </Match>
             <Match when={authMethod() === 'ssh'}>
               <Form
                 label='SSH秘密鍵'
                 value={authConfig.ssh.value.sshKey}
-                onInput={(e) => setAuthConfig('ssh', "value" , "sshKey", e.currentTarget.value)}
+                onInput={(e) => setAuthConfig('ssh', 'value', 'sshKey', e.currentTarget.value)}
               />
               <Show when={authConfig.ssh.value.sshKey.length === 0}>
                 <div>

--- a/dashboard/src/pages/repos/new.tsx
+++ b/dashboard/src/pages/repos/new.tsx
@@ -210,7 +210,6 @@ export default () => {
             <Match when={authMethod() === 'ssh'}>
               <Form
                 label='SSH秘密鍵'
-                placeholder=''
                 value={sshAuthConfig.sshKey}
                 onInput={(e) => setSshAuthConfig('sshKey', e.currentTarget.value)}
               />

--- a/dashboard/src/pages/repos/new.tsx
+++ b/dashboard/src/pages/repos/new.tsx
@@ -13,6 +13,7 @@ import { Header } from '/@/components/Header'
 import { client } from '/@/libs/api'
 import { Container } from '/@/libs/layout'
 import { vars } from '/@/theme'
+import { ImClipboard } from 'solid-icons/im'
 
 // copy from /pages/apps AppsTitle component
 const PageTitle = styled('div', {
@@ -99,6 +100,13 @@ const Form = (props: FormProps): JSXElement => {
   )
 }
 
+const ToggleButtonsWrapper = styled('div', {
+  base: {
+    display: 'flex',
+    flexDirection: 'row',
+  },
+})
+
 interface ToggleButtonsProps<T> {
   items: {
     value: T
@@ -110,7 +118,7 @@ interface ToggleButtonsProps<T> {
 
 const ToggleButtons = <T extends unknown>(props: ToggleButtonsProps<T>): JSXElement => {
   return (
-    <div>
+    <ToggleButtonsWrapper>
       <For each={props.items}>
         {(item) => (
           <Button color='black1' size='large' onclick={() => props.onChange(item.value)}>
@@ -118,22 +126,44 @@ const ToggleButtons = <T extends unknown>(props: ToggleButtonsProps<T>): JSXElem
           </Button>
         )}
       </For>
-    </div>
+    </ToggleButtonsWrapper>
   )
 }
+
+const SshDetails = styled('div', {
+  base: {
+    color: vars.text.black2,
+    marginBottom: '4px',
+  },
+})
+
+const PublicKeyCode = styled('code', {
+  base: {
+    display: 'block',
+    padding: '8px 12px',
+    fontFamily: 'monospace',
+    fontSize: '14px',
+    background: vars.bg.white2,
+    color: vars.text.black1,
+    border: `1px solid ${vars.bg.white4}`,
+    borderRadius: '4px',
+  },
+})
 
 const SystemPublicKey = (): JSXElement => {
   const [systemPublicKey] = createResource(() => client.getSystemPublicKey({}))
 
   return (
     <div>
-      <div>公開鍵を入力せずにSSH認証でリポジトリを登録する場合、以下のSSH公開鍵が認証に使用されます。</div>
+      <SshDetails>
+        公開鍵を入力せずにSSH認証でリポジトリを登録する場合、以下のSSH公開鍵が認証に使用されます。
+      </SshDetails>
       <Switch>
         <Match when={systemPublicKey.loading}>
           <div>Loading...</div>
         </Match>
         <Match when={systemPublicKey()}>
-          <code>{systemPublicKey().publicKey}</code>
+          <PublicKeyCode>{systemPublicKey().publicKey}</PublicKeyCode>
         </Match>
       </Switch>
     </div>

--- a/dashboard/src/pages/repos/new.tsx
+++ b/dashboard/src/pages/repos/new.tsx
@@ -14,6 +14,7 @@ import { client } from '/@/libs/api'
 import { Container } from '/@/libs/layout'
 import { vars } from '/@/theme'
 
+// copy from /pages/apps AppsTitle component
 const PageTitle = styled('div', {
   base: {
     marginTop: '48px',
@@ -23,6 +24,8 @@ const PageTitle = styled('div', {
   },
 })
 
+// copy from /pages/apps
+// and delete unnecessary styles
 const ContentContainer = styled('div', {
   base: {
     marginTop: '24px',

--- a/dashboard/src/pages/repos/new.tsx
+++ b/dashboard/src/pages/repos/new.tsx
@@ -1,5 +1,7 @@
 import { JSX, JSXElement, Match, Show, Switch, createEffect, createResource, createSignal } from 'solid-js'
 import { createStore } from 'solid-js/store'
+import toast from 'solid-toast'
+import { ConnectError } from '@bufbuild/connect'
 import { Empty } from '@bufbuild/protobuf'
 import { styled } from '@macaron-css/solid'
 import {
@@ -161,8 +163,16 @@ export default () => {
     // validate form
     if (formContainer.reportValidity()) {
       setRequestConfig('auth', 'auth', authConfig[authMethod()])
-      const res = await client.createRepository(requestConfig)
-      // TODO: navigate to repository page when success / show error message when failed
+      try {
+        const res = await client.createRepository(requestConfig)
+        toast.success('リポジトリを登録しました')
+      } catch (e) {
+        console.error(e)
+        // gRPCエラー
+        if (e instanceof ConnectError) {
+          toast.error('リポジトリの登録に失敗しました\n' + e.message)
+        }
+      }
     }
   }
 

--- a/dashboard/src/pages/repos/new.tsx
+++ b/dashboard/src/pages/repos/new.tsx
@@ -1,4 +1,4 @@
-import { For, JSX, JSXElement, Match, Show, Switch, createEffect, createResource, createSignal } from 'solid-js'
+import { JSX, JSXElement, Match, Show, Switch, createEffect, createResource, createSignal } from 'solid-js'
 import { createStore } from 'solid-js/store'
 import { Empty } from '@bufbuild/protobuf'
 import { styled } from '@macaron-css/solid'
@@ -10,6 +10,7 @@ import {
 } from '/@/api/neoshowcase/protobuf/gateway_pb'
 import { Button } from '/@/components/Button'
 import { Header } from '/@/components/Header'
+import { Radio } from '/@/components/Radio'
 import { client } from '/@/libs/api'
 import { Container } from '/@/libs/layout'
 import { vars } from '/@/theme'
@@ -96,36 +97,6 @@ const Form = (props: FormProps): JSXElement => {
         onInput={props.onInput}
       />
     </InputForm>
-  )
-}
-
-const ToggleButtonsWrapper = styled('div', {
-  base: {
-    display: 'flex',
-    flexDirection: 'row',
-  },
-})
-
-interface ToggleButtonsProps<T> {
-  items: {
-    value: T
-    label: string
-  }[]
-  selected: T
-  onChange: (value: T) => void
-}
-
-const ToggleButtons = <T extends unknown>(props: ToggleButtonsProps<T>): JSXElement => {
-  return (
-    <ToggleButtonsWrapper>
-      <For each={props.items}>
-        {(item) => (
-          <Button color='black1' size='large' onclick={() => props.onChange(item.value)}>
-            {item.label}
-          </Button>
-        )}
-      </For>
-    </ToggleButtonsWrapper>
   )
 }
 
@@ -236,15 +207,18 @@ export default () => {
               })
             }
           />
-          <ToggleButtons<AuthMethod>
-            items={[
-              { label: '認証を使用しない', value: 'none' },
-              { label: 'Basic認証を使用', value: 'basic' },
-              { label: 'SSH認証を使用', value: 'ssh' },
-            ]}
-            selected={authMethod()}
-            onChange={setAuthMethod}
-          />
+          <InputForm>
+            <InputFormText>認証方法</InputFormText>
+            <Radio
+              items={[
+                { title: '認証を使用しない', value: 'none' },
+                { title: 'Basic認証を使用', value: 'basic' },
+                { title: 'SSH認証を使用', value: 'ssh' },
+              ]}
+              selected={authMethod()}
+              setSelected={setAuthMethod}
+            />
+          </InputForm>
           <Switch>
             <Match when={authMethod() === 'basic'}>
               <Form

--- a/dashboard/src/pages/repos/new.tsx
+++ b/dashboard/src/pages/repos/new.tsx
@@ -13,7 +13,6 @@ import { Header } from '/@/components/Header'
 import { client } from '/@/libs/api'
 import { Container } from '/@/libs/layout'
 import { vars } from '/@/theme'
-import { ImClipboard } from 'solid-icons/im'
 
 // copy from /pages/apps AppsTitle component
 const PageTitle = styled('div', {

--- a/dashboard/src/pages/repos/new.tsx
+++ b/dashboard/src/pages/repos/new.tsx
@@ -1,0 +1,202 @@
+import { For, JSX, JSXElement, Match, Show, Switch, createEffect, createResource, createSignal } from 'solid-js'
+import { createStore } from 'solid-js/store'
+import { Empty } from '@bufbuild/protobuf'
+import { styled } from '@macaron-css/solid'
+import {
+  CreateRepositoryAuth,
+  CreateRepositoryAuthBasic,
+  CreateRepositoryAuthSSH,
+  CreateRepositoryRequest,
+} from '/@/api/neoshowcase/protobuf/gateway_pb'
+import { Button } from '/@/components/Button'
+import { Header } from '/@/components/Header'
+import { client } from '/@/libs/api'
+import { Container } from '/@/libs/layout'
+import { vars } from '/@/theme'
+
+const PageTitle = styled('div', {
+  base: {
+    marginTop: '48px',
+    fontSize: '32px',
+    fontWeight: 'bold',
+    color: vars.text.black1,
+  },
+})
+
+const ContentContainer = styled('div', {
+  base: {
+    marginTop: '24px',
+  },
+})
+
+interface FormProps {
+  label: string
+  type?: JSX.InputHTMLAttributes<HTMLInputElement>['type']
+  placeholder?: JSX.InputHTMLAttributes<HTMLInputElement>['placeholder']
+  value: JSX.InputHTMLAttributes<HTMLInputElement>['value']
+  onInput: JSX.InputHTMLAttributes<HTMLInputElement>['onInput']
+}
+
+const Form = (props: FormProps): JSXElement => {
+  return (
+    <div>
+      <label>{props.label}</label>
+      <input
+        type={props.type ?? 'text'}
+        placeholder={props.placeholder ?? ''}
+        value={props.value}
+        onInput={props.onInput}
+      />
+    </div>
+  )
+}
+
+interface ToggleButtonsProps<T> {
+  items: {
+    value: T
+    label: string
+  }[]
+  selected: T
+  onChange: (value: T) => void
+}
+
+const ToggleButtons = <T extends unknown>(props: ToggleButtonsProps<T>): JSXElement => {
+  return (
+    <div>
+      <For each={props.items}>
+        {(item) => (
+          <Button color='black1' size='large' onclick={() => props.onChange(item.value)}>
+            {item.label}
+          </Button>
+        )}
+      </For>
+    </div>
+  )
+}
+
+const SystemPublicKey = (): JSXElement => {
+  const [systemPublicKey] = createResource(() => client.getSystemPublicKey({}))
+
+  return (
+    <div>
+      <div>公開鍵を入力せずにSSH認証でリポジトリを登録する場合、以下のSSH公開鍵が認証に使用されます。</div>
+      <Switch>
+        <Match when={systemPublicKey.loading}>
+          <div>Loading...</div>
+        </Match>
+        <Match when={systemPublicKey()}>
+          <code>{systemPublicKey().publicKey}</code>
+        </Match>
+      </Switch>
+    </div>
+  )
+}
+
+export default () => {
+  // 認証方法 ("none" | "ssh" | "basic")
+  type AuthMethod = CreateRepositoryAuth['auth']['case']
+  const [authMethod, setAuthMethod] = createSignal<AuthMethod>('none')
+
+  const [sshAuthConfig, setSshAuthConfig] = createStore(new CreateRepositoryAuthSSH())
+  const [basicAuthConfig, setBasicAuthConfig] = createStore(new CreateRepositoryAuthBasic())
+
+  const [requestConfig, setRequestConfig] = createStore(
+    new CreateRepositoryRequest({
+      auth: new CreateRepositoryAuth(),
+    }),
+  )
+
+  const createRepository = async () => {
+    // 認証方法に応じて認証情報を設定
+    switch (authMethod()) {
+      case 'none':
+        setRequestConfig('auth', 'auth', { value: new Empty(), case: 'none' })
+        break
+      case 'ssh':
+        setRequestConfig('auth', 'auth', { value: sshAuthConfig, case: 'ssh' })
+        break
+      case 'basic':
+        setRequestConfig('auth', 'auth', { value: basicAuthConfig, case: 'basic' })
+        break
+    }
+
+    const res = await client.createRepository(requestConfig)
+    // TODO: navigate to repository page when success / show error message when failed
+  }
+
+  // URLからリポジトリ名を自動入力
+  createEffect(() => {
+    const segments = requestConfig.url.split('/')
+    const lastSegment = segments.pop() || segments.pop() // 末尾のスラッシュを除去
+    const repositoryName = lastSegment?.replace(/\.git$/, '') ?? ''
+    setRequestConfig('name', repositoryName)
+  })
+
+  return (
+    <Container>
+      <Header />
+      <PageTitle>Create Repository</PageTitle>
+      <ContentContainer>
+        <Form
+          label='URL'
+          type='url'
+          placeholder='https://example.com/my-app.git'
+          value={requestConfig.url}
+          onInput={(e) =>
+            setRequestConfig({
+              url: e.currentTarget.value,
+            })
+          }
+        />
+        <Form
+          label='リポジトリ名'
+          placeholder='my-app'
+          value={requestConfig.name}
+          onInput={(e) =>
+            setRequestConfig({
+              name: e.currentTarget.value,
+            })
+          }
+        />
+        <ToggleButtons<AuthMethod>
+          items={[
+            { label: '認証を使用しない', value: 'none' },
+            { label: 'Basic認証を使用', value: 'basic' },
+            { label: 'SSH認証を使用', value: 'ssh' },
+          ]}
+          selected={authMethod()}
+          onChange={setAuthMethod}
+        />
+        <Switch>
+          <Match when={authMethod() === 'basic'}>
+            <Form
+              label='ユーザー名'
+              value={basicAuthConfig.username}
+              onInput={(e) => setBasicAuthConfig('username', e.currentTarget.value)}
+            />
+            <Form
+              label='パスワード'
+              type='password'
+              value={basicAuthConfig.password}
+              onInput={(e) => setBasicAuthConfig('password', e.currentTarget.value)}
+            />
+          </Match>
+          <Match when={authMethod() === 'ssh'}>
+            <Form
+              label='SSH公開鍵'
+              placeholder='ssh-ed25519 ******'
+              value={sshAuthConfig.sshKey}
+              onInput={(e) => setSshAuthConfig('sshKey', e.currentTarget.value)}
+            />
+            <Show when={sshAuthConfig.sshKey.length === 0}>
+              <SystemPublicKey />
+            </Show>
+          </Match>
+        </Switch>
+        <Button color='black1' size='large' onclick={createRepository}>
+          + Create new Repository
+        </Button>
+      </ContentContainer>
+    </Container>
+  )
+}

--- a/dashboard/src/pages/repos/new.tsx
+++ b/dashboard/src/pages/repos/new.tsx
@@ -32,6 +32,51 @@ const ContentContainer = styled('div', {
   },
 })
 
+// copy from /pages/apps/new
+const InputFormContainer = styled('div', {
+  base: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '20px',
+
+    background: vars.bg.white3,
+    border: `1px solid ${vars.bg.white4}`,
+    borderRadius: '4px',
+    padding: '8px 12px',
+  },
+})
+const InputForm = styled('div', {
+  base: {},
+})
+const InputFormText = styled('div', {
+  base: {
+    fontSize: '16px',
+    alignItems: 'center',
+    fontWeight: 700,
+    color: vars.text.black1,
+
+    marginBottom: '4px',
+  },
+})
+const InputBar = styled('input', {
+  base: {
+    padding: '8px 12px',
+    borderRadius: '4px',
+    border: `1px solid ${vars.bg.white4}`,
+    fontSize: '14px',
+    marginLeft: '4px',
+
+    width: '320px',
+
+    display: 'flex',
+    flexDirection: 'column',
+
+    '::placeholder': {
+      color: vars.text.black3,
+    },
+  },
+})
+
 interface FormProps {
   label: string
   type?: JSX.InputHTMLAttributes<HTMLInputElement>['type']
@@ -42,15 +87,15 @@ interface FormProps {
 
 const Form = (props: FormProps): JSXElement => {
   return (
-    <div>
-      <label>{props.label}</label>
-      <input
+    <InputForm>
+      <InputFormText>{props.label}</InputFormText>
+      <InputBar
         type={props.type ?? 'text'}
         placeholder={props.placeholder ?? ''}
         value={props.value}
         onInput={props.onInput}
       />
-    </div>
+    </InputForm>
   )
 }
 
@@ -140,65 +185,67 @@ export default () => {
       <Header />
       <PageTitle>Create Repository</PageTitle>
       <ContentContainer>
-        <Form
-          label='URL'
-          type='url'
-          placeholder='https://example.com/my-app.git'
-          value={requestConfig.url}
-          onInput={(e) =>
-            setRequestConfig({
-              url: e.currentTarget.value,
-            })
-          }
-        />
-        <Form
-          label='リポジトリ名'
-          placeholder='my-app'
-          value={requestConfig.name}
-          onInput={(e) =>
-            setRequestConfig({
-              name: e.currentTarget.value,
-            })
-          }
-        />
-        <ToggleButtons<AuthMethod>
-          items={[
-            { label: '認証を使用しない', value: 'none' },
-            { label: 'Basic認証を使用', value: 'basic' },
-            { label: 'SSH認証を使用', value: 'ssh' },
-          ]}
-          selected={authMethod()}
-          onChange={setAuthMethod}
-        />
-        <Switch>
-          <Match when={authMethod() === 'basic'}>
-            <Form
-              label='ユーザー名'
-              value={basicAuthConfig.username}
-              onInput={(e) => setBasicAuthConfig('username', e.currentTarget.value)}
-            />
-            <Form
-              label='パスワード'
-              type='password'
-              value={basicAuthConfig.password}
-              onInput={(e) => setBasicAuthConfig('password', e.currentTarget.value)}
-            />
-          </Match>
-          <Match when={authMethod() === 'ssh'}>
-            <Form
-              label='SSH公開鍵'
-              placeholder='ssh-ed25519 ******'
-              value={sshAuthConfig.sshKey}
-              onInput={(e) => setSshAuthConfig('sshKey', e.currentTarget.value)}
-            />
-            <Show when={sshAuthConfig.sshKey.length === 0}>
-              <SystemPublicKey />
-            </Show>
-          </Match>
-        </Switch>
-        <Button color='black1' size='large' onclick={createRepository}>
-          + Create new Repository
-        </Button>
+        <InputFormContainer>
+          <Form
+            label='URL'
+            type='url'
+            placeholder='https://example.com/my-app.git'
+            value={requestConfig.url}
+            onInput={(e) =>
+              setRequestConfig({
+                url: e.currentTarget.value,
+              })
+            }
+          />
+          <Form
+            label='リポジトリ名'
+            placeholder='my-app'
+            value={requestConfig.name}
+            onInput={(e) =>
+              setRequestConfig({
+                name: e.currentTarget.value,
+              })
+            }
+          />
+          <ToggleButtons<AuthMethod>
+            items={[
+              { label: '認証を使用しない', value: 'none' },
+              { label: 'Basic認証を使用', value: 'basic' },
+              { label: 'SSH認証を使用', value: 'ssh' },
+            ]}
+            selected={authMethod()}
+            onChange={setAuthMethod}
+          />
+          <Switch>
+            <Match when={authMethod() === 'basic'}>
+              <Form
+                label='ユーザー名'
+                value={basicAuthConfig.username}
+                onInput={(e) => setBasicAuthConfig('username', e.currentTarget.value)}
+              />
+              <Form
+                label='パスワード'
+                type='password'
+                value={basicAuthConfig.password}
+                onInput={(e) => setBasicAuthConfig('password', e.currentTarget.value)}
+              />
+            </Match>
+            <Match when={authMethod() === 'ssh'}>
+              <Form
+                label='SSH公開鍵'
+                placeholder='ssh-ed25519 ******'
+                value={sshAuthConfig.sshKey}
+                onInput={(e) => setSshAuthConfig('sshKey', e.currentTarget.value)}
+              />
+              <Show when={sshAuthConfig.sshKey.length === 0}>
+                <SystemPublicKey />
+              </Show>
+            </Match>
+          </Switch>
+          <Button color='black1' size='large' onclick={createRepository}>
+            + Create new Repository
+          </Button>
+        </InputFormContainer>
       </ContentContainer>
     </Container>
   )

--- a/dashboard/src/pages/repos/new.tsx
+++ b/dashboard/src/pages/repos/new.tsx
@@ -120,26 +120,6 @@ const PublicKeyCode = styled('code', {
   },
 })
 
-const SystemPublicKey = (): JSXElement => {
-  const [systemPublicKey] = createResource(() => client.getSystemPublicKey({}))
-
-  return (
-    <div>
-      <SshDetails>
-        秘密鍵を入力せずにSSH認証でリポジトリを登録する場合、以下のSSH公開鍵が認証に使用されます。
-      </SshDetails>
-      <Switch>
-        <Match when={systemPublicKey.loading}>
-          <div>Loading...</div>
-        </Match>
-        <Match when={systemPublicKey()}>
-          <PublicKeyCode>{systemPublicKey().publicKey}</PublicKeyCode>
-        </Match>
-      </Switch>
-    </div>
-  )
-}
-
 export default () => {
   // 認証方法 ("none" | "ssh" | "basic")
   type AuthMethod = CreateRepositoryAuth['auth']['case']
@@ -179,6 +159,8 @@ export default () => {
     const repositoryName = lastSegment?.replace(/\.git$/, '') ?? ''
     setRequestConfig('name', repositoryName)
   })
+
+  const [systemPublicKey] = createResource(() => client.getSystemPublicKey({}))
 
   return (
     <Container>
@@ -241,7 +223,19 @@ export default () => {
                 onInput={(e) => setSshAuthConfig('sshKey', e.currentTarget.value)}
               />
               <Show when={sshAuthConfig.sshKey.length === 0}>
-                <SystemPublicKey />
+                <div>
+                  <SshDetails>
+                    秘密鍵を入力せずにSSH認証でリポジトリを登録する場合、以下のSSH公開鍵が認証に使用されます。
+                  </SshDetails>
+                  <Switch>
+                    <Match when={systemPublicKey.loading}>
+                      <div>Loading...</div>
+                    </Match>
+                    <Match when={systemPublicKey()}>
+                      <PublicKeyCode>{systemPublicKey().publicKey}</PublicKeyCode>
+                    </Match>
+                  </Switch>
+                </div>
               </Show>
             </Match>
           </Switch>

--- a/dashboard/src/routes.tsx
+++ b/dashboard/src/routes.tsx
@@ -27,6 +27,10 @@ export default useRoutes([
     component: lazy(() => import('/@/pages/apps/new')),
   },
   {
+    path: '/repos/:id',
+    component: lazy(() => import('/@/pages/repos/[id]')),
+  },
+  {
     path: '/repos/new',
     component: lazy(() => import('/@/pages/repos/new')),
   },

--- a/dashboard/src/routes.tsx
+++ b/dashboard/src/routes.tsx
@@ -26,4 +26,8 @@ export default useRoutes([
     path: '/apps/new',
     component: lazy(() => import('/@/pages/apps/new')),
   },
+  {
+    path: '/repos/new',
+    component: lazy(() => import('/@/pages/repos/new')),
+  },
 ])

--- a/dashboard/yarn.lock
+++ b/dashboard/yarn.lock
@@ -2023,6 +2023,11 @@ solid-refresh@^0.5.0:
     "@babel/helper-module-imports" "^7.18.6"
     "@babel/types" "^7.21.2"
 
+solid-toast@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/solid-toast/-/solid-toast-0.5.0.tgz#ed31363aad38434a67c1da1c423fd1492460c6ba"
+  integrity sha512-t770JakjyS2P9b8Qa1zMLOD51KYKWXbTAyJePVUoYex5c5FH5S/HtUBUbZAWFcqRCKmAE8KhyIiCvDZA8bOnxQ==
+
 source-map-js@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"


### PR DESCRIPTION
## なぜやるか

ref: #478

## やったこと (やること)

- [x] リポジトリ情報入力フォームの作成
- [x] リポジトリ作成リクエスト送信時のエラーメッセージ表示
    - HTML標準で用意されている`HTMLFormElement.reportValidity()`を使用した検証
    - エラーが発生した場合、[solid-toast]([https://www.solid-toast.com](https://www.solid-toast.com)で表示
- [x] デザインの調整

## やらなかったこと

- コンポーネントの切り出し・/components下への配置
    - `/pages/apps/new`から一部コンポーネントをコピーして使用しましたが、コンポーネントの共通化は #511 #512 が進んでからのほうが良いと判断しました
- 各リポジトリの詳細ページ (`/repos/[id]`)
    - そのリポジトリからアプリ作成ページにジャンプできるように
    - そのリポジトリの削除ができるように
    - そのリポジトリの所有者を変更できるように
    - (別プルリクエストで実装します)

## 資料

- [HTMLFormElement.reportValidity() - Web API | MDN](https://developer.mozilla.org/ja/docs/Web/API/HTMLFormElement/reportValidity)
