### PR TITLE
performance(backend): Add traefik rule priority offset

### DIFF
--- a/.local-dev/config/ns.yaml
+++ b/.local-dev/config/ns.yaml
@@ -71,6 +71,10 @@ components:
       ss:
         url: http://static-server:80/
 
+      routing:
+        type: traefik
+        traefik:
+          priorityOffset: 0
       tls:
         certResolver: nsresolver
         wildcard:
@@ -118,6 +122,10 @@ components:
         port: 80
         scheme: http
 
+      routing:
+        type: traefik
+        traefik:
+          priorityOffset: 0
       tls:
         type: traefik
         traefik:

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -164,6 +164,8 @@ func init() {
 	viper.SetDefault("components.controller.docker.ports", nil)
 
 	viper.SetDefault("components.controller.docker.ss.url", "")
+	viper.SetDefault("components.controller.docker.routing.type", "traefik")
+	viper.SetDefault("components.controller.docker.routing.traefik.priorityOffset", 0)
 	viper.SetDefault("components.controller.docker.tls.certResolver", "nsresolver")
 	viper.SetDefault("components.controller.docker.tls.wildcard.domains", nil)
 
@@ -183,6 +185,8 @@ func init() {
 	viper.SetDefault("components.controller.k8s.ss.port", 80)
 	viper.SetDefault("components.controller.k8s.ss.scheme", "http")
 
+	viper.SetDefault("components.controller.k8s.routing.type", "traefik")
+	viper.SetDefault("components.controller.k8s.routing.traefik.priorityOffset", 0)
 	viper.SetDefault("components.controller.k8s.tls.type", "traefik")
 	viper.SetDefault("components.controller.k8s.tls.traefik.certResolver", "nsresolver")
 	viper.SetDefault("components.controller.k8s.tls.traefik.wildcard.domains", nil)

--- a/pkg/infrastructure/backend/dockerimpl/backend_test.go
+++ b/pkg/infrastructure/backend/dockerimpl/backend_test.go
@@ -26,10 +26,11 @@ func prepareManager(t *testing.T) (*Backend, *client.Client) {
 		t.Fatal(err)
 	}
 
-	m, err := NewDockerBackend(c, Config{
-		ConfDir: "../../../../.local-dev/traefik",
-		Network: "neoshowcase_apps",
-	}, builder.ImageConfig{})
+	config := Config{}
+	config.ConfDir = "../../../../.local-dev/traefik"
+	config.Network = "neoshowcase_apps"
+	config.Routing.Type = routingTypeTraefik
+	m, err := NewDockerBackend(c, config, builder.ImageConfig{})
 	require.NoError(t, err)
 	err = m.Start(context.Background())
 	require.NoError(t, err)

--- a/pkg/infrastructure/backend/dockerimpl/config.go
+++ b/pkg/infrastructure/backend/dockerimpl/config.go
@@ -1,6 +1,7 @@
 package dockerimpl
 
 import (
+	"fmt"
 	"math"
 
 	"github.com/friendsofgo/errors"
@@ -8,6 +9,10 @@ import (
 
 	"github.com/traPtitech/neoshowcase/pkg/domain"
 	"github.com/traPtitech/neoshowcase/pkg/util/mapper"
+)
+
+const (
+	routingTypeTraefik = "traefik"
 )
 
 type domainAuthConf = struct {
@@ -67,6 +72,18 @@ type Config struct {
 		URL string `mapstructure:"url" yaml:"url"`
 	} `mapstructure:"ss" yaml:"ss"`
 
+	// Routing section defines ingress settings.
+	Routing struct {
+		// Type defines which ingress controller to use.
+		// Possible values:
+		// 	"traefik: Uses traefik ingress controller.
+		Type    string `mapstructure:"type" yaml:"type"`
+		Traefik struct {
+			// PriorityOffset defines HTTP routes' priority offset for user apps.
+			// This is optionally used to optimize routing performance.
+			PriorityOffset int `mapstructure:"priorityOffset" yaml:"priorityOffset"`
+		} `mapstructure:"traefik" yaml:"traefik"`
+	} `mapstructure:"routing" yaml:"routing"`
 	// TLS section defines tls setting for user app ingress.
 	TLS struct {
 		CertResolver string `mapstructure:"certResolver" yaml:"certResolver"`
@@ -107,6 +124,12 @@ func (c *Config) Validate() error {
 		}
 	}
 
+	switch c.Routing.Type {
+	case routingTypeTraefik:
+		// Nothing to validate as of now
+	default:
+		return errors.New(fmt.Sprintf("docker.routing.type is invalid: %s", c.Routing.Type))
+	}
 	if err := c.TLS.Wildcard.Domains.Validate(); err != nil {
 		return errors.Wrap(err, "docker.tls.wildcard.domains is invalid")
 	}

--- a/pkg/infrastructure/backend/dockerimpl/ingress.go
+++ b/pkg/infrastructure/backend/dockerimpl/ingress.go
@@ -58,10 +58,14 @@ func (b *Backend) routerBase(website *domain.Website, svcName string) (router m,
 		}
 	}
 
+	priorityOffset := b.config.Routing.Traefik.PriorityOffset
+	priority := len(rule) + priorityOffset
+
 	router = m{
 		"entrypoints": entrypoints,
 		"middlewares": middlewareNames,
 		"rule":        rule,
+		"priority":    priority,
 		"service":     svcName,
 	}
 

--- a/pkg/infrastructure/backend/k8simpl/backend_test.go
+++ b/pkg/infrastructure/backend/k8simpl/backend_test.go
@@ -59,6 +59,7 @@ func prepareManager(t *testing.T) (*Backend, *kubernetes.Clientset, *traefikv1al
 
 	var config Config
 	config.Namespace = appsNamespace
+	config.Routing.Type = routingTypeTraefik
 	config.TLS.Type = tlsTypeTraefik
 	b, err := NewK8SBackend(kubeconf, client, traefikClient, certManagerClient, config)
 	require.NoError(t, err)

--- a/pkg/infrastructure/backend/k8simpl/config.go
+++ b/pkg/infrastructure/backend/k8simpl/config.go
@@ -1,6 +1,7 @@
 package k8simpl
 
 import (
+	"fmt"
 	"strconv"
 
 	"github.com/friendsofgo/errors"
@@ -17,6 +18,8 @@ import (
 )
 
 const (
+	routingTypeTraefik = "traefik"
+
 	tlsTypeTraefik     = "traefik"
 	tlsTypeCertManager = "cert-manager"
 
@@ -166,6 +169,18 @@ type Config struct {
 		Scheme    string `mapstructure:"scheme" yaml:"scheme"`
 	} `mapstructure:"ss" yaml:"ss"`
 
+	// Routing section defines ingress controller settings.
+	Routing struct {
+		// Type defines which ingress controller to use.
+		// Possible values:
+		// 	"traefik: Uses traefik ingress controller.
+		Type    string `mapstructure:"type" yaml:"type"`
+		Traefik struct {
+			// PriorityOffset defines HTTP routes' priority offset for user apps.
+			// This is optionally used to optimize routing performance.
+			PriorityOffset int `mapstructure:"priorityOffset" yaml:"priorityOffset"`
+		} `mapstructure:"traefik" yaml:"traefik"`
+	} `mapstructure:"routing" yaml:"routing"`
 	// TLS section defines tls setting for user app ingress.
 	TLS struct {
 		// Type defines which provider is responsible for obtaining http certificates.
@@ -326,6 +341,12 @@ func (c *Config) Validate() error {
 		}
 	}
 
+	switch c.Routing.Type {
+	case routingTypeTraefik:
+		// Nothing to validate as of now
+	default:
+		return errors.New(fmt.Sprintf("k8s.routing.type is invalid: %s", c.Routing.Type))
+	}
 	switch c.TLS.Type {
 	case tlsTypeTraefik:
 		if err := c.TLS.Traefik.Wildcard.Domains.Validate(); err != nil {

--- a/pkg/infrastructure/backend/k8simpl/ingress.go
+++ b/pkg/infrastructure/backend/k8simpl/ingress.go
@@ -107,6 +107,11 @@ func (b *Backend) ingressRoute(
 			middlewareRefs = append(middlewareRefs, traefikv1alpha1.MiddlewareRef{Name: middleware.Name})
 		}
 	}
+	var rulePriority int
+	{
+		priorityOffset := b.config.Routing.Traefik.PriorityOffset
+		rulePriority = len(rule) + priorityOffset
+	}
 
 	var tls *traefikv1alpha1.TLS
 	var certs []*certmanagerv1.Certificate
@@ -141,6 +146,7 @@ func (b *Backend) ingressRoute(
 			EntryPoints: entrypoints,
 			Routes: []traefikv1alpha1.Route{{
 				Match:       rule,
+				Priority:    rulePriority,
 				Kind:        "Rule",
 				Services:    serviceRefs,
 				Middlewares: middlewareRefs,


### PR DESCRIPTION
## なぜやるか
https://github.com/traefik/traefik/blob/e9bd2b45ac2bb1983fdee27d4efd76c450dfa338/pkg/muxer/http/mux.go#L53

traefik は priority が高いルートから検証していくため、大量にルートがあるとパフォーマンスが落ちる（かもしれない）
（計ってないので程度は知らない）
このようなときに特にアクセスが来ないルートのpriorityを下げるとパフォーマンス的に嬉しい

しかし、そもそもそこを気にするならtraefikインスタンスを分けるべきかも

どちらにしろ、ユーザーアプリの priority 値の制御はあると細かい制御ができて嬉しい

## やったこと

priorityOffset 設定を追加

## やらなかったこと

## 資料
https://doc.traefik.io/traefik/routing/routers/#priority