### PR TITLE
Dashboard/display available domain/port

### DIFF
--- a/dashboard/src/components/PortPublications.tsx
+++ b/dashboard/src/components/PortPublications.tsx
@@ -6,6 +6,23 @@ import { SetStoreFunction } from 'solid-js/store'
 import { FormButton, FormSettings, FormSettingsButton, SettingsContainer } from '/@/components/AppsNew'
 import { For } from 'solid-js'
 import { storify } from '/@/libs/storify'
+import { styled } from '@macaron-css/solid'
+import { vars } from '../theme'
+import { availablePorts } from '../libs/api'
+import { portPublicationProtocolMap } from '../libs/application'
+
+const AvailablePortContainer = styled('div', {
+  base: {
+    fontSize: '14px',
+    color: vars.text.black2,
+    padding: '8px',
+  },
+})
+const AvailableDomainUl = styled('ul', {
+  base: {
+    margin: '8px 0',
+  },
+})
 
 interface PortPublicationProps {
   portPublication: PortPublication
@@ -17,12 +34,33 @@ const PortPublications = (props: PortPublicationProps) => {
   return (
     <FormSettings>
       <div>
+        <InputLabel>Protocol</InputLabel>
+        <Radio
+          items={protocolItems}
+          selected={props.portPublication.protocol}
+          setSelected={(proto) => props.setPortPublication('protocol', proto)}
+        />
+      </div>
+      <div>
         <InputLabel>Internet Port</InputLabel>
         <InputBar
           placeholder='39000'
           type='number'
           onChange={(e) => props.setPortPublication('internetPort', +e.target.value)}
         />
+        <AvailablePortContainer>
+          使用可能なポート
+          <AvailableDomainUl>
+            <For each={availablePorts()?.availablePorts}>
+              {(port) => (
+                <li>
+                  {port.startPort}/{portPublicationProtocolMap[port.protocol]}~{port.endPort}/
+                  {portPublicationProtocolMap[port.protocol]}
+                </li>
+              )}
+            </For>
+          </AvailableDomainUl>
+        </AvailablePortContainer>
       </div>
       <div>
         <InputLabel>Application Port</InputLabel>
@@ -32,13 +70,7 @@ const PortPublications = (props: PortPublicationProps) => {
           onChange={(e) => props.setPortPublication('applicationPort', +e.target.value)}
         />
       </div>
-      <div>
-        <Radio
-          items={protocolItems}
-          selected={props.portPublication.protocol}
-          setSelected={(proto) => props.setPortPublication('protocol', proto)}
-        />
-      </div>
+
       <FormSettingsButton>
         <Button onclick={props.deletePortPublication} color='black1' size='large' width='auto' type='button'>
           Delete port publication

--- a/dashboard/src/components/WebsiteSettings.tsx
+++ b/dashboard/src/components/WebsiteSettings.tsx
@@ -7,6 +7,22 @@ import { For, Show } from 'solid-js'
 import { storify } from '/@/libs/storify'
 import { InputBar, InputLabel } from '/@/components/Input'
 import { FormButton, FormCheckBox, FormSettings, FormSettingsButton, SettingsContainer } from '/@/components/AppsNew'
+import { availableDomains } from '../libs/api'
+import { styled } from '@macaron-css/solid'
+import { vars } from '../theme'
+
+const AvailableDomainContainer = styled('div', {
+  base: {
+    fontSize: '14px',
+    color: vars.text.black2,
+    padding: '8px',
+  },
+})
+const AvailableDomainUl = styled('ul', {
+  base: {
+    margin: '8px 0',
+  },
+})
 
 interface WebsiteSettingProps {
   runtime: boolean
@@ -31,6 +47,20 @@ export const WebsiteSetting = (props: WebsiteSettingProps) => {
           value={props.website.fqdn}
           onInput={(e) => props.setWebsite('fqdn', e.target.value)}
         />
+        <AvailableDomainContainer>
+          使用可能なドメイン
+          <AvailableDomainUl>
+            <For each={availableDomains()?.domains}>
+              {(domain) => (
+                <li>
+                  {domain.domain}
+                  <Show when={domain.excludeDomains.length > 0}>&nbsp;({domain.excludeDomains.join(', ')}を除く)</Show>
+                  ：{domain.authAvailable ? '部員認証の使用可能' : '部員認証の使用不可'}
+                </li>
+              )}
+            </For>
+          </AvailableDomainUl>
+        </AvailableDomainContainer>
       </div>
       <div>
         <InputLabel>Path Prefix</InputLabel>
@@ -70,6 +100,7 @@ export const WebsiteSetting = (props: WebsiteSettingProps) => {
         </div>
       </Show>
       <div>
+        <InputLabel>部員認証</InputLabel>
         <Radio
           items={authenticationTypeItems}
           selected={props.website.authentication}

--- a/dashboard/src/libs/api.ts
+++ b/dashboard/src/libs/api.ts
@@ -12,6 +12,7 @@ export const client = createPromiseClient(APIService, transport)
 export const [user] = createResource(() => client.getMe({}))
 export const [sshInfo] = createResource(() => client.getSSHInfo({}))
 export const [availableDomains] = createResource(() => client.getAvailableDomains({}))
+export const [availablePorts] = createResource(() => client.getAvailablePorts({}))
 
 export const handleAPIError = (e, message: string) => {
   if (e instanceof ConnectError) {

--- a/dashboard/src/libs/api.ts
+++ b/dashboard/src/libs/api.ts
@@ -11,6 +11,7 @@ export const client = createPromiseClient(APIService, transport)
 
 export const [user] = createResource(() => client.getMe({}))
 export const [sshInfo] = createResource(() => client.getSSHInfo({}))
+export const [availableDomains] = createResource(() => client.getAvailableDomains({}))
 
 export const handleAPIError = (e, message: string) => {
   if (e instanceof ConnectError) {

--- a/dashboard/src/libs/application.tsx
+++ b/dashboard/src/libs/application.tsx
@@ -4,6 +4,7 @@ import {
   ApplicationConfig,
   Build_BuildStatus,
   DeployType,
+  PortPublicationProtocol,
   Repository_AuthMethod,
   Website,
 } from '/@/api/neoshowcase/protobuf/gateway_pb'
@@ -87,4 +88,9 @@ export const authMethodMap: Record<Repository_AuthMethod, AuthMethod> = {
   [Repository_AuthMethod.NONE]: 'none',
   [Repository_AuthMethod.BASIC]: 'basic',
   [Repository_AuthMethod.SSH]: 'ssh',
+}
+
+export const portPublicationProtocolMap: Record<PortPublicationProtocol, string> = {
+  [PortPublicationProtocol.TCP]: 'TCP',
+  [PortPublicationProtocol.UDP]: 'UDP',
 }


### PR DESCRIPTION
## なぜやるか

アプリ設定画面で使用可能なドメイン/ポートの例が表示されておらずわかりにくいため

## やったこと

- ウェブサイト設定での使用可能なドメインの表示
- ポート設定での使用可能なポートの表示
- "部員認証"のラベルの追加

![image](https://github.com/traPtitech/NeoShowcase/assets/59188998/e2e44190-ab27-4d1a-9aec-de71ca1d7a9e)
![image](https://github.com/traPtitech/NeoShowcase/assets/59188998/6554562b-7bfc-4ac9-816d-5e2b23ee99d6)
![image](https://github.com/traPtitech/NeoShowcase/assets/59188998/03b576f4-3a2c-45f0-ac61-19c0771adbe9)
