### PR TITLE
:bug: fix runtimeCofig to be changed

### DIFF
--- a/dashboard/src/pages/apps/[id]/settings.tsx
+++ b/dashboard/src/pages/apps/[id]/settings.tsx
@@ -257,9 +257,9 @@ export default () => {
         case 'runtimeBuildpack':
         case 'runtimeCmd':
         case 'runtimeDockerfile':
-          setBuildConfig('runtimeBuildpack', 'value', 'runtimeConfig', conf.buildConfig.value.runtimeConfig)
-          setBuildConfig('runtimeCmd', 'value', 'runtimeConfig', conf.buildConfig.value.runtimeConfig)
-          setBuildConfig('runtimeDockerfile', 'value', 'runtimeConfig', conf.buildConfig.value.runtimeConfig)
+          setBuildConfig('runtimeBuildpack', 'value', { runtimeConfig: conf.buildConfig.value.runtimeConfig })
+          setBuildConfig('runtimeCmd', 'value', { runtimeConfig: conf.buildConfig.value.runtimeConfig })
+          setBuildConfig('runtimeDockerfile', 'value', { runtimeConfig: conf.buildConfig.value.runtimeConfig })
       }
     })
 


### PR DESCRIPTION
## なぜやるか

アプリケーションのビルド設定項目において、ビルド/ランタイム種類を変更しなかった場合、DB, EntryPoint, Commandの変更が反映されていなかった

## やったこと

ページロード後のビルド設定の反映時の、`setBuildConfig`の引数の修正

3aeb8d131ce1dfb5dcf999ef89c5cd33d01bbaa6 と同一の原因だと思いますが、正直なぜこうなるのか仕様がつかみ切れていません、もう少し勉強します...