### PR TITLE
システムデフォルト鍵でリポジトリ作成ができなくなっていた

### DIFF
--- a/pkg/usecase/apiserver/repository_service.go
+++ b/pkg/usecase/apiserver/repository_service.go
@@ -27,6 +27,13 @@ func (s *Service) convertRepositoryAuth(a CreateRepositoryAuth) (domain.Reposito
 			Password: a.Password,
 		}, nil
 	case domain.RepositoryAuthMethodSSH:
+		if a.KeyID == "" {
+			// Use system default
+			return domain.RepositoryAuth{
+				Method: domain.RepositoryAuthMethodSSH,
+				SSHKey: "",
+			}, nil
+		}
 		key, ok := s.tmpKeys.GetIfExists(a.KeyID)
 		if !ok {
 			return domain.RepositoryAuth{}, newError(ErrorTypeBadRequest, fmt.Sprintf("key %v does not exist", a.KeyID), nil)


### PR DESCRIPTION
fix: use system default if key id is left empty