### PR TITLE
環境変数設定時にdeadlockするのを修正

### DIFF
--- a/pkg/infrastructure/repository/environment.go
+++ b/pkg/infrastructure/repository/environment.go
@@ -44,17 +44,13 @@ func (r *environmentRepository) GetEnv(ctx context.Context, cond domain.GetEnvCo
 	return ds.Map(environments, repoconvert.ToDomainEnvironment), nil
 }
 
-func (r *environmentRepository) SetEnv(ctx context.Context, env *domain.Environment) (err error) {
+func (r *environmentRepository) SetEnv(ctx context.Context, env *domain.Environment) error {
 	// NOTE: sqlboiler does not recognize multiple column unique keys: https://github.com/volatiletech/sqlboiler/issues/328
 	tx, err := r.db.BeginTx(ctx, nil)
 	if err != nil {
 		return errors.Wrap(err, "failed to start transaction")
 	}
-	defer func() {
-		if err != nil {
-			tx.Rollback()
-		}
-	}()
+	defer tx.Rollback()
 
 	_, err = models.Applications(
 		qm.Select(models.ApplicationColumns.ID),


### PR DESCRIPTION
## なぜやるか
環境変数を一度に複数設定するとdeadlockする
![deadlock-sample](https://github.com/traPtitech/NeoShowcase/assets/130675136/d5ccea24-ff6a-46b2-8763-f41394a9bf12)
何回か `Save` を押せば一応ちゃんと保存される

## やったこと
application テーブルでロックをとるようにした

## 資料
https://zenn.dev/shuntagami/articles/ea44a20911b817
