### PR TITLE
Add app setting page

### DIFF
--- a/dashboard/src/components/AppNav.tsx
+++ b/dashboard/src/components/AppNav.tsx
@@ -65,6 +65,11 @@ export const AppNav = (props: AppNavProps): JSXElement => {
             Builds
           </Button>
         </A>
+        <A href={`/apps/${props.appID}/settings`}>
+          <Button color='black1' size='large'>
+            Settings
+          </Button>
+        </A>
       </AppNavContainer>
     </>
   )

--- a/dashboard/src/components/AppNav.tsx
+++ b/dashboard/src/components/AppNav.tsx
@@ -2,9 +2,9 @@ import { styled } from '@macaron-css/solid'
 import { vars } from '/@/theme'
 import { providerToIcon } from '/@/libs/application'
 import { A } from '@solidjs/router'
-import { Button } from '/@/components/Button'
 import { JSXElement } from 'solid-js'
 import { CenterInline } from '/@/libs/layout'
+import { style } from '@macaron-css/core'
 
 const AppTitleContainer = styled('div', {
   base: {
@@ -37,6 +37,24 @@ const AppNavContainer = styled('div', {
   },
 })
 
+const AnchorStyle = style({
+  fontSize: '24px',
+  fontWeight: 'medium',
+  color: vars.text.black3,
+  textDecoration: 'none',
+  padding: '4px 12px',
+  selectors: {
+    '&:hover': {
+      color: vars.text.black2,
+    },
+  },
+})
+
+const AnchorActiveStyle = style({
+  color: vars.text.black1,
+  borderBottom: `2px solid ${vars.text.black1}`,
+})
+
 export interface AppNavProps {
   repoName: string
   appName: string
@@ -55,20 +73,14 @@ export const AppNav = (props: AppNavProps): JSXElement => {
         </AppTitle>
       </AppTitleContainer>
       <AppNavContainer>
-        <A href={`/apps/${props.appID}`}>
-          <Button color='black1' size='large'>
-            General
-          </Button>
+        <A href={`/apps/${props.appID}`} class={AnchorStyle} activeClass={AnchorActiveStyle} end>
+          General
         </A>
-        <A href={`/apps/${props.appID}/builds`}>
-          <Button color='black1' size='large'>
-            Builds
-          </Button>
+        <A href={`/apps/${props.appID}/builds`} class={AnchorStyle} activeClass={AnchorActiveStyle}>
+          Builds
         </A>
-        <A href={`/apps/${props.appID}/settings`}>
-          <Button color='black1' size='large'>
-            Settings
-          </Button>
+        <A href={`/apps/${props.appID}/settings`} class={AnchorStyle} activeClass={AnchorActiveStyle}>
+          Settings
         </A>
       </AppNavContainer>
     </>

--- a/dashboard/src/components/UserAvatar.tsx
+++ b/dashboard/src/components/UserAvatar.tsx
@@ -1,0 +1,31 @@
+import { styled } from '@macaron-css/solid'
+import { JSX, Component, splitProps } from 'solid-js'
+import { User } from '/@/api/neoshowcase/protobuf/gateway_pb'
+
+const UserAvatarImg = styled('img', {
+  base: {
+    height: 'auto',
+    aspectRatio: '1',
+    borderRadius: '50%',
+  },
+})
+
+export interface UserAvatarProps extends JSX.HTMLAttributes<HTMLImageElement> {
+  user: User
+  size?: number
+}
+
+const UserAvatar: Component<UserAvatarProps> = (props) => {
+  const [addedProps, originalImgProps] = splitProps(props, ['user', 'size'])
+  return (
+    <UserAvatarImg
+      src={addedProps.user.avatarUrl}
+      style={{
+        width: addedProps.size ? `${addedProps.size}px` : '100%',
+      }}
+      {...originalImgProps}
+    />
+  )
+}
+
+export default UserAvatar

--- a/dashboard/src/components/UserSearch.tsx
+++ b/dashboard/src/components/UserSearch.tsx
@@ -10,7 +10,7 @@ const UserSearchContainer = styled('div', {
   base: {
     display: 'flex',
     flexDirection: 'column',
-    gap: '8px',
+    gap: '16px',
   },
 })
 const UserRow = styled('div', {
@@ -19,6 +19,7 @@ const UserRow = styled('div', {
     flexDirection: 'row',
     justifyContent: 'space-between',
     alignItems: 'center',
+    gap: '16px',
   },
 })
 const UserContainer = styled('div', {
@@ -42,6 +43,12 @@ const UsersList = styled('div', {
     gap: '8px',
     overflowY: 'auto',
     maxHeight: '400px',
+  },
+})
+const NoUsersFound = styled('div', {
+  base: {
+    color: vars.text.black2,
+    textAlign: 'center',
   },
 })
 
@@ -93,7 +100,7 @@ export const UserSearch: FlowComponent<
           )}
         </For>
         <Show when={userSearchResults().length === 0}>
-          <div>No Users Found</div>
+          <NoUsersFound>No Users Found</NoUsersFound>
         </Show>
       </UsersList>
     </UserSearchContainer>

--- a/dashboard/src/components/UserSearch.tsx
+++ b/dashboard/src/components/UserSearch.tsx
@@ -1,0 +1,101 @@
+import { styled } from '@macaron-css/solid'
+import Fuse from 'fuse.js'
+import { FlowComponent, For, JSX, Show, createMemo, createSignal } from 'solid-js'
+import { User } from '/@/api/neoshowcase/protobuf/gateway_pb'
+import { vars } from '/@/theme'
+import { InputBar } from '/@/components/Input'
+import UserAvatar from '/@/components/UserAvatar'
+
+const UserSearchContainer = styled('div', {
+  base: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '8px',
+  },
+})
+const UserRow = styled('div', {
+  base: {
+    display: 'flex',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+})
+const UserContainer = styled('div', {
+  base: {
+    display: 'flex',
+    flexDirection: 'row',
+    gap: '8px',
+    alignItems: 'center',
+  },
+})
+const UserName = styled('div', {
+  base: {
+    fontSize: '16px',
+    color: vars.text.black1,
+  },
+})
+const UsersList = styled('div', {
+  base: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '8px',
+    overflowY: 'auto',
+    maxHeight: '400px',
+  },
+})
+
+export const UserSearch: FlowComponent<
+  {
+    users: User[]
+  },
+  (user: User) => JSX.Element
+> = (props) => {
+  const [userSearchQuery, setUserSearchQuery] = createSignal('')
+
+  // users()の更新時にFuseインスタンスを再生成する
+  const fuse = createMemo(
+    () =>
+      new Fuse(props.users, {
+        keys: ['name'],
+      }),
+  )
+  // userSearchQuery()の更新時に検索を実行する
+  const userSearchResults = createMemo(() => {
+    // 検索クエリが空の場合は全ユーザーを表示する
+    if (userSearchQuery() === '') {
+      return props.users
+    } else {
+      return fuse()
+        .search(userSearchQuery())
+        .map((result) => result.item)
+    }
+  })
+
+  return (
+    <UserSearchContainer>
+      <InputBar
+        type='text'
+        value={userSearchQuery()}
+        onInput={(e) => setUserSearchQuery(e.target.value)}
+        placeholder='search users...'
+      />
+      <UsersList>
+        <For each={userSearchResults()}>
+          {(user) => (
+            <UserRow>
+              <UserContainer>
+                <UserAvatar user={user} size={32} />
+                <UserName>{user.name}</UserName>
+              </UserContainer>
+              {props.children(user)}
+            </UserRow>
+          )}
+        </For>
+        <Show when={userSearchResults().length === 0}>
+          <div>No Users Found</div>
+        </Show>
+      </UsersList>
+    </UserSearchContainer>
+  )
+}

--- a/dashboard/src/components/WebsiteSettings.tsx
+++ b/dashboard/src/components/WebsiteSettings.tsx
@@ -4,15 +4,16 @@ import { Checkbox } from '/@/components/Checkbox'
 import { Radio, RadioItem } from '/@/components/Radio'
 import { Button } from '/@/components/Button'
 import { SetStoreFunction } from 'solid-js/store'
-import { For } from 'solid-js'
+import { For, Show } from 'solid-js'
 import { storify } from '/@/libs/storify'
 import { InputBar, InputLabel } from '/@/components/Input'
 import { FormButton, FormCheckBox, FormSettings, FormSettingsButton, SettingsContainer } from '/@/components/AppsNew'
 
-interface WebsiteProps {
+interface WebsiteSettingProps {
   website: CreateWebsiteRequest
   setWebsite: <T extends keyof CreateWebsiteRequest>(valueName: T, value: CreateWebsiteRequest[T]) => void
   deleteWebsite: () => void
+  saveWebsite?: () => void
 }
 
 const authenticationTypeItems: RadioItem<AuthenticationType>[] = [
@@ -21,7 +22,7 @@ const authenticationTypeItems: RadioItem<AuthenticationType>[] = [
   { value: AuthenticationType.HARD, title: 'HARD' },
 ]
 
-const Website = (props: WebsiteProps) => {
+export const WebsiteSetting = (props: WebsiteSettingProps) => {
   return (
     <FormSettings>
       <div>
@@ -71,6 +72,11 @@ const Website = (props: WebsiteProps) => {
         <Button onclick={props.deleteWebsite} color='black1' size='large' type='button'>
           Delete website setting
         </Button>
+        <Show when={props.saveWebsite}>
+          <Button onclick={props.saveWebsite} color='black1' size='large' type='button'>
+            Save
+          </Button>
+        </Show>
       </FormSettingsButton>
     </FormSettings>
   )
@@ -86,7 +92,7 @@ export const WebsiteSettings = (props: WebsiteSettingsProps) => {
     <SettingsContainer>
       <For each={props.websiteConfigs}>
         {(website, i) => (
-          <Website
+          <WebsiteSetting
             website={website}
             setWebsite={(valueName, value) => {
               props.setWebsiteConfigs(i(), valueName, value)

--- a/dashboard/src/pages/apps/[id]/settings.tsx
+++ b/dashboard/src/pages/apps/[id]/settings.tsx
@@ -34,9 +34,48 @@ import { userFromId, users } from '/@/libs/useAllUsers'
 import { UserSearch } from '/@/components/UserSearch'
 import useModal from '/@/libs/useModal'
 
-const ConfigsContainer = styled('div', {
+const ContentContainer = styled('div', {
   base: {
     marginTop: '24px',
+    display: 'grid',
+    gridTemplateColumns: '380px 1fr',
+    gap: '40px',
+    position: 'relative',
+  },
+})
+const SidebarContainer = styled('div', {
+  base: {
+    position: 'sticky',
+    top: '64px',
+    padding: '24px 40px',
+    backgroundColor: vars.bg.white1,
+    borderRadius: '4px',
+    border: `1px solid ${vars.bg.white4}`,
+  },
+})
+const SidebarOptions = styled('div', {
+  base: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '12px',
+
+    fontSize: '20px',
+    color: vars.text.black1,
+  },
+})
+const SidebarNavAnchor = styled('a', {
+  base: {
+    color: vars.text.black2,
+    textDecoration: 'none',
+    selectors: {
+      '&:hover': {
+        color: vars.text.black1,
+      },
+    },
+  },
+})
+const ConfigsContainer = styled('div', {
+  base: {
     display: 'flex',
     flexDirection: 'column',
     gap: '24px',
@@ -101,7 +140,7 @@ export default () => {
     return (
       <form ref={formContainer}>
         <SettingFieldSet>
-          <FormTextBig>General settings</FormTextBig>
+          <FormTextBig id='general-settings'>General settings</FormTextBig>
           <div>
             <InputLabel>Application Name</InputLabel>
             <InputBar
@@ -202,7 +241,7 @@ export default () => {
 
     return (
       <SettingFieldSet>
-        <FormTextBig>Build Settings</FormTextBig>
+        <FormTextBig id='build-settings'>Build Settings</FormTextBig>
         <BuildConfigs
           setBuildConfig={setBuildConfig}
           buildConfig={buildConfig}
@@ -275,7 +314,7 @@ export default () => {
 
     return (
       <SettingFieldSet>
-        <FormTextBig>Website Settings</FormTextBig>
+        <FormTextBig id='website-settings'>Website Settings</FormTextBig>
         <For each={websites}>
           {(website, i) => (
             <WebsiteSetting
@@ -344,7 +383,7 @@ export default () => {
 
     return (
       <SettingFieldSet>
-        <FormTextBig>Port Publication Settings</FormTextBig>
+        <FormTextBig id='port-settings'>Port Publication Settings</FormTextBig>
         <PortPublicationSettings
           portPublications={currentPortPublications}
           setPortPublications={setCurrentPortPublications}
@@ -395,7 +434,7 @@ export default () => {
     return (
       <>
         <SettingFieldSet>
-          <FormTextBig>Owner Settings</FormTextBig>
+          <FormTextBig id='owner-settings'>Owner Settings</FormTextBig>
           <Button color='black1' size='large' onclick={open}>
             アプリオーナーを追加する
           </Button>
@@ -437,13 +476,26 @@ export default () => {
       <Header />
       <Show when={loaded()}>
         <AppNav repoName={repo().name} appName={app().name} appID={app().id} />
-        <ConfigsContainer>
-          <GeneralConfigsContainer />
-          <BuildConfigsContainer />
-          <WebsitesConfigContainer />
-          <PortPublicationConfigContainer />
-          <OwnerConfigContainer />
-        </ConfigsContainer>
+        <ContentContainer>
+          <div>
+            <SidebarContainer>
+              <SidebarOptions>
+                <SidebarNavAnchor href='#general-settings'>General</SidebarNavAnchor>
+                <SidebarNavAnchor href='#build-settings'>Build</SidebarNavAnchor>
+                <SidebarNavAnchor href='#website-settings'>Website</SidebarNavAnchor>
+                <SidebarNavAnchor href='#port-settings'>Port Publication</SidebarNavAnchor>
+                <SidebarNavAnchor href='#owner-settings'>Owner</SidebarNavAnchor>
+              </SidebarOptions>
+            </SidebarContainer>
+          </div>
+          <ConfigsContainer>
+            <GeneralConfigsContainer />
+            <BuildConfigsContainer />
+            <WebsitesConfigContainer />
+            <PortPublicationConfigContainer />
+            <OwnerConfigContainer />
+          </ConfigsContainer>
+        </ContentContainer>
       </Show>
     </Container>
   )

--- a/dashboard/src/pages/apps/[id]/settings.tsx
+++ b/dashboard/src/pages/apps/[id]/settings.tsx
@@ -1,0 +1,367 @@
+import { useParams } from '@solidjs/router'
+import { Component, For, JSX, Show, createEffect, createResource, createSignal, onMount } from 'solid-js'
+import { client, handleAPIError } from '/@/libs/api'
+import { Container } from '/@/libs/layout'
+import { Header } from '/@/components/Header'
+import { AppNav } from '/@/components/AppNav'
+import { Button } from '/@/components/Button'
+import { styled } from '@macaron-css/solid'
+import { vars } from '/@/theme'
+import { createStore } from 'solid-js/store'
+import {
+  ApplicationConfig,
+  BuildConfigRuntimeBuildpack,
+  BuildConfigRuntimeCmd,
+  BuildConfigRuntimeDockerfile,
+  BuildConfigStaticCmd,
+  BuildConfigStaticDockerfile,
+  CreateWebsiteRequest,
+  PortPublication,
+  RuntimeConfig,
+  UpdateApplicationRequest,
+  Website,
+} from '/@/api/neoshowcase/protobuf/gateway_pb'
+import { BuildConfigs } from '/@/components/BuildConfigs'
+import { storify } from '/@/libs/storify'
+import toast from 'solid-toast'
+import { WebsiteSetting } from '/@/components/WebsiteSettings'
+import { InputLabel } from '/@/components/Input'
+import { InputBar } from '/@/components/Input'
+import { FormButton, FormTextBig } from '/@/components/AppsNew'
+import { PortPublicationSettings } from '/@/components/PortPublications'
+
+const ConfigsContainer = styled('div', {
+  base: {
+    marginTop: '24px',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '24px',
+  },
+})
+const SettingFieldSet = styled('div', {
+  base: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '16px',
+    padding: '24px',
+    border: `1px solid ${vars.bg.white4}`,
+    borderRadius: '4px',
+    background: vars.bg.white1,
+  },
+})
+
+export default () => {
+  const params = useParams()
+  const [app, { refetch: refetchApp }] = createResource(
+    () => params.id,
+    (id) => client.getApplication({ id }),
+  )
+  const [repo] = createResource(
+    () => app()?.repositoryId,
+    (id) => client.getRepository({ repositoryId: id }),
+  )
+  const loaded = () => !!(app() && repo())
+
+  const GeneralConfigsContainer: Component = () => {
+    // 現在の設定で初期化
+    const [generalConfig, setGeneralConfig] = createStore({
+      name: app().name,
+      refName: app().refName,
+    })
+    let formContainer: HTMLFormElement
+
+    const updateGeneralSettings: JSX.EventHandler<HTMLButtonElement, MouseEvent> = async (e) => {
+      // prevent default form submit (reload page)
+      e.preventDefault()
+
+      // validate form
+      if (!formContainer.reportValidity()) {
+        return
+      }
+
+      const updateApplicationRequest = new UpdateApplicationRequest({
+        id: app().id,
+        name: generalConfig.name,
+        refName: generalConfig.refName,
+      })
+
+      try {
+        await client.updateApplication(updateApplicationRequest)
+        toast.success('アプリ設定を更新しました')
+        refetchApp()
+      } catch (e) {
+        handleAPIError(e, 'アプリ設定の更新に失敗しました')
+      }
+    }
+
+    return (
+      <form ref={formContainer}>
+        <SettingFieldSet>
+          <FormTextBig>General settings</FormTextBig>
+          <div>
+            <InputLabel>Application Name</InputLabel>
+            <InputBar
+              placeholder='my-app'
+              value={generalConfig.name}
+              onChange={(e) => setGeneralConfig('name', e.currentTarget.value)}
+              required
+            />
+          </div>
+          <div>
+            <InputLabel>Branch Name</InputLabel>
+            <InputBar
+              placeholder='main'
+              value={generalConfig.refName}
+              onChange={(e) => setGeneralConfig('refName', e.currentTarget.value)}
+              required
+            />
+          </div>
+          <Button color='black1' size='large' onclick={updateGeneralSettings} type='submit'>
+            Save
+          </Button>
+        </SettingFieldSet>
+      </form>
+    )
+  }
+
+  const BuildConfigsContainer: Component = () => {
+    type BuildConfigMethod = ApplicationConfig['buildConfig']['case']
+    const [runtimeConfig, setRuntimeConfig] = createStore<RuntimeConfig>(new RuntimeConfig())
+    const [buildConfigMethod, setBuildConfigMethod] = createSignal<BuildConfigMethod>(app().config.buildConfig.case)
+    const [buildConfig, setBuildConfig] = createStore<{
+      [K in BuildConfigMethod]: Extract<ApplicationConfig['buildConfig'], { case: K }>
+    }>({
+      runtimeBuildpack: {
+        case: 'runtimeBuildpack',
+        value: storify(
+          new BuildConfigRuntimeBuildpack({
+            runtimeConfig: runtimeConfig,
+          }),
+        ),
+      },
+      runtimeCmd: {
+        case: 'runtimeCmd',
+        value: storify(
+          new BuildConfigRuntimeCmd({
+            runtimeConfig: runtimeConfig,
+          }),
+        ),
+      },
+      runtimeDockerfile: {
+        case: 'runtimeDockerfile',
+        value: storify(
+          new BuildConfigRuntimeDockerfile({
+            runtimeConfig: runtimeConfig,
+          }),
+        ),
+      },
+      staticCmd: {
+        case: 'staticCmd',
+        value: storify(new BuildConfigStaticCmd()),
+      },
+      staticDockerfile: {
+        case: 'staticDockerfile',
+        value: storify(new BuildConfigStaticDockerfile()),
+      },
+    })
+
+    // 現在のビルド設定を反映
+    onMount(() => {
+      setBuildConfigMethod(app().config.buildConfig.case)
+      setBuildConfig(app().config.buildConfig.case, {
+        case: app().config.buildConfig.case,
+        value: storify(app().config.buildConfig.value),
+      })
+    })
+
+    const updateBuildSettings: JSX.EventHandler<HTMLButtonElement, MouseEvent> = async (e) => {
+      // prevent default form submit (reload page)
+      e.preventDefault()
+
+      const updateApplicationRequest = new UpdateApplicationRequest({
+        id: app().id,
+        config: {
+          buildConfig: buildConfig[buildConfigMethod()],
+        },
+      })
+
+      try {
+        await client.updateApplication(updateApplicationRequest)
+        toast.success('ビルド設定を更新しました')
+        refetchApp()
+      } catch (e) {
+        handleAPIError(e, 'ビルド設定の更新に失敗しました')
+      }
+    }
+
+    return (
+      <SettingFieldSet>
+        <FormTextBig>Build Settings</FormTextBig>
+        <BuildConfigs
+          setBuildConfig={setBuildConfig}
+          buildConfig={buildConfig}
+          runtimeConfig={runtimeConfig}
+          setRuntimeConfig={setRuntimeConfig}
+          buildConfigMethod={buildConfigMethod()}
+          setBuildConfigMethod={setBuildConfigMethod}
+        />
+        <Button color='black1' size='large' onclick={updateBuildSettings} type='submit'>
+          Save
+        </Button>
+      </SettingFieldSet>
+    )
+  }
+
+  const WebsitesConfigContainer: Component = () => {
+    // アプリにすでに存在するウェブサイト設定: `Website`
+    // 新規追加するウェブサイト設定: `CreateWebsiteRequest`
+    const [websites, setWebsites] = createStore<(Website | CreateWebsiteRequest)[]>([])
+    // 現在のウェブサイト設定を反映 (`onMount`ではrefetch時に反映されないので`createEffect`を使用)
+    createEffect(() => {
+      setWebsites(app().websites.map((website) => storify(website)))
+    })
+
+    const AddWebsites = async (website: CreateWebsiteRequest) => {
+      const updateApplicationRequest = new UpdateApplicationRequest({
+        id: app().id,
+        newWebsites: [website],
+      })
+
+      try {
+        await client.updateApplication(updateApplicationRequest)
+        toast.success('ウェブサイト設定を追加しました')
+        refetchApp()
+      } catch (e) {
+        handleAPIError(e, 'ウェブサイト設定の追加に失敗しました')
+      }
+    }
+
+    const deleteWebsites = async (websiteId: Website['id']) => {
+      const updateApplicationRequest = new UpdateApplicationRequest({
+        id: app().id,
+        deleteWebsites: [{ id: websiteId }],
+      })
+
+      try {
+        await client.updateApplication(updateApplicationRequest)
+        toast.success('ウェブサイト設定を削除しました')
+        refetchApp()
+      } catch (e) {
+        handleAPIError(e, 'ウェブサイト設定の削除に失敗しました')
+      }
+    }
+
+    const updateWebsites = async (website: Website) => {
+      const updateApplicationRequest = new UpdateApplicationRequest({
+        id: app().id,
+        deleteWebsites: [{ id: website.id }],
+        newWebsites: [website],
+      })
+
+      try {
+        await client.updateApplication(updateApplicationRequest)
+        toast.success('ウェブサイト設定を更新しました')
+        refetchApp()
+      } catch (e) {
+        handleAPIError(e, 'ウェブサイト設定の更新に失敗しました')
+      }
+    }
+
+    return (
+      <SettingFieldSet>
+        <FormTextBig>Website Settings</FormTextBig>
+        <For each={websites}>
+          {(website, i) => (
+            <WebsiteSetting
+              website={website}
+              deleteWebsite={() => {
+                if (website instanceof CreateWebsiteRequest) {
+                  // 新規に追加したウェブサイト設定は配列から削除する
+                  setWebsites([...websites.slice(0, i()), ...websites.slice(i() + 1)])
+                } else {
+                  // もとからあるウェブサイト設定は削除リクエストを送る
+                  deleteWebsites(website.id)
+                }
+              }}
+              setWebsite={(key, value) => {
+                setWebsites(i(), key, value)
+              }}
+              saveWebsite={() => {
+                if (website instanceof CreateWebsiteRequest) {
+                  // 新規に追加したウェブサイト設定は追加リクエストを送る
+                  AddWebsites(website)
+                } else {
+                  // もとからあるウェブサイト設定は更新処理を実行する
+                  updateWebsites(website)
+                }
+              }}
+            />
+          )}
+        </For>
+        <FormButton>
+          <Button
+            onclick={() => {
+              setWebsites([...websites, storify(new CreateWebsiteRequest())])
+            }}
+            color='black1'
+            size='large'
+            type='button'
+          >
+            Add website setting
+          </Button>
+        </FormButton>
+      </SettingFieldSet>
+    )
+  }
+
+  const PortPublicationConfigContainer: Component = () => {
+    const [currentPortPublications, setCurrentPortPublications] = createStore<PortPublication[]>([])
+    // 現在のポート設定を反映
+    onMount(() => {
+      setCurrentPortPublications(app().portPublications.map((PortPublication) => storify(PortPublication)))
+    })
+
+    const updatePortPublications = async () => {
+      const updateApplicationRequest = new UpdateApplicationRequest({
+        id: app().id,
+        portPublications: currentPortPublications,
+      })
+
+      try {
+        await client.updateApplication(updateApplicationRequest)
+        toast.success('ポート設定を更新しました')
+        refetchApp()
+      } catch (e) {
+        handleAPIError(e, 'ポート設定の更新に失敗しました')
+      }
+    }
+
+    return (
+      <SettingFieldSet>
+        <FormTextBig>Port Publication Settings</FormTextBig>
+        <PortPublicationSettings
+          portPublications={currentPortPublications}
+          setPortPublications={setCurrentPortPublications}
+        />
+        <Button color='black1' size='large' onclick={updatePortPublications} type='submit'>
+          Save
+        </Button>
+      </SettingFieldSet>
+    )
+  }
+
+  return (
+    <Container>
+      <Header />
+      <Show when={loaded()}>
+        <AppNav repoName={repo().name} appName={app().name} appID={app().id} />
+        <ConfigsContainer>
+          <GeneralConfigsContainer />
+          <BuildConfigsContainer />
+          <WebsitesConfigContainer />
+          <PortPublicationConfigContainer />
+        </ConfigsContainer>
+      </Show>
+    </Container>
+  )
+}

--- a/dashboard/src/pages/apps/[id]/settings.tsx
+++ b/dashboard/src/pages/apps/[id]/settings.tsx
@@ -168,9 +168,11 @@ export default () => {
     // 現在のビルド設定を反映
     onMount(() => {
       setBuildConfigMethod(app().config.buildConfig.case)
-      setBuildConfig(app().config.buildConfig.case, {
-        case: app().config.buildConfig.case,
-        value: storify(app().config.buildConfig.value),
+      setBuildConfig({
+        [app().config.buildConfig.case]: {
+          case: app().config.buildConfig.case,
+          value: storify(app().config.buildConfig.value),
+        },
       })
     })
 

--- a/dashboard/src/routes.tsx
+++ b/dashboard/src/routes.tsx
@@ -23,6 +23,10 @@ export default useRoutes([
     component: lazy(() => import('/@/pages/apps/[id]/builds/[id]')),
   },
   {
+    path: '/apps/:id/settings',
+    component: lazy(() => import('/@/pages/apps/[id]/settings')),
+  },
+  {
     path: '/apps/new',
     component: lazy(() => import('/@/pages/apps/new')),
   },


### PR DESCRIPTION
## なぜやるか

ref: #484

## やったこと

- [x] アプリ設定ページの作成
  - [x] アプリ名設定
  - [x] リポジトリブランチ設定
  - [x] ビルド設定
  - [x] ウェブサイト設定
  - [x] ポート設定
  - [x] オーナー設定
    - リポジトリオーナー設定と共通化
- [x] アプリ設定ページへの遷移ボタンの追加
  - アプリ情報ページ/ビルド一覧ページ/設定ページの切り替えボタンのデザイン修正
