### PR TITLE
Chores/dashboard

### DIFF
--- a/dashboard/src/components/templates/app/AppBranchResolution.tsx
+++ b/dashboard/src/components/templates/app/AppBranchResolution.tsx
@@ -89,7 +89,7 @@ const AppBranchResolution: Component<{
             {c.authorName}
             <span>, </span>
             <ToolTip props={{ content: localeString }}>
-              <span>{diff}</span>
+              <span>{diff()}</span>
             </ToolTip>
             <span>, </span>
             {shortSha(c.hash)}

--- a/dashboard/src/components/templates/app/AppBranchResolution.tsx
+++ b/dashboard/src/components/templates/app/AppBranchResolution.tsx
@@ -78,7 +78,8 @@ const AppBranchResolution: Component<{
       return base
     }
 
-    const { diff, localeString } = diffHuman(c.commitDate.toDate())
+    const diff = diffHuman(c.commitDate.toDate())
+    const localeString = c.commitDate.toDate().toLocaleString()
     return (
       <DataRows>
         {base}

--- a/dashboard/src/components/templates/app/AppDeployInfo.tsx
+++ b/dashboard/src/components/templates/app/AppDeployInfo.tsx
@@ -200,7 +200,7 @@ const AppDeployInfo: Component<{
     }
 
     const firstLine = c.message.split('\n')[0]
-    const { diff } = diffHuman(c.commitDate.toDate())
+    const diff = diffHuman(c.commitDate.toDate())
     const tooltip = (
       <DataRows>
         <For each={c.message.split('\n')}>{(line) => <div>{line}</div>}</For>

--- a/dashboard/src/components/templates/app/AppDeployInfo.tsx
+++ b/dashboard/src/components/templates/app/AppDeployInfo.tsx
@@ -205,7 +205,7 @@ const AppDeployInfo: Component<{
       <DataRows>
         <For each={c.message.split('\n')}>{(line) => <div>{line}</div>}</For>
         <div>
-          {c.authorName}, {diff}, {shortSha(c.hash)}
+          {c.authorName}, {diff()}, {shortSha(c.hash)}
         </div>
       </DataRows>
     )

--- a/dashboard/src/components/templates/app/AppNav.tsx
+++ b/dashboard/src/components/templates/app/AppNav.tsx
@@ -79,7 +79,7 @@ export const AppNav: Component<{
           const localeString = nonNullUpdatedAt().toDate().toLocaleString()
           return (
             <ToolTip props={{ content: `App Last Edited: ${localeString}` }}>
-              <div>{diff}</div>
+              <div>{diff()}</div>
             </ToolTip>
           )
         }}

--- a/dashboard/src/components/templates/app/AppNav.tsx
+++ b/dashboard/src/components/templates/app/AppNav.tsx
@@ -75,7 +75,8 @@ export const AppNav: Component<{
       <BiRegularPencil />
       <Show when={props.app.updatedAt}>
         {(nonNullUpdatedAt) => {
-          const { diff, localeString } = diffHuman(nonNullUpdatedAt().toDate())
+          const diff = diffHuman(nonNullUpdatedAt().toDate())
+          const localeString = nonNullUpdatedAt().toDate().toLocaleString()
           return (
             <ToolTip props={{ content: `App Last Edited: ${localeString}` }}>
               <div>{diff}</div>

--- a/dashboard/src/components/templates/app/AppRow.tsx
+++ b/dashboard/src/components/templates/app/AppRow.tsx
@@ -143,7 +143,7 @@ export const AppRow: Component<Props> = (props) => {
   const commitTooltip = () => {
     const c = commit()
     if (!c || !c.commitDate) return `${shortSha(props.app!.commit)}`
-    const { diff } = diffHuman(c.commitDate.toDate())
+    const diff = diffHuman(c.commitDate.toDate())
     return (
       <>
         <For each={c.message.split('\n')}>{(line) => <div>{line}</div>}</For>
@@ -163,7 +163,8 @@ export const AppRow: Component<Props> = (props) => {
             <AppName>{props.app!.name}</AppName>
             <Show when={props.app!.updatedAt}>
               {(nonNullUpdatedAt) => {
-                const { diff, localeString } = diffHuman(nonNullUpdatedAt().toDate())
+                const diff = diffHuman(nonNullUpdatedAt().toDate())
+                const localeString = nonNullUpdatedAt().toDate().toLocaleString()
                 return (
                   <ToolTip props={{ content: localeString }}>
                     <UpdatedAt>{diff}</UpdatedAt>

--- a/dashboard/src/components/templates/app/AppRow.tsx
+++ b/dashboard/src/components/templates/app/AppRow.tsx
@@ -148,7 +148,7 @@ export const AppRow: Component<Props> = (props) => {
       <>
         <For each={c.message.split('\n')}>{(line) => <div>{line}</div>}</For>
         <div>
-          {c.authorName}, {diff}, {shortSha(c.hash)}
+          {c.authorName}, {diff()}, {shortSha(c.hash)}
         </div>
       </>
     )
@@ -167,7 +167,7 @@ export const AppRow: Component<Props> = (props) => {
                 const localeString = nonNullUpdatedAt().toDate().toLocaleString()
                 return (
                   <ToolTip props={{ content: localeString }}>
-                    <UpdatedAt>{diff}</UpdatedAt>
+                    <UpdatedAt>{diff()}</UpdatedAt>
                   </ToolTip>
                 )
               }}

--- a/dashboard/src/components/templates/build/BuildRow.tsx
+++ b/dashboard/src/components/templates/build/BuildRow.tsx
@@ -112,7 +112,8 @@ export const BuildRow: Component<Props> = (props) => {
   const commitDetails = () => {
     const c = commit()
     if (!c || !c.commitDate) return '<no info>'
-    const { diff, localeString } = diffHuman(c.commitDate.toDate())
+    const diff = diffHuman(c.commitDate.toDate())
+    const localeString = c.commitDate.toDate().toLocaleString()
     return (
       <>
         {c.authorName}
@@ -140,7 +141,8 @@ export const BuildRow: Component<Props> = (props) => {
           <Spacer />
           <Show when={props.build.queuedAt}>
             {(nonNullQueuedAt) => {
-              const { diff, localeString } = diffHuman(nonNullQueuedAt().toDate())
+              const diff = diffHuman(nonNullQueuedAt().toDate())
+              const localeString = nonNullQueuedAt().toDate().toString()
               return (
                 <ToolTip props={{ content: localeString }}>
                   <UpdatedAt>{diff}</UpdatedAt>

--- a/dashboard/src/components/templates/build/BuildRow.tsx
+++ b/dashboard/src/components/templates/build/BuildRow.tsx
@@ -119,7 +119,7 @@ export const BuildRow: Component<Props> = (props) => {
         {c.authorName}
         <span>, </span>
         <ToolTip props={{ content: localeString }}>
-          <span>{diff}</span>
+          <span>{diff()}</span>
         </ToolTip>
         <span>, </span>
         {shortSha(c.hash)}
@@ -145,7 +145,7 @@ export const BuildRow: Component<Props> = (props) => {
               const localeString = nonNullQueuedAt().toDate().toString()
               return (
                 <ToolTip props={{ content: localeString }}>
-                  <UpdatedAt>{diff}</UpdatedAt>
+                  <UpdatedAt>{diff()}</UpdatedAt>
                 </ToolTip>
               )
             }}

--- a/dashboard/src/components/templates/build/BuildStatusTable.tsx
+++ b/dashboard/src/components/templates/build/BuildStatusTable.tsx
@@ -111,7 +111,7 @@ const BuildStatusTable: Component<{
           {c.authorName}
           <span>, </span>
           <ToolTip props={{ content: localeString }}>
-            <span>{diff}</span>
+            <span>{diff()}</span>
           </ToolTip>
           <span>, </span>
           {shortSha(c.hash)}
@@ -163,7 +163,7 @@ const BuildStatusTable: Component<{
                 <List.RowContent>
                   <List.RowTitle>キュー登録時刻</List.RowTitle>
                   <ToolTip props={{ content: localeString }}>
-                    <List.RowData>{diff}</List.RowData>
+                    <List.RowData>{diff()}</List.RowData>
                   </ToolTip>
                 </List.RowContent>
               </List.Row>
@@ -180,7 +180,7 @@ const BuildStatusTable: Component<{
                 <List.RowContent>
                   <List.RowTitle>ビルド開始時刻</List.RowTitle>
                   <ToolTip props={{ content: localeString }}>
-                    <List.RowData>{diff}</List.RowData>
+                    <List.RowData>{diff()}</List.RowData>
                   </ToolTip>
                 </List.RowContent>
               </List.Row>
@@ -199,7 +199,7 @@ const BuildStatusTable: Component<{
                 const localeString = ts.toLocaleString()
                 return (
                   <ToolTip props={{ content: localeString }}>
-                    <List.RowData>{diff}</List.RowData>
+                    <List.RowData>{diff()}</List.RowData>
                   </ToolTip>
                 )
               }}

--- a/dashboard/src/components/templates/build/BuildStatusTable.tsx
+++ b/dashboard/src/components/templates/build/BuildStatusTable.tsx
@@ -102,7 +102,8 @@ const BuildStatusTable: Component<{
       return shortSha(props.build.commit)
     }
 
-    const { diff, localeString } = diffHuman(c.commitDate.toDate())
+    const diff = diffHuman(c.commitDate.toDate())
+    const localeString = c.commitDate.toDate().toLocaleString()
     return (
       <DataRows>
         <For each={c.message.split('\n')}>{(line) => <div>{line}</div>}</For>
@@ -155,7 +156,8 @@ const BuildStatusTable: Component<{
       <List.Columns>
         <Show when={props.build.queuedAt}>
           {(nonNullQueuedAt) => {
-            const { diff, localeString } = diffHuman(nonNullQueuedAt().toDate())
+            const diff = diffHuman(nonNullQueuedAt().toDate())
+            const localeString = nonNullQueuedAt().toDate().toLocaleString()
             return (
               <List.Row>
                 <List.RowContent>
@@ -170,7 +172,9 @@ const BuildStatusTable: Component<{
         </Show>
         <Show when={props.build.startedAt?.valid && props.build.startedAt} fallback={'-'}>
           {(nonNullStartedAt) => {
-            const { diff, localeString } = diffHuman((nonNullStartedAt().timestamp as Timestamp).toDate())
+            const ts = (nonNullStartedAt().timestamp as Timestamp).toDate()
+            const diff = diffHuman(ts)
+            const localeString = ts.toLocaleString()
             return (
               <List.Row>
                 <List.RowContent>
@@ -190,7 +194,9 @@ const BuildStatusTable: Component<{
             <List.RowTitle>ビルド終了時刻</List.RowTitle>
             <Show when={props.build.finishedAt?.valid && props.build.finishedAt} fallback={'-'}>
               {(nonNullFinishedAt) => {
-                const { diff, localeString } = diffHuman((nonNullFinishedAt().timestamp as Timestamp).toDate())
+                const ts = (nonNullFinishedAt().timestamp as Timestamp).toDate()
+                const diff = diffHuman(ts)
+                const localeString = ts.toLocaleString()
                 return (
                   <ToolTip props={{ content: localeString }}>
                     <List.RowData>{diff}</List.RowData>

--- a/dashboard/src/libs/format.tsx
+++ b/dashboard/src/libs/format.tsx
@@ -1,4 +1,5 @@
 import type { Timestamp } from '@bufbuild/protobuf'
+import { createSignal } from 'solid-js'
 
 export const shortSha = (sha1: string): string => sha1.substring(0, 7)
 
@@ -52,13 +53,13 @@ export const durationHuman = (millis: number): string => {
   return `${remainMillis} ms`
 }
 
-export const diffHuman = (target: Date) => {
-  const diff = new Date().getTime() - target.getTime()
+// const [now, setNow] = createSignal(new Date())
+// setInterval(() => setNow(new Date()), 1000)
+const now = () => new Date()
+
+export const diffHuman = (target: Date): string => {
+  const diff = now().getTime() - target.getTime()
   const suffix = diff > 0 ? 'ago' : 'from now'
   const human = durationHuman(Math.abs(diff))
-  const localeString = target.toLocaleString()
-  return {
-    diff: `${human} ${suffix}`,
-    localeString,
-  }
+  return `${human} ${suffix}`
 }

--- a/dashboard/src/libs/format.tsx
+++ b/dashboard/src/libs/format.tsx
@@ -53,13 +53,14 @@ export const durationHuman = (millis: number): string => {
   return `${remainMillis} ms`
 }
 
-// const [now, setNow] = createSignal(new Date())
-// setInterval(() => setNow(new Date()), 1000)
-const now = () => new Date()
+const [now, setNow] = createSignal(new Date())
+setInterval(() => setNow(new Date()), 10000)
 
-export const diffHuman = (target: Date): string => {
-  const diff = now().getTime() - target.getTime()
-  const suffix = diff > 0 ? 'ago' : 'from now'
-  const human = durationHuman(Math.abs(diff))
-  return `${human} ${suffix}`
+export const diffHuman = (target: Date): () => string => {
+  return () => {
+    const diff = now().getTime() - target.getTime()
+    const suffix = diff > 0 ? 'ago' : 'from now'
+    const human = durationHuman(Math.abs(diff))
+    return `${human} ${suffix}`
+  }
 }

--- a/dashboard/src/libs/format.tsx
+++ b/dashboard/src/libs/format.tsx
@@ -56,7 +56,7 @@ export const durationHuman = (millis: number): string => {
 const [now, setNow] = createSignal(new Date())
 setInterval(() => setNow(new Date()), 10000)
 
-export const diffHuman = (target: Date): () => string => {
+export const diffHuman = (target: Date): (() => string) => {
   return () => {
     const diff = now().getTime() - target.getTime()
     const suffix = diff > 0 ? 'ago' : 'from now'

--- a/dashboard/src/pages/apps/[id]/builds.tsx
+++ b/dashboard/src/pages/apps/[id]/builds.tsx
@@ -1,4 +1,4 @@
-import { createMemo, useTransition } from 'solid-js'
+import { createMemo, onCleanup, useTransition } from 'solid-js'
 import { Show } from 'solid-js'
 import { MaterialSymbols } from '/@/components/UI/MaterialSymbols'
 import { DataTable } from '/@/components/layouts/DataTable'
@@ -8,8 +8,11 @@ import { BuildList, List } from '/@/components/templates/List'
 import { useApplicationData } from '/@/routes'
 
 export default () => {
-  const { app, builds, commits } = useApplicationData()
+  const { app, builds, commits, refetch } = useApplicationData()
   const loaded = () => !!(app() && builds())
+
+  const refetchTimer = setInterval(refetch, 10000)
+  onCleanup(() => clearInterval(refetchTimer))
 
   const sortedBuilds = createMemo(
     () =>

--- a/dashboard/src/pages/apps/[id]/settings.tsx
+++ b/dashboard/src/pages/apps/[id]/settings.tsx
@@ -1,6 +1,6 @@
 import { styled } from '@macaron-css/solid'
 import { type RouteSectionProps, useMatch, useNavigate } from '@solidjs/router'
-import { ErrorBoundary, Show, Suspense, useTransition } from 'solid-js'
+import { ErrorBoundary, onCleanup, Show, Suspense, useTransition } from 'solid-js'
 import { Button } from '/@/components/UI/Button'
 import { MaterialSymbols } from '/@/components/UI/MaterialSymbols'
 import ErrorView from '/@/components/layouts/ErrorView'
@@ -21,8 +21,12 @@ const SideMenu = styled('div', {
 })
 
 export default (props: RouteSectionProps) => {
-  const { app } = useApplicationData()
+  const { app, refetch } = useApplicationData()
   const loaded = () => !!app()
+
+  const refetchTimer = setInterval(refetch, 10000)
+  onCleanup(() => clearInterval(refetchTimer))
+
   const matchGeneralPage = useMatch(() => `/apps/${app()?.id}/settings/`)
   const matchBuildPage = useMatch(() => `/apps/${app()?.id}/settings/build`)
   const matchURLsPage = useMatch(() => `/apps/${app()?.id}/settings/urls`)

--- a/dashboard/src/pages/apps/[id]/settings.tsx
+++ b/dashboard/src/pages/apps/[id]/settings.tsx
@@ -1,6 +1,6 @@
 import { styled } from '@macaron-css/solid'
 import { type RouteSectionProps, useMatch, useNavigate } from '@solidjs/router'
-import { ErrorBoundary, onCleanup, Show, Suspense, useTransition } from 'solid-js'
+import { ErrorBoundary, Show, Suspense, onCleanup, useTransition } from 'solid-js'
 import { Button } from '/@/components/UI/Button'
 import { MaterialSymbols } from '/@/components/UI/MaterialSymbols'
 import ErrorView from '/@/components/layouts/ErrorView'

--- a/dashboard/src/pages/apps/[id]/settings/build.tsx
+++ b/dashboard/src/pages/apps/[id]/settings/build.tsx
@@ -46,6 +46,8 @@ export default () => {
       })
       toast.success('ビルド設定を更新しました')
       void refetch()
+      // 非同期でビルドが開始されるので1秒程度待ってから再度リロード
+      setTimeout(refetch, 1000)
     } catch (e) {
       handleAPIError(e, 'ビルド設定の更新に失敗しました')
     }

--- a/dashboard/src/pages/apps/[id]/settings/general.tsx
+++ b/dashboard/src/pages/apps/[id]/settings/general.tsx
@@ -33,7 +33,7 @@ const GeneralInfo: Component<{
               <List.RowContent>
                 <List.RowTitle>作成日</List.RowTitle>
                 <ToolTip props={{ content: localeString }}>
-                  <List.RowData>{diff}</List.RowData>
+                  <List.RowData>{diff()}</List.RowData>
                 </ToolTip>
               </List.RowContent>
             </List.Row>

--- a/dashboard/src/pages/apps/[id]/settings/general.tsx
+++ b/dashboard/src/pages/apps/[id]/settings/general.tsx
@@ -26,7 +26,8 @@ const GeneralInfo: Component<{
     <List.Container>
       <Show when={props.app.createdAt}>
         {(nonNullCreatedAt) => {
-          const { diff, localeString } = diffHuman(nonNullCreatedAt().toDate())
+          const diff = diffHuman(nonNullCreatedAt().toDate())
+          const localeString = nonNullCreatedAt().toDate().toLocaleString()
           return (
             <List.Row>
               <List.RowContent>

--- a/dashboard/src/pages/apps/[id]/settings/general.tsx
+++ b/dashboard/src/pages/apps/[id]/settings/general.tsx
@@ -150,6 +150,8 @@ export default () => {
       })
       toast.success('アプリケーション設定を更新しました')
       void refetch()
+      // 非同期でビルドが開始されるので1秒程度待ってから再度リロード
+      setTimeout(refetch, 1000)
     } catch (e) {
       handleAPIError(e, 'アプリケーション設定の更新に失敗しました')
     }


### PR DESCRIPTION
- 相対日付表示をタイマーで更新
- アプリページで10秒ごとにデータを更新
- アプリの設定を更新した後にデータを更新
