### PR TITLE
部員認証のラジオボタン切り替え時エラーの修正

### DIFF
--- a/dashboard/src/components/templates/app/WebsiteSettings.tsx
+++ b/dashboard/src/components/templates/app/WebsiteSettings.tsx
@@ -365,8 +365,15 @@ export const WebsiteSetting = (props: WebsiteSettingProps) => {
               </WarningsContainer>
             </Show>
           </FormItem>
-          <Field of={props.formStore} name={'website.authentication'} type="number">
-            {(field) => (
+          {/* website.authenticationがnumberであるため型としてはtype="number"の指定が正しいが、numberを指定すると入力時のonInput内でinput.valueAsNumberが使用される。すると、RadioGroup内で使用されているinput要素はtype="number"等が指定されていない(kobalteのRadioGroupではもともと文字列のみが扱える)ため、valueAsNumberでの取得結果がNaNになってしまい正しくsetValueできない。そのためtype="string"を指定してinput.valueが使用されるようにしています */}
+          {/* see: https://github.com/traPtitech/NeoShowcase/pull/878#issuecomment-1953994009 */}
+          <Field
+            of={props.formStore}
+            name={'website.authentication'}
+            // @ts-expect-error
+            type="string"
+          >
+            {(field, fieldProps) => (
               <RadioGroup<`${AuthenticationType}`>
                 label="部員認証"
                 info={{
@@ -381,6 +388,7 @@ export const WebsiteSetting = (props: WebsiteSettingProps) => {
                     ),
                   },
                 }}
+                {...fieldProps}
                 tooltip={{
                   props: {
                     content: `${getValue(props.formStore, 'website.domain')}では部員認証が使用できません`,

--- a/dashboard/src/components/templates/app/WebsiteSettings.tsx
+++ b/dashboard/src/components/templates/app/WebsiteSettings.tsx
@@ -366,7 +366,7 @@ export const WebsiteSetting = (props: WebsiteSettingProps) => {
             </Show>
           </FormItem>
           <Field of={props.formStore} name={'website.authentication'} type="number">
-            {(field, fieldProps) => (
+            {(field) => (
               <RadioGroup<`${AuthenticationType}`>
                 label="部員認証"
                 info={{
@@ -387,7 +387,6 @@ export const WebsiteSetting = (props: WebsiteSettingProps) => {
                   },
                   disabled: getValue(props.formStore, 'website.authAvailable') && props.hasPermission,
                 }}
-                {...fieldProps}
                 options={authenticationTypeOptions}
                 value={`${field.value ?? AuthenticationType.OFF}`}
                 setValue={(value) => {

--- a/dashboard/src/components/templates/app/WebsiteSettings.tsx
+++ b/dashboard/src/components/templates/app/WebsiteSettings.tsx
@@ -372,6 +372,10 @@ export const WebsiteSetting = (props: WebsiteSettingProps) => {
             name={'website.authentication'}
             // @ts-expect-error
             type="string"
+            transform={(v) => {
+              if (v === undefined) return AuthenticationType.OFF
+              return authenticationTypeOptionsMap[v]
+            }}
           >
             {(field, fieldProps) => (
               <RadioGroup<`${AuthenticationType}`>
@@ -397,9 +401,6 @@ export const WebsiteSetting = (props: WebsiteSettingProps) => {
                 }}
                 options={authenticationTypeOptions}
                 value={`${field.value ?? AuthenticationType.OFF}`}
-                setValue={(value) => {
-                  setValue(props.formStore, 'website.authentication', authenticationTypeOptionsMap[value])
-                }}
                 disabled={!getValue(props.formStore, 'website.authAvailable')}
                 readOnly={!props.hasPermission}
               />


### PR DESCRIPTION
## なぜやるか

closes #875

## やったこと

部員認証方法選択ではラジオボタンコンポーネントが使用されている。
このラジオボタンコンポーネント自体はstring型の入力にしか対応していないため、enum(=number)で表されていたAuthenticationTypeを扱えるようにするため、認証方法変更時に変換処理を挟んでいる。
しかし、modular formsによって自動生成されるonChange関数なども一緒に設定されてしまっていたために、modular forms側での変換処理も実施されてしまい、設定値がNaNになってしまっていた。

modular fomrsによって自動作成されるcallback関数を削除することで、正しく動作するよう修正した。
