### PR TITLE
他人のリポジトリからアプリを作ったときに、アプリ作成者がアプリオーナーになるように

### DIFF
--- a/pkg/usecase/apiserver/app_service.go
+++ b/pkg/usecase/apiserver/app_service.go
@@ -51,12 +51,10 @@ func (s *Service) validateApp(ctx context.Context, app *domain.Application) erro
 }
 
 func (s *Service) CreateApplication(ctx context.Context, app *domain.Application) (*domain.Application, error) {
-	// Fill owners field
 	repo, err := s.gitRepo.GetRepository(ctx, app.RepositoryID)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get repository metadata")
 	}
-	app.OwnerIDs = repo.OwnerIDs
 
 	for _, website := range app.Websites {
 		website.Normalize()


### PR DESCRIPTION
## なぜやるか
実装のミスにより、他人のリポジトリからアプリを作ったときに、アプリ作成者がオーナーにならないようになっていた

## やったこと
問題の修正

## やらなかったこと

## 資料
