### PR TITLE
chore: package.json の packageManager フィールドにsha512ハッシュを足した

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -54,5 +54,5 @@
     "solid-toast": "0.5.0",
     "tippy.js": "6.3.7"
   },
-  "packageManager": "yarn@4.1.1"
+  "packageManager": "yarn@4.1.1+sha512.ec40d0639bb307441b945d9467139cbb88d14394baac760b52eca038b330d16542d66fef61574271534ace5a200518dabf3b53a85f1f9e4bfa37141b538a9590"
 }


### PR DESCRIPTION
## なぜやるか
Corepackのベストプラクティスに従うため (セキュリティ的な話だと思う)

## やったこと
`npx corepack use yarn@4.1.1` した

## やらなかったこと
なし (強いて言うならYarnのアプデ)