### PR TITLE
fix: use LocalMounts in buildkit SolveOpt

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.19.0
 	github.com/stretchr/testify v1.9.0
+	github.com/tonistiigi/fsutil v0.0.0-20240424095704-91a3fc46842c
 	github.com/traefik/traefik/v3 v3.1.1
 	github.com/volatiletech/null/v8 v8.1.2
 	github.com/volatiletech/sqlboiler/v4 v4.16.2
@@ -54,8 +55,6 @@ require (
 	k8s.io/apimachinery v0.30.3
 	k8s.io/client-go v0.30.3
 )
-
-require github.com/tonistiigi/fsutil v0.0.0-20240424095704-91a3fc46842c
 
 require (
 	dario.cat/mergo v1.0.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -55,6 +55,8 @@ require (
 	k8s.io/client-go v0.30.3
 )
 
+require github.com/tonistiigi/fsutil v0.0.0-20240424095704-91a3fc46842c
+
 require (
 	dario.cat/mergo v1.0.0 // indirect
 	filippo.io/edwards25519 v1.1.0 // indirect
@@ -171,7 +173,6 @@ require (
 	github.com/spf13/afero v1.11.0 // indirect
 	github.com/spf13/cast v1.6.0 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
-	github.com/tonistiigi/fsutil v0.0.0-20240424095704-91a3fc46842c // indirect
 	github.com/tonistiigi/go-csvvalue v0.0.0-20240710180619-ddb21b71c0b4 // indirect
 	github.com/tonistiigi/units v0.0.0-20180711220420-6950e57a87ea // indirect
 	github.com/tonistiigi/vt100 v0.0.0-20240514184818-90bafcd6abab // indirect


### PR DESCRIPTION
## なぜやるか
`SolveOpt` の `LocalDirs` の使用が非推奨のため
https://pkg.go.dev/github.com/moby/buildkit/client#SolveOpt

## やったこと
代わりに `LocalMounts` を使う

## やらなかったこと

## 資料

