### PR TITLE
[dashboard] Appsフィルターが画面内に収まらないときスクロールできるように

### DIFF
--- a/dashboard/src/components/templates/app/AppsFilter.tsx
+++ b/dashboard/src/components/templates/app/AppsFilter.tsx
@@ -19,9 +19,11 @@ const contentHideKeyframes = keyframes({
   to: { opacity: 0, transform: 'translateY(-8px)' },
 })
 const contentStyle = style({
+  maxWidth: 'var(--kb-popper-content-available-width)',
+  overflowX: 'auto',
   padding: '16px',
   display: 'grid',
-  gridTemplateColumns: 'repeat(3, 1fr)',
+  gridTemplateColumns: 'repeat(3, auto)',
   gridTemplateRows: '1fr auto',
   gridTemplateAreas: `
     "status provider sort"


### PR DESCRIPTION
## なぜやるか

closes #818

## やったこと

- Appsのフィルターの最大幅を`--kb-popper-content-available-width`で指定するようにした
  - DropdownMenuコンポーネントに`fitViewport`(https://kobalte.dev/docs/core/components/dropdown-menu#dropdownmenu)propsがあるが、これを使うだけでは解決しなかったため直接最大幅を指定しています

## 資料

![ns-filter-fit](https://github.com/traPtitech/NeoShowcase/assets/59188998/c2b5dbbb-ec06-4cba-8251-81342f4b30ed)
