### PR TITLE
Hash計算に環境変数を含めるようにした

### DIFF
--- a/cmd/ns-controller/wire_gen.go
+++ b/cmd/ns-controller/wire_gen.go
@@ -56,13 +56,13 @@ func NewWithDocker(c2 Config) (*Server, error) {
 		return nil, err
 	}
 	buildRepository := repository.NewBuildRepository(db)
+	environmentRepository := repository.NewEnvironmentRepository(db)
 	service := logstream.NewService()
 	controllerBuilderService := grpc.NewControllerBuilderService(service)
-	environmentRepository := repository.NewEnvironmentRepository(db)
 	controllerSSGenService := grpc.NewControllerSSGenService()
 	appDeployHelper := cdservice.NewAppDeployHelper(backend, applicationRepository, buildRepository, environmentRepository, controllerSSGenService, imageConfig)
 	containerStateMutator := cdservice.NewContainerStateMutator(applicationRepository, backend)
-	cdserviceService, err := cdservice.NewService(applicationRepository, buildRepository, backend, controllerBuilderService, appDeployHelper, containerStateMutator)
+	cdserviceService, err := cdservice.NewService(applicationRepository, buildRepository, environmentRepository, backend, controllerBuilderService, appDeployHelper, containerStateMutator)
 	if err != nil {
 		return nil, err
 	}
@@ -135,14 +135,14 @@ func NewWithK8S(c2 Config) (*Server, error) {
 		return nil, err
 	}
 	buildRepository := repository.NewBuildRepository(db)
+	environmentRepository := repository.NewEnvironmentRepository(db)
 	service := logstream.NewService()
 	controllerBuilderService := grpc.NewControllerBuilderService(service)
-	environmentRepository := repository.NewEnvironmentRepository(db)
 	controllerSSGenService := grpc.NewControllerSSGenService()
 	imageConfig := c2.Image
 	appDeployHelper := cdservice.NewAppDeployHelper(backend, applicationRepository, buildRepository, environmentRepository, controllerSSGenService, imageConfig)
 	containerStateMutator := cdservice.NewContainerStateMutator(applicationRepository, backend)
-	cdserviceService, err := cdservice.NewService(applicationRepository, buildRepository, backend, controllerBuilderService, appDeployHelper, containerStateMutator)
+	cdserviceService, err := cdservice.NewService(applicationRepository, buildRepository, environmentRepository, backend, controllerBuilderService, appDeployHelper, containerStateMutator)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/domain/app.go
+++ b/pkg/domain/app.go
@@ -2,6 +2,7 @@ package domain
 
 import (
 	"encoding/json"
+	"sort"
 	"strings"
 	"time"
 
@@ -25,8 +26,11 @@ func (c *ApplicationConfig) Validate(deployType DeployType) error {
 	return nil
 }
 
-func (c *ApplicationConfig) Hash() string {
+func (c *ApplicationConfig) Hash(env []*Environment) string {
 	b := lo.Must(json.Marshal(c))
+	sort.SliceStable(env, func(i, j int) bool { return env[i].Key < env[j].Key })
+	e := lo.Must(json.Marshal(env))
+	b = append(b, e...)
 	return hash.XXH3Hex(b)
 }
 

--- a/pkg/domain/app_build.go
+++ b/pkg/domain/app_build.go
@@ -44,11 +44,11 @@ type Build struct {
 	Artifacts     []*Artifact
 }
 
-func NewBuild(app *Application) *Build {
+func NewBuild(app *Application, env []*Environment) *Build {
 	return &Build{
 		ID:            NewID(),
 		Commit:        app.Commit,
-		ConfigHash:    app.Config.Hash(),
+		ConfigHash:    app.Config.Hash(env),
 		Status:        BuildStatusQueued,
 		ApplicationID: app.ID,
 		QueuedAt:      time.Now(),

--- a/pkg/domain/app_test.go
+++ b/pkg/domain/app_test.go
@@ -217,7 +217,6 @@ func TestApplicationConfig_Validate(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name+" (hash)", func(t *testing.T) {
-			// TODO: 勝手に変えたから後でどうにかしないといけないかもしれない
 			xxh3 := tt.config.Hash(nil)
 			t.Logf("hash: %v", xxh3)
 			assert.Len(t, xxh3, 16)
@@ -351,17 +350,15 @@ func TestHashWithEnv(t *testing.T) {
 	}
 
 	t.Run(test.name, func(t *testing.T) {
-		before := test.config.Hash(testEnv)
-		t.Logf("first hash: %v", before)
+		hash := test.config.Hash(testEnv)
+
 		testEnv = append(testEnv, &Environment{Key: "key3", Value: "value3"})
+		added := test.config.Hash(testEnv)
+		assert.NotEqual(t, hash, added)
 
-		after := test.config.Hash(testEnv)
-		assert.NotEqual(t, before, after)
-
+		// test that the hash is the same if the order of the envs is different
 		testEnv = []*Environment{{Key: "key2", Value: "value2"}, {Key: "key1", Value: "value1"}}
-		assert.Equal(t, before, test.config.Hash(testEnv))
-
-		testEnv = []*Environment{{Key: "key", Value: "value"}}
-		assert.NotEqual(t, before, test.config.Hash(testEnv))
+		orderChanged := test.config.Hash(testEnv)
+		assert.Equal(t, hash, orderChanged)
 	})
 }

--- a/pkg/domain/app_test.go
+++ b/pkg/domain/app_test.go
@@ -335,16 +335,20 @@ func TestHashWithEnv(t *testing.T) {
 	}
 	hash := config.Hash(testEnv)
 
-	testEnv = append(testEnv, &Environment{Key: "key3", Value: "value3"})
-	t.Run("add env", func(t *testing.T) {
-		assert.NotEqual(t, hash, config.Hash(testEnv))
+	t.Run("hash should be equal when env is different", func(t *testing.T) {
+		testEnv2 := []*Environment{
+			{Key: "key1", Value: "value1"},
+			{Key: "key2", Value: "value2"},
+			{Key: "key3", Value: "value3"},
+		}
+		assert.NotEqual(t, hash, config.Hash(testEnv2))
 	})
 
-	testEnv = []*Environment{
-		{Key: "key2", Value: "value2"},
-		{Key: "key1", Value: "value1"},
-	}
-	t.Run("change order", func(t *testing.T) {
-		assert.Equal(t, hash, config.Hash(testEnv))
+	t.Run("order should not matter", func(t *testing.T) {
+		reversedTestEnv := []*Environment{
+			{Key: "key2", Value: "value2"},
+			{Key: "key1", Value: "value1"},
+		}
+		assert.Equal(t, hash, config.Hash(reversedTestEnv))
 	})
 }


### PR DESCRIPTION
## なぜやるか
今のままだとHashの計算に環境変数が考慮されていないから

## やったこと
Hashの計算で環境変数を考慮するようにした

## やらなかったこと

## 資料
closes https://github.com/traPtitech/NeoShowcase/issues/671
