### PR TITLE
環境変数/SSH公開鍵 コピーボタンの追加

### DIFF
--- a/dashboard/src/components/Button.tsx
+++ b/dashboard/src/components/Button.tsx
@@ -78,6 +78,9 @@ export const Button: ParentComponent<Props> = (props) => {
         disabled: !props.tooltip,
         hidden: true,
       }}
+      style={{
+        width: props.width === 'full' ? '100%' : 'fit-content',
+      }}
     >
       <Container color={addedProps.color} width={addedProps.width} cursor={cursor()} {...originalButtonProps}>
         <Text color={addedProps.color} size={addedProps.size}>

--- a/dashboard/src/components/Input.tsx
+++ b/dashboard/src/components/Input.tsx
@@ -78,6 +78,9 @@ export const InputBar: Component<InputBarProps> = (props) => {
         disabled: !props.tooltip,
         hidden: true,
       }}
+      style={{
+        width: props.width === 'full' ? '100%' : 'fit-content',
+      }}
     >
       <StyledInput width={addedProps.width} {...inputProps} />
     </span>

--- a/dashboard/src/components/Input.tsx
+++ b/dashboard/src/components/Input.tsx
@@ -26,7 +26,6 @@ const inputStyle: ComplexStyleRule = {
   borderRadius: '4px',
   border: `1px solid ${vars.bg.white4}`,
   fontSize: '14px',
-  marginLeft: '4px',
 
   width: '100%',
 

--- a/dashboard/src/components/RepositoryAuthSettings.tsx
+++ b/dashboard/src/components/RepositoryAuthSettings.tsx
@@ -1,12 +1,15 @@
 import { InfoTooltip } from '/@/components/InfoTooltip'
 import { PlainMessage } from '@bufbuild/protobuf'
 import { styled } from '@macaron-css/solid'
+import { OcCopy2 } from 'solid-icons/oc'
 import { Component, Match, Show, Switch, createEffect, createResource, createSignal } from 'solid-js'
 import { SetStoreFunction } from 'solid-js/store'
 import { CreateRepositoryAuth } from '../api/neoshowcase/protobuf/gateway_pb'
 import { client, systemInfo } from '../libs/api'
+import { writeToClipboard } from '../libs/clipboard'
 import { vars } from '../theme'
 import { Button } from './Button'
+import { IconButton } from './IconButton'
 import { InputBar, InputLabel } from './Input'
 import { Radio } from './Radio'
 
@@ -55,6 +58,8 @@ export const RepositoryAuthSettings: Component<RepositoryAuthSettingsProps> = (p
   })
   const publicKey = () => (useTmpKey() ? tmpKey()?.publicKey : systemInfo()?.publicKey)
 
+  const handleCopyPublicKey = () => writeToClipboard(publicKey())
+
   return (
     <div>
       <InputLabel>認証方法</InputLabel>
@@ -75,21 +80,37 @@ export const RepositoryAuthSettings: Component<RepositoryAuthSettingsProps> = (p
               <InputBar
                 // SSH URLはURLとしては不正なのでtypeを変更
                 value={v().username}
-                onInput={(e) => props.setAuthConfig('auth', 'value', { username: e.currentTarget.value })}
+                onInput={(e) =>
+                  props.setAuthConfig('auth', 'value', {
+                    username: e.currentTarget.value,
+                  })
+                }
               />
               <InputLabel>パスワード</InputLabel>
               <InputBar
                 // SSH URLはURLとしては不正なのでtypeを変更
                 type="password"
                 value={v().password}
-                onInput={(e) => props.setAuthConfig('auth', 'value', { password: e.currentTarget.value })}
+                onInput={(e) =>
+                  props.setAuthConfig('auth', 'value', {
+                    password: e.currentTarget.value,
+                  })
+                }
               />
             </>
           )}
         </Match>
         <Match when={props.authConfig.auth.case === 'ssh'}>
-          <SshDetails>以下のSSH公開鍵{!useTmpKey() && ' (システム共通) '}をリポジトリに登録してください。</SshDetails>
-          <PublicKeyCode>{publicKey()}</PublicKeyCode>
+          <SshDetails>
+            以下のSSH公開鍵{!useTmpKey() && ' (システム共通) '}
+            をリポジトリに登録してください。
+          </SshDetails>
+          <Row>
+            <PublicKeyCode>{publicKey()}</PublicKeyCode>
+            <IconButton onClick={handleCopyPublicKey} tooltip="クリップボードにコピー">
+              <OcCopy2 size={18} color={vars.text.black2} />
+            </IconButton>
+          </Row>
           <Show when={!useTmpKey()}>
             <Row>
               <Button color="black1" size="large" width="auto" onclick={() => setUseTmpKey(true)} type="submit">

--- a/dashboard/src/libs/clipboard.ts
+++ b/dashboard/src/libs/clipboard.ts
@@ -1,0 +1,28 @@
+import toast from 'solid-toast'
+
+const copyTextToClipboard = async (text: string): Promise<void> => {
+  if (navigator.clipboard) {
+    // Use Clipboard API when available
+    return navigator.clipboard.writeText(text)
+  } else {
+    const textArea = document.createElement('textarea')
+    textArea.value = text
+
+    // Avoid scrolling
+    textArea.style.position = 'fixed'
+    textArea.style.top = '0'
+
+    document.body.appendChild(textArea)
+    textArea.focus()
+    textArea.select()
+    document.execCommand('copy')
+    document.body.removeChild(textArea)
+  }
+}
+
+export const writeToClipboard = (text: string): Promise<void> =>
+  toast.promise(copyTextToClipboard(text), {
+    success: 'Copied to clipboard',
+    loading: 'Copying to clipboard...',
+    error: 'Failed to copy to clipboard',
+  })

--- a/dashboard/src/pages/apps/[id]/settings.tsx
+++ b/dashboard/src/pages/apps/[id]/settings.tsx
@@ -4,6 +4,7 @@ import { FormTextBig } from '/@/components/AppsNew'
 import { BuildConfigs } from '/@/components/BuildConfigs'
 import { Button } from '/@/components/Button'
 import { Header } from '/@/components/Header'
+import { IconButton } from '/@/components/IconButton'
 import { InfoTooltip } from '/@/components/InfoTooltip'
 import { InputBar, InputLabel } from '/@/components/Input'
 import { InputSuggestion } from '/@/components/InputSuggestion'
@@ -13,6 +14,7 @@ import { UserSearch } from '/@/components/UserSearch'
 import { WebsiteSettings } from '/@/components/WebsiteSettings'
 import { client, handleAPIError } from '/@/libs/api'
 import { useBranchesSuggestion } from '/@/libs/branchesSuggestion'
+import { writeToClipboard } from '/@/libs/clipboard'
 import { Container } from '/@/libs/layout'
 import { userFromId, users } from '/@/libs/useAllUsers'
 import useModal from '/@/libs/useModal'
@@ -21,6 +23,7 @@ import { PlainMessage } from '@bufbuild/protobuf'
 import { style } from '@macaron-css/core'
 import { styled } from '@macaron-css/solid'
 import { useParams } from '@solidjs/router'
+import { OcCopy2 } from 'solid-icons/oc'
 import { Component, For, JSX, Show, createEffect, createMemo, createResource, createSignal } from 'solid-js'
 import { createStore } from 'solid-js/store'
 import toast from 'solid-toast'
@@ -99,11 +102,17 @@ const EnvVarKeyCode = styled('code', {
     padding: '8px 12px',
     borderRadius: '4px',
     fontSize: '14px',
-    marginLeft: '4px',
 
     width: '100%',
     display: 'flex',
     alignItems: 'center',
+  },
+})
+const EnvVarInputContainer = styled('div', {
+  base: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '4px',
   },
 })
 const EnvVarButtonContainer = styled('div', {
@@ -370,6 +379,8 @@ export default () => {
       let valueInputRef: HTMLInputElement
       const { Modal: DeleteEnvVarModal, open: openDeleteEnvVarModal, close: closeDeleteEnvVarModal } = useModal()
 
+      const handleCopyEnvVarValue = () => writeToClipboard(props.envVar.value)
+
       const handleUpdateEnvVar: JSX.EventHandler<HTMLButtonElement, MouseEvent> = async (e) => {
         // prevent default form submit (reload page)
         e.preventDefault()
@@ -413,14 +424,22 @@ export default () => {
       return (
         <form class={EnvVarContainerClass} ref={formRef}>
           <EnvVarKeyCode>{props.envVar.key}</EnvVarKeyCode>
-          <InputBar
-            type="text"
-            disabled={!isEditing()}
-            required
-            placeholder="VALUE"
-            ref={valueInputRef}
-            value={props.envVar.value}
-          />
+          <EnvVarInputContainer>
+            <InputBar
+              type="text"
+              disabled={!isEditing()}
+              required
+              placeholder="VALUE"
+              ref={valueInputRef}
+              value={props.envVar.value}
+              width="full"
+            />
+            <Show when={!isEditing()}>
+              <IconButton onClick={handleCopyEnvVarValue} tooltip="クリップボードにコピー">
+                <OcCopy2 size={18} color={vars.text.black2} />
+              </IconButton>
+            </Show>
+          </EnvVarInputContainer>
           <EnvVarButtonContainer>
             <Show
               when={!isEditing()}
@@ -502,8 +521,8 @@ export default () => {
 
       return (
         <form class={EnvVarContainerClass} ref={formRef}>
-          <InputBar type="text" required placeholder="KEY" ref={keyInputRef} />
-          <InputBar type="text" required placeholder="VALUE" ref={valueInputRef} />
+          <InputBar type="text" required placeholder="KEY" width="full" ref={keyInputRef} />
+          <InputBar type="text" required placeholder="VALUE" width="full" ref={valueInputRef} />
           <Button color="black1" size="large" width="full" type="submit" onclick={handleAddEnvVar}>
             Add
           </Button>


### PR DESCRIPTION
## なぜやるか

resolve #627

## やったこと

- アプリ設定画面での環境変数コピーボタンの追加
- リポジトリ追加画面でのSSH公開鍵コピーボタンの追加
- `input`についていた不要なマージンの削除
  - input自体に`margin-left`が付いており、縦並びでは問題なかったが横並びさせた時にデザインが崩れたため削除
- ツールチップ表示用に追加された`span`要素により、width="full"としたbutton/inputの幅が100%になっていなかったため修正