### PR TITLE
fix: gateway server startup

### DIFF
--- a/pkg/infrastructure/grpc/api_system_service.go
+++ b/pkg/infrastructure/grpc/api_system_service.go
@@ -11,7 +11,10 @@ import (
 )
 
 func (s *APIService) GetSystemInfo(ctx context.Context, _ *connect.Request[emptypb.Empty]) (*connect.Response[pb.SystemInfo], error) {
-	i := s.svc.GetSystemInfo(ctx)
+	i, err := s.svc.GetSystemInfo(ctx)
+	if err != nil {
+		return nil, handleUseCaseError(err)
+	}
 	res := connect.NewResponse(pbconvert.ToPBSystemInfo(i))
 	return res, nil
 }

--- a/pkg/usecase/apiserver/app_service.go
+++ b/pkg/usecase/apiserver/app_service.go
@@ -21,7 +21,11 @@ func (s *Service) validateApp(ctx context.Context, app *domain.Application) erro
 	if err != nil {
 		return errors.Wrap(err, "getting existing applications")
 	}
-	err = app.Validate(web.GetUser(ctx), existingApps, s.systemInfo.AvailableDomains, s.systemInfo.AvailablePorts)
+	si, err := s.systemInfo(ctx)
+	if err != nil {
+		return errors.Wrap(err, "getting system info")
+	}
+	err = app.Validate(web.GetUser(ctx), existingApps, si.AvailableDomains, si.AvailablePorts)
 	if err != nil {
 		return newError(ErrorTypeBadRequest, "invalid application", err)
 	}

--- a/pkg/usecase/apiserver/system_service.go
+++ b/pkg/usecase/apiserver/system_service.go
@@ -12,8 +12,8 @@ import (
 	"github.com/traPtitech/neoshowcase/pkg/domain"
 )
 
-func (s *Service) GetSystemInfo(_ context.Context) *domain.SystemInfo {
-	return s.systemInfo
+func (s *Service) GetSystemInfo(ctx context.Context) (*domain.SystemInfo, error) {
+	return s.systemInfo(ctx)
 }
 
 type tmpKeyPairService struct {

--- a/pkg/usecase/cdservice/service.go
+++ b/pkg/usecase/cdservice/service.go
@@ -11,10 +11,10 @@ import (
 	"golang.org/x/exp/slices"
 
 	"github.com/traPtitech/neoshowcase/pkg/domain"
-	"github.com/traPtitech/neoshowcase/pkg/util/coalesce"
 	"github.com/traPtitech/neoshowcase/pkg/util/ds"
 	"github.com/traPtitech/neoshowcase/pkg/util/loop"
 	"github.com/traPtitech/neoshowcase/pkg/util/optional"
+	"github.com/traPtitech/neoshowcase/pkg/util/scutil"
 )
 
 type Service interface {
@@ -59,7 +59,7 @@ func NewService(
 
 	ctx, cancel := context.WithCancel(context.Background())
 
-	doStartBuild := coalesce.NewCoalescer(func(ctx context.Context) error {
+	doStartBuild := scutil.NewCoalescer(func(ctx context.Context) error {
 		start := time.Now()
 		if err := cd.startBuilds(ctx); err != nil {
 			log.Errorf("failed to start builds: %+v", err)
@@ -73,7 +73,7 @@ func NewService(
 		_ = doStartBuild.Do(context.Background())
 	}
 
-	doSyncDeploy := coalesce.NewCoalescer(func(ctx context.Context) error {
+	doSyncDeploy := scutil.NewCoalescer(func(ctx context.Context) error {
 		start := time.Now()
 		if err := cd.syncDeployments(ctx); err != nil {
 			log.Errorf("failed to sync deployments: %+v", err)

--- a/pkg/usecase/ssgen/generator.go
+++ b/pkg/usecase/ssgen/generator.go
@@ -14,8 +14,8 @@ import (
 
 	"github.com/traPtitech/neoshowcase/pkg/domain"
 	"github.com/traPtitech/neoshowcase/pkg/infrastructure/grpc/pb"
-	"github.com/traPtitech/neoshowcase/pkg/util/coalesce"
 	"github.com/traPtitech/neoshowcase/pkg/util/retry"
+	"github.com/traPtitech/neoshowcase/pkg/util/scutil"
 	"github.com/traPtitech/neoshowcase/pkg/util/tarfs"
 )
 
@@ -40,7 +40,7 @@ type generatorService struct {
 
 	cancel   func()
 	reloaded atomic.Bool
-	reloader *coalesce.Coalescer
+	reloader *scutil.Coalescer
 }
 
 func NewGeneratorService(
@@ -59,7 +59,7 @@ func NewGeneratorService(
 		engine:    engine,
 		docsRoot:  string(path),
 	}
-	g.reloader = coalesce.NewCoalescer(g._reload)
+	g.reloader = scutil.NewCoalescer(g._reload)
 	return g
 }
 

--- a/pkg/util/scutil/coalescer.go
+++ b/pkg/util/scutil/coalescer.go
@@ -1,4 +1,4 @@
-package coalesce
+package scutil
 
 import (
 	"context"

--- a/pkg/util/scutil/once.go
+++ b/pkg/util/scutil/once.go
@@ -1,0 +1,21 @@
+package scutil
+
+import (
+	"context"
+	"time"
+
+	"github.com/motoki317/sc"
+)
+
+const inf = 100 * 365 * 24 * time.Hour
+
+func Once[T any](fn func(ctx context.Context) (T, error)) func(ctx context.Context) (T, error) {
+	// ref: sync.OnceFunc in go 1.21+
+	replaceFn := func(ctx context.Context, _ struct{}) (T, error) {
+		return fn(ctx)
+	}
+	c := sc.NewMust(replaceFn, inf, inf)
+	return func(ctx context.Context) (T, error) {
+		return c.Get(ctx, struct{}{})
+	}
+}


### PR DESCRIPTION
system infoの読み込みをlazyにすることで、gatewayがすぐ立ち上がるようにする