### PR TITLE
Runtimeアプリのイメージサイズをダッシュボードから見られるようにする

### DIFF
--- a/dashboard/src/components/templates/build/RuntimeImageRow.tsx
+++ b/dashboard/src/components/templates/build/RuntimeImageRow.tsx
@@ -1,0 +1,32 @@
+import type { Component } from 'solid-js'
+import type { RuntimeImage } from '/@/api/neoshowcase/protobuf/gateway_pb'
+import { List } from '../List'
+
+const humanReadableSize = (size: bigint): string => {
+  const s = Number(size)
+  if (size < 1024) {
+    return `${size} B`
+  }
+  if (size < 1024 * 1024) {
+    return `${(s / 1024).toFixed(2)} KB`
+  }
+  if (size < 1024 * 1024 * 1024) {
+    return `${(s / 1024 / 1024).toFixed(2)} MB`
+  }
+  return `${(s / 1024 / 1024 / 1024).toFixed(2)} GB`
+}
+
+export interface Props {
+  image: RuntimeImage
+}
+
+export const RuntimeImageRow: Component<Props> = (props) => {
+  return (
+    <List.Row>
+      <List.RowContent>
+        <List.RowTitle>Image Size</List.RowTitle>
+        <List.RowData>{humanReadableSize(props.image.size)}</List.RowData>
+      </List.RowContent>
+    </List.Row>
+  )
+}

--- a/dashboard/src/components/templates/build/RuntimeImageRow.tsx
+++ b/dashboard/src/components/templates/build/RuntimeImageRow.tsx
@@ -1,20 +1,7 @@
 import type { Component } from 'solid-js'
 import type { RuntimeImage } from '/@/api/neoshowcase/protobuf/gateway_pb'
+import { formatBytes } from '/@/libs/format'
 import { List } from '../List'
-
-const humanReadableSize = (size: bigint): string => {
-  const s = Number(size)
-  if (size < 1024) {
-    return `${size} B`
-  }
-  if (size < 1024 * 1024) {
-    return `${(s / 1024).toFixed(2)} KB`
-  }
-  if (size < 1024 * 1024 * 1024) {
-    return `${(s / 1024 / 1024).toFixed(2)} MB`
-  }
-  return `${(s / 1024 / 1024 / 1024).toFixed(2)} GB`
-}
 
 export interface Props {
   image: RuntimeImage
@@ -24,8 +11,8 @@ export const RuntimeImageRow: Component<Props> = (props) => {
   return (
     <List.Row>
       <List.RowContent>
-        <List.RowTitle>Image Size</List.RowTitle>
-        <List.RowData>{humanReadableSize(props.image.size)}</List.RowData>
+        <List.RowTitle>Size</List.RowTitle>
+        <List.RowData>{formatBytes(Number(props.image.size))}</List.RowData>
       </List.RowContent>
     </List.Row>
   )

--- a/dashboard/src/pages/apps/[id]/builds/[id].tsx
+++ b/dashboard/src/pages/apps/[id]/builds/[id].tsx
@@ -66,7 +66,7 @@ export default () => {
           </Show>
           <Show when={build()!.runtimeImage != null}>
             <DataTable.Container>
-              <DataTable.Title>Runtime Image</DataTable.Title>
+              <DataTable.Title>Artifact</DataTable.Title>
               <List.Container>
                 <RuntimeImageRow image={build()!.runtimeImage!} />
               </List.Container>

--- a/dashboard/src/pages/apps/[id]/builds/[id].tsx
+++ b/dashboard/src/pages/apps/[id]/builds/[id].tsx
@@ -7,10 +7,10 @@ import { List } from '/@/components/templates/List'
 import { ArtifactRow } from '/@/components/templates/build/ArtifactRow'
 import { BuildLog } from '/@/components/templates/build/BuildLog'
 import BuildStatusTable from '/@/components/templates/build/BuildStatusTable'
+import { RuntimeImageRow } from '/@/components/templates/build/RuntimeImageRow'
 import { client } from '/@/libs/api'
 import { useBuildData } from '/@/routes'
 import { colorVars } from '/@/theme'
-import { RuntimeImageRow } from '/@/components/templates/build/RuntimeImageRow'
 
 const MainView = styled('div', {
   base: {

--- a/dashboard/src/pages/apps/[id]/builds/[id].tsx
+++ b/dashboard/src/pages/apps/[id]/builds/[id].tsx
@@ -10,6 +10,7 @@ import BuildStatusTable from '/@/components/templates/build/BuildStatusTable'
 import { client } from '/@/libs/api'
 import { useBuildData } from '/@/routes'
 import { colorVars } from '/@/theme'
+import { RuntimeImageRow } from '/@/components/templates/build/RuntimeImageRow'
 
 const MainView = styled('div', {
   base: {
@@ -60,6 +61,14 @@ export default () => {
               <DataTable.Title>Artifacts</DataTable.Title>
               <List.Container>
                 <For each={build()!.artifacts}>{(artifact) => <ArtifactRow artifact={artifact} />}</For>
+              </List.Container>
+            </DataTable.Container>
+          </Show>
+          <Show when={build()!.runtimeImage != null}>
+            <DataTable.Container>
+              <DataTable.Title>Runtime Image</DataTable.Title>
+              <List.Container>
+                <RuntimeImageRow image={build()!.runtimeImage!} />
               </List.Container>
             </DataTable.Container>
           </Show>


### PR DESCRIPTION
## なぜやるか
close #921

## やったこと
ビルド結果のページでRuntimeアプリのイメージサイズを見られるようにする
StaticアプリのArtifactと同じ位置に表示するようにしました

## やらなかったこと

## 資料
