### PR TITLE
fix: アプリケーション登録画面で、登録処理中にボタンを押せないように

### DIFF
--- a/dashboard/src/pages/apps/new.tsx
+++ b/dashboard/src/pages/apps/new.tsx
@@ -426,6 +426,7 @@ const WebsiteStep: Component<{
   backToGeneralStep: () => void
   submit: () => Promise<void>
 }> = (props) => {
+  const [isSubmitting, setIsSubmitting] = createSignal(false)
   const addWebsiteForm = () => {
     const form = createFormStore<WebsiteFormStatus>({
       initialValues: {
@@ -439,7 +440,9 @@ const WebsiteStep: Component<{
   const handleSubmit = async () => {
     const isValid = (await Promise.all(props.websiteForms().map((form) => validate(form)))).every((v) => v)
     if (!isValid) return
+    setIsSubmitting(true)
     await props.submit()
+    setIsSubmitting(false)
   }
 
   return (
@@ -500,6 +503,7 @@ const WebsiteStep: Component<{
             size="medium"
             variants="primary"
             onClick={handleSubmit}
+            disabled={isSubmitting()}
             // TODO: hostが空の状態でsubmitして一度requiredエラーが出たあとhostを入力してもエラーが消えない
             // disabled={props.websiteForms().some((form) => form.invalid)}
           >
@@ -589,7 +593,6 @@ export default () => {
     setCurrentStep(formStep.repository)
     // 選択していたリポジトリをリセットする
     setParam({ repositoryID: undefined })
-    mutateRepo(undefined)
   }
   const GoToGeneralStep = () => {
     setCurrentStep(formStep.general)

--- a/dashboard/src/pages/apps/new.tsx
+++ b/dashboard/src/pages/apps/new.tsx
@@ -444,7 +444,7 @@ const WebsiteStep: Component<{
       setIsSubmitting(true)
       await props.submit()
     } catch (err) {
-      console.error(err);
+      console.error(err)
     } finally {
       setIsSubmitting(false)
     }
@@ -509,8 +509,8 @@ const WebsiteStep: Component<{
             variants="primary"
             onClick={handleSubmit}
             disabled={isSubmitting()}
-          // TODO: hostが空の状態でsubmitして一度requiredエラーが出たあとhostを入力してもエラーが消えない
-          // disabled={props.websiteForms().some((form) => form.invalid)}
+            // TODO: hostが空の状態でsubmitして一度requiredエラーが出たあとhostを入力してもエラーが消えない
+            // disabled={props.websiteForms().some((form) => form.invalid)}
           >
             Create Application
           </Button>

--- a/dashboard/src/pages/apps/new.tsx
+++ b/dashboard/src/pages/apps/new.tsx
@@ -438,11 +438,16 @@ const WebsiteStep: Component<{
   }
 
   const handleSubmit = async () => {
-    const isValid = (await Promise.all(props.websiteForms().map((form) => validate(form)))).every((v) => v)
-    if (!isValid) return
-    setIsSubmitting(true)
-    await props.submit()
-    setIsSubmitting(false)
+    try {
+      const isValid = (await Promise.all(props.websiteForms().map((form) => validate(form)))).every((v) => v)
+      if (!isValid) return
+      setIsSubmitting(true)
+      await props.submit()
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setIsSubmitting(false)
+    }
   }
 
   return (
@@ -504,8 +509,8 @@ const WebsiteStep: Component<{
             variants="primary"
             onClick={handleSubmit}
             disabled={isSubmitting()}
-            // TODO: hostが空の状態でsubmitして一度requiredエラーが出たあとhostを入力してもエラーが消えない
-            // disabled={props.websiteForms().some((form) => form.invalid)}
+          // TODO: hostが空の状態でsubmitして一度requiredエラーが出たあとhostを入力してもエラーが消えない
+          // disabled={props.websiteForms().some((form) => form.invalid)}
           >
             Create Application
           </Button>


### PR DESCRIPTION
## なぜやるか
close #911

## やったこと
アプリケーション登録画面で、登録処理中にボタンを押せないように

## やらなかったこと
特になし

## コメント
他のところと違う実装方法なんですが、分からなかったのでとりあえずこういう形で実装してみました
もっと良い実装方法があれば教えて欲しいです