### PR TITLE
/apps/:id/settingsでブランチ取得に失敗するとエラーが出ていた

### DIFF
--- a/dashboard/src/libs/branchesSuggestion.ts
+++ b/dashboard/src/libs/branchesSuggestion.ts
@@ -45,7 +45,7 @@ export const useBranches = (repoID: () => string): (() => string[]) => {
     (id) =>
       client.getRepositoryRefs({ repositoryId: id }).catch(() => {
         // ブランチ取得の失敗時は502エラーが返ってくるのでcatchで処理する
-        toast.error('ブランチの取得に失敗しました。リポジトリが削除されたか認証方法に問題があります')
+        toast.error('ブランチの取得に失敗しました。リポジトリへのアクセス権を確認してください。')
         return { refs: [] }
       }),
   )

--- a/dashboard/src/libs/branchesSuggestion.ts
+++ b/dashboard/src/libs/branchesSuggestion.ts
@@ -43,8 +43,9 @@ export const useBranches = (repoID: () => string): (() => string[]) => {
   const [refs] = createResource(
     () => repoID(),
     (id) =>
-      client.getRepositoryRefs({ repositoryId: id }).catch(() => {
+      client.getRepositoryRefs({ repositoryId: id }).catch((err) => {
         // ブランチ取得の失敗時は502エラーが返ってくるのでcatchで処理する
+        console.trace(err)
         toast.error('ブランチの取得に失敗しました。リポジトリへのアクセス権を確認してください。')
         return { refs: [] }
       }),

--- a/dashboard/src/libs/branchesSuggestion.ts
+++ b/dashboard/src/libs/branchesSuggestion.ts
@@ -1,5 +1,6 @@
 import Fuse from 'fuse.js'
 import { createMemo, createResource } from 'solid-js'
+import toast from 'solid-toast'
 import { client } from '/@/libs/api'
 
 export const useBranchesSuggestion = (repoID: () => string, current: () => string): (() => string[]) => {
@@ -41,7 +42,12 @@ export const useBranchesSuggestion = (repoID: () => string, current: () => strin
 export const useBranches = (repoID: () => string): (() => string[]) => {
   const [refs] = createResource(
     () => repoID(),
-    (id) => client.getRepositoryRefs({ repositoryId: id }),
+    (id) =>
+      client.getRepositoryRefs({ repositoryId: id }).catch(() => {
+        // ブランチ取得の失敗時は502エラーが返ってくるのでcatchで処理する
+        toast.error('ブランチの取得に失敗しました。リポジトリが削除されたか認証方法に問題があります')
+        return { refs: [] }
+      }),
   )
 
   return createMemo(() => {


### PR DESCRIPTION
closes #831

ブランチ一覧の読込を遅延するようにし、エラーハンドリングを追加した
エラーメッセージが少しかっこ悪いかも?

![ns-branches-loading](https://github.com/traPtitech/NeoShowcase/assets/59188998/565b650f-10e7-45f3-9f48-db3db22561f5)
