### PR TITLE
Buttonコンポーネントでbutton要素の標準プロパティを使用できるように

### DIFF
--- a/dashboard/src/components/Button.tsx
+++ b/dashboard/src/components/Button.tsx
@@ -1,6 +1,6 @@
 import { styled } from '@macaron-css/solid'
 import { vars } from '/@/theme'
-import { JSXElement } from 'solid-js'
+import { JSX, splitProps } from 'solid-js'
 
 const Container = styled('button', {
   base: {
@@ -50,25 +50,18 @@ const Text = styled('div', {
   },
 })
 
-export interface Props {
-  children: JSXElement
+export interface Props extends JSX.ButtonHTMLAttributes<HTMLButtonElement> {
   color: 'black1'
   size: 'large'
-  disabled?: boolean
-  onclick?: () => void
 }
 
 export const Button = (props: Props) => {
-  const cursor = () => (props.onclick !== undefined && !props.disabled ? 'pointer' : 'none')
+  const [addedProps, originalButtonProps] = splitProps(props, ['color', 'size'])
+
+  const cursor = () => (originalButtonProps.onclick !== undefined && !originalButtonProps.disabled ? 'pointer' : 'none')
   return (
-    <Container
-      color={props.color}
-      size={props.size}
-      cursor={cursor()}
-      onclick={props.onclick}
-      disabled={props.disabled}
-    >
-      <Text color={props.color} size={props.size}>
+    <Container color={addedProps.color} size={addedProps.size} cursor={cursor()} {...originalButtonProps}>
+      <Text color={addedProps.color} size={addedProps.size}>
         {props.children}
       </Text>
     </Container>

--- a/dashboard/src/components/Button.tsx
+++ b/dashboard/src/components/Button.tsx
@@ -1,6 +1,6 @@
 import { styled } from '@macaron-css/solid'
 import { vars } from '/@/theme'
-import { JSX, splitProps } from 'solid-js'
+import { JSX, ParentComponent, splitProps } from 'solid-js'
 
 const Container = styled('button', {
   base: {
@@ -55,7 +55,7 @@ export interface Props extends JSX.ButtonHTMLAttributes<HTMLButtonElement> {
   size: 'large'
 }
 
-export const Button = (props: Props) => {
+export const Button: ParentComponent<Props> = (props) => {
   const [addedProps, originalButtonProps] = splitProps(props, ['color', 'size'])
 
   const cursor = () => (originalButtonProps.onclick !== undefined && !originalButtonProps.disabled ? 'pointer' : 'none')


### PR DESCRIPTION
## なぜやるか

Buttonコンポーネントで使用可能なプロパティがハードコードされており、`onClick`と`disabled`のみが操作できるようになっていた。

#542 や #543 でのフォームの実装において、button要素の`type`プロパティを操作する必要があり(`type=submit`を使用できるとブラウザで用意されたバリデーションチェックを簡単に実装できるため)、button要素の標準プロパティを操作できるようにすることでこれを達成できるため。

## やったこと

- Buttonコンポーネントの受け付けるプロパティのinterfaceを`JSX.ButtonHTMLAttributes<HTMLButtonElement>`から継承させた
- Buttonコンポーネント内で`splitProps()`を使用して、独自に定義していた`color`, `size`プロパティと、それ以外のプロパティ(=`JSX.ButtonHTMLAttributes<HTMLButtonElement>`)の2つに分割し、後者をbutton要素のプロパティとして分割代入するようにした
- コンポーネントの型を定義するのに`ParentComponent<P>`を使用した
    - コンポーネント設計の基本方針に従い、今後はsolid.jsで用意されたこれらの型を使用する

## やらなかったこと

styled componentのvariantをpropsとして渡しているが(`color`, `size`)、これらの型はハードコーディングされたままになっています(styled componentの型がmacaron-cssでexportされておらず、おそらく独自に型パズルをしないといけない)。

## 資料

- [`splitProps()` - solid.js](https://www.solidjs.com/docs/latest/api#splitprops)
