### PR TITLE
CacheInterceptor: panicするのを修正

### DIFF
--- a/pkg/infrastructure/grpc/cache_interceptor.go
+++ b/pkg/infrastructure/grpc/cache_interceptor.go
@@ -30,6 +30,9 @@ func (c *CacheInterceptor) hash(resp connect.AnyResponse) (string, bool) {
 func (c *CacheInterceptor) WrapUnary(unaryFunc connect.UnaryFunc) connect.UnaryFunc {
 	return func(ctx context.Context, request connect.AnyRequest) (connect.AnyResponse, error) {
 		resp, err := unaryFunc(ctx, request)
+		if err != nil {
+			return resp, err
+		}
 		if request.HTTPMethod() == http.MethodGet {
 			// Calculate hash and set etag
 			respHash, ok := c.hash(resp)


### PR DESCRIPTION
## なぜやるか
`err != nil` の時 (`resp == nil` の時) にhashを計算しようとするとpanicする
panicするとerrの内容にかかわらず 500 Internal Server Error になってしまう

## やったこと
err をチェックする

## やらなかったこと

## 資料
