### PR TITLE
fix typo

### DIFF
--- a/.local-dev/config/ns-auth.ini
+++ b/.local-dev/config/ns-auth.ini
@@ -8,7 +8,7 @@ auth-host = auth.local.trapti.tech
 cookie-domain = local.trapti.tech
 
 default-provider = generic-oauth
-header-name = X-Showcase-User
+header-names = X-Showcase-User
 user-id-path = name
 
 providers.generic-oauth.auth-url = https://q.toki317.dev/api/v3/oauth2/authorize


### PR DESCRIPTION
オプションの名前がちょっと違ってた

[https://github.com/traPtitech/traefik-forward-auth](https://github.com/traPtitech/traefik-forward-auth?tab=readme-ov-file#overview:~:text=multiple%20times%20%5B%24DOMAIN%5D%0A%20%20%20%20%20%20%2D%2D-,header%2Dnames,-%3D%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20User%20header%20names)