### PR TITLE
fix: delete runtime images before deleting application

### DIFF
--- a/cmd/wire_gen.go
+++ b/cmd/wire_gen.go
@@ -283,6 +283,7 @@ func NewGateway(c Config) (component, error) {
 		return nil, err
 	}
 	artifactRepository := repository.NewArtifactRepository(db)
+	runtimeImageRepository := repository.NewRuntimeImageRepository(db)
 	applicationRepository := repository.NewApplicationRepository(db)
 	buildRepository := repository.NewBuildRepository(db)
 	environmentRepository := repository.NewEnvironmentRepository(db)
@@ -325,7 +326,7 @@ func NewGateway(c Config) (component, error) {
 	if err != nil {
 		return nil, err
 	}
-	service, err := apiserver.NewService(artifactRepository, applicationRepository, buildRepository, environmentRepository, gitRepositoryRepository, repositoryCommitRepository, userRepository, storage, mariaDBManager, mongoDBManager, metricsService, containerLogger, controllerServiceClient, imageConfig, publicKeys)
+	service, err := apiserver.NewService(artifactRepository, runtimeImageRepository, applicationRepository, buildRepository, environmentRepository, gitRepositoryRepository, repositoryCommitRepository, userRepository, storage, mariaDBManager, mongoDBManager, metricsService, containerLogger, controllerServiceClient, imageConfig, publicKeys)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/domain/repository.go
+++ b/pkg/domain/repository.go
@@ -102,6 +102,7 @@ type ArtifactRepository interface {
 
 type RuntimeImageRepository interface {
 	CreateRuntimeImage(ctx context.Context, image *RuntimeImage) error
+	HardDeleteRuntimeImages(ctx context.Context, appId string) error
 }
 
 type GetBuildCondition struct {

--- a/pkg/usecase/apiserver/app_service.go
+++ b/pkg/usecase/apiserver/app_service.go
@@ -3,8 +3,9 @@ package apiserver
 import (
 	"context"
 	"fmt"
-	"github.com/regclient/regclient/types/ref"
 	"strconv"
+
+	"github.com/regclient/regclient/types/ref"
 
 	"github.com/traPtitech/neoshowcase/pkg/util/regutil"
 
@@ -380,6 +381,11 @@ func (s *Service) DeleteApplication(ctx context.Context, id string) error {
 		}
 	}
 	err = s.artifactRepo.HardDeleteArtifacts(ctx, domain.GetArtifactCondition{ApplicationID: optional.From(app.ID)})
+	if err != nil {
+		return err
+	}
+	// delete runtime images
+	err = s.runtimeImageRepo.HardDeleteRuntimeImages(ctx, app.ID)
 	if err != nil {
 		return err
 	}

--- a/pkg/usecase/apiserver/service.go
+++ b/pkg/usecase/apiserver/service.go
@@ -2,8 +2,9 @@ package apiserver
 
 import (
 	"context"
-	"github.com/motoki317/sc"
 	"time"
+
+	"github.com/motoki317/sc"
 
 	"github.com/friendsofgo/errors"
 	"github.com/go-git/go-git/v5/plumbing/transport/ssh"
@@ -25,21 +26,22 @@ func handleRepoError[T any](entity T, err error) (T, error) {
 }
 
 type Service struct {
-	artifactRepo    domain.ArtifactRepository
-	appRepo         domain.ApplicationRepository
-	buildRepo       domain.BuildRepository
-	envRepo         domain.EnvironmentRepository
-	gitRepo         domain.GitRepositoryRepository
-	commitRepo      domain.RepositoryCommitRepository
-	userRepo        domain.UserRepository
-	storage         domain.Storage
-	mariaDBManager  domain.MariaDBManager
-	mongoDBManager  domain.MongoDBManager
-	metricsService  domain.MetricsService
-	containerLogger domain.ContainerLogger
-	controller      domain.ControllerServiceClient
-	fallbackKey     *ssh.PublicKeys
-	image           builder.ImageConfig
+	artifactRepo     domain.ArtifactRepository
+	runtimeImageRepo domain.RuntimeImageRepository
+	appRepo          domain.ApplicationRepository
+	buildRepo        domain.BuildRepository
+	envRepo          domain.EnvironmentRepository
+	gitRepo          domain.GitRepositoryRepository
+	commitRepo       domain.RepositoryCommitRepository
+	userRepo         domain.UserRepository
+	storage          domain.Storage
+	mariaDBManager   domain.MariaDBManager
+	mongoDBManager   domain.MongoDBManager
+	metricsService   domain.MetricsService
+	containerLogger  domain.ContainerLogger
+	controller       domain.ControllerServiceClient
+	fallbackKey      *ssh.PublicKeys
+	image            builder.ImageConfig
 
 	systemInfo *sc.Cache[struct{}, *domain.SystemInfo]
 	tmpKeys    *tmpKeyPairService
@@ -47,6 +49,7 @@ type Service struct {
 
 func NewService(
 	artifactRepo domain.ArtifactRepository,
+	runtimeImageRepo domain.RuntimeImageRepository,
 	appRepo domain.ApplicationRepository,
 	buildRepo domain.BuildRepository,
 	envRepo domain.EnvironmentRepository,
@@ -63,21 +66,22 @@ func NewService(
 	fallbackKey *ssh.PublicKeys,
 ) (*Service, error) {
 	return &Service{
-		artifactRepo:    artifactRepo,
-		appRepo:         appRepo,
-		buildRepo:       buildRepo,
-		envRepo:         envRepo,
-		gitRepo:         gitRepo,
-		commitRepo:      commitRepo,
-		userRepo:        userRepo,
-		storage:         storage,
-		mariaDBManager:  mariaDBManager,
-		mongoDBManager:  mongoDBManager,
-		metricsService:  metricsService,
-		containerLogger: containerLogger,
-		controller:      controller,
-		fallbackKey:     fallbackKey,
-		image:           image,
+		artifactRepo:     artifactRepo,
+		runtimeImageRepo: runtimeImageRepo,
+		appRepo:          appRepo,
+		buildRepo:        buildRepo,
+		envRepo:          envRepo,
+		gitRepo:          gitRepo,
+		commitRepo:       commitRepo,
+		userRepo:         userRepo,
+		storage:          storage,
+		mariaDBManager:   mariaDBManager,
+		mongoDBManager:   mongoDBManager,
+		metricsService:   metricsService,
+		containerLogger:  containerLogger,
+		controller:       controller,
+		fallbackKey:      fallbackKey,
+		image:            image,
 
 		systemInfo: sc.NewMust(scutil.WrapFunc(controller.GetSystemInfo), 5*time.Minute, 10*time.Minute),
 		tmpKeys:    newTmpKeyPairService(),


### PR DESCRIPTION
## なぜやるか
fix #959
アプリの削除をする際、外部キーで紐づいているデータを削除しなければならないが、`runtime_images`から削除する処理が抜けていたため、アプリを削除できないようになっていた

## やったこと
アプリ削除の前に紐づいているデータを削除する

## やらなかったこと

## 資料
