### PR TITLE
ドメイン名に半角英数字を弾く正規表現を追加した

### DIFF
--- a/pkg/domain/app_website.go
+++ b/pkg/domain/app_website.go
@@ -13,7 +13,7 @@ import (
 	"github.com/traPtitech/neoshowcase/pkg/util/ds"
 )
 
-var urlRegexp = regexp.MustCompile(`^[a-z0-9-_]+(\.[a-z0-9-_]+)*$`)
+var domainRegexp = regexp.MustCompile(`^[a-z0-9-_]+(\.[a-z0-9-_]+)*$`)
 
 func ValidateDomain(domain string) error {
 	// ドメインが大文字を含むときはエラー
@@ -22,8 +22,8 @@ func ValidateDomain(domain string) error {
 	}
 
 	// 半角数字と英小文字以外を含むときはエラー
-	if urlRegexp.MatchString(domain) {
-		return errors.Errorf("domain %v must be numbers or lower letters", domain)
+	if !domainRegexp.MatchString(domain) {
+		return errors.Errorf("domain %v must consist of lower alpha-numeric letters, hyphen (-), or underscore (_)", domain)
 	}
 
 	// 面倒なのでtrailing dotは無しで統一

--- a/pkg/domain/app_website.go
+++ b/pkg/domain/app_website.go
@@ -3,6 +3,7 @@ package domain
 import (
 	"fmt"
 	"net/url"
+	"regexp"
 	"strings"
 
 	"github.com/friendsofgo/errors"
@@ -17,6 +18,13 @@ func ValidateDomain(domain string) error {
 	if domain != strings.ToLower(domain) {
 		return errors.Errorf("domain %v must be lower case", domain)
 	}
+
+	// 半角数字と英小文字以外を含むときはエラー
+	re := regexp.MustCompile(`^[a-z0-9-_]+(\.[a-z0-9-_]+)*$`)
+	if re.MatchString(domain) {
+		return errors.Errorf("domain %v must be numbers or lower letters", domain)
+	}
+
 	// 面倒なのでtrailing dotは無しで統一
 	if strings.HasSuffix(domain, ".") {
 		return errors.Errorf("trailing dot not allowed in domain %v", domain)

--- a/pkg/domain/app_website.go
+++ b/pkg/domain/app_website.go
@@ -13,6 +13,8 @@ import (
 	"github.com/traPtitech/neoshowcase/pkg/util/ds"
 )
 
+var urlRegexp = regexp.MustCompile(`^[a-z0-9-_]+(\.[a-z0-9-_]+)*$`)
+
 func ValidateDomain(domain string) error {
 	// ドメインが大文字を含むときはエラー
 	if domain != strings.ToLower(domain) {
@@ -20,8 +22,7 @@ func ValidateDomain(domain string) error {
 	}
 
 	// 半角数字と英小文字以外を含むときはエラー
-	re := regexp.MustCompile(`^[a-z0-9-_]+(\.[a-z0-9-_]+)*$`)
-	if re.MatchString(domain) {
+	if urlRegexp.MatchString(domain) {
 		return errors.Errorf("domain %v must be numbers or lower letters", domain)
 	}
 

--- a/pkg/domain/app_website_test.go
+++ b/pkg/domain/app_website_test.go
@@ -20,7 +20,7 @@ func TestValidateDomain(t *testing.T) {
 		{"invalid characters 1", "admin@example.com", true},
 		{"invalid characters 2", "space not allowed.example.com", true},
 		{"invalid characters 3", "UPPERCASE.example.com", true},
-		{"invalid characters 4", "日本語.jp", false},
+		{"invalid characters 4", "日本語.jp", true},
 		{"wildcard ng", "*.trap.show", true},
 		{"multi wildcard ng", "*.*.trap.show", true},
 		{"wildcard in middle", "trap.*.show", true},

--- a/pkg/domain/app_website_test.go
+++ b/pkg/domain/app_website_test.go
@@ -16,11 +16,11 @@ func TestValidateDomain(t *testing.T) {
 	}{
 		{"ok 1", "google.com", false},
 		{"ok 2", "hyphens-are-allowed.example.com", false},
-		{"ok 3", "日本語.jp", false},
-		{"ok 4", "underscore_allowed.example.com", false},
+		{"ok 3", "underscore_allowed.example.com", false},
 		{"invalid characters 1", "admin@example.com", true},
 		{"invalid characters 2", "space not allowed.example.com", true},
 		{"invalid characters 3", "UPPERCASE.example.com", true},
+		{"invalid characters 4", "日本語.jp", false},
 		{"wildcard ng", "*.trap.show", true},
 		{"multi wildcard ng", "*.*.trap.show", true},
 		{"wildcard in middle", "trap.*.show", true},


### PR DESCRIPTION
## なぜやるか
close #923
ドメイン名から日本語文字を弾くため

## やったこと
半角英字と数字、ドット(.)以外の文字を弾くようにした

## やらなかったこと
大文字を弾く処理をそのまま残したこと
-> エラーは一括で出るよりも細かく出たほうがいいと思うので、敢えて残しました

## 資料
特になし