### PR TITLE
fix too strict path traversal check

### DIFF
--- a/pkg/domain/app_website.go
+++ b/pkg/domain/app_website.go
@@ -184,10 +184,7 @@ func (w *Website) pathComponents() []string {
 func (w *Website) pathContainedBy(target *Website) bool {
 	this := w.pathComponents()
 	other := target.pathComponents()
-	if len(this) < len(other) {
-		return false
-	}
-	return ds.Equals(this[:len(other)], other)
+	return ds.HasPrefix(this, other)
 }
 
 func (w *Website) Equals(target *Website) bool {

--- a/pkg/util/ds/slice.go
+++ b/pkg/util/ds/slice.go
@@ -59,6 +59,13 @@ func Equals[T comparable](s, t []T) bool {
 	return true
 }
 
+func HasPrefix[T comparable](s, prefix []T) bool {
+	if len(s) < len(prefix) {
+		return false
+	}
+	return Equals(s[:len(prefix)], prefix)
+}
+
 func FirstN[T any](s []T, n int) []T {
 	if len(s) < n {
 		return s

--- a/pkg/util/ds/slice_test.go
+++ b/pkg/util/ds/slice_test.go
@@ -1,0 +1,58 @@
+package ds
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestHasPrefix(t *testing.T) {
+	type testCase[T comparable] struct {
+		name   string
+		s      []T
+		prefix []T
+		want   bool
+	}
+	tests := []testCase[string]{
+		{
+			name:   "empty",
+			s:      []string{},
+			prefix: []string{},
+			want:   true,
+		},
+		{
+			name:   "has prefix (same length)",
+			s:      []string{"a"},
+			prefix: []string{"a"},
+			want:   true,
+		},
+		{
+			name:   "has prefix (different length)",
+			s:      []string{"a", "b"},
+			prefix: []string{"a"},
+			want:   true,
+		},
+		{
+			name:   "has no prefix (same length)",
+			s:      []string{"b"},
+			prefix: []string{"a"},
+			want:   false,
+		},
+		{
+			name:   "has no prefix (shorter length)",
+			s:      []string{"a"},
+			prefix: []string{"a", "b"},
+			want:   false,
+		},
+		{
+			name:   "has no prefix (longer length)",
+			s:      []string{"b", "a"},
+			prefix: []string{"a"},
+			want:   false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, HasPrefix(tt.s, tt.prefix), "HasPrefix(%v, %v)", tt.s, tt.prefix)
+		})
+	}
+}

--- a/pkg/util/tarfs/extract_test.go
+++ b/pkg/util/tarfs/extract_test.go
@@ -1,0 +1,64 @@
+package tarfs
+
+import "testing"
+
+func Test_isValidRelPath(t *testing.T) {
+	tests := []struct {
+		name    string
+		relPath string
+		want    bool
+	}{
+		{
+			name:    "valid 1",
+			relPath: "./",
+			want:    true,
+		},
+		{
+			name:    "valid 2",
+			relPath: "./foo/bar",
+			want:    true,
+		},
+		{
+			name:    "valid 3",
+			relPath: ".",
+			want:    true,
+		},
+		{
+			name:    "valid 4",
+			relPath: "./node_modules/some-module/test/../link.js",
+			want:    true,
+		},
+		{
+			name:    "valid 5",
+			relPath: "./[...weird-name].txt",
+			want:    true,
+		},
+		{
+			name:    "valid 6",
+			relPath: "./weird../name",
+			want:    true,
+		},
+		{
+			name:    "invalid 1",
+			relPath: "../",
+			want:    false,
+		},
+		{
+			name:    "invalid 2 (same name prefix)",
+			relPath: "../pathprefixed",
+			want:    false,
+		},
+		{
+			name:    "invalid 3",
+			relPath: "./test/../../foo",
+			want:    false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isValidRelPath(tt.relPath); got != tt.want {
+				t.Errorf("isValidRelPath() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
> [ns-builder] Build failed: copying files to container: unknown: invalid path pages/[...slug].vue

のような形のファイルが間違って弾かれてしまう