### PR TITLE
Builder mockの作成

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -55,6 +55,7 @@ type BuilderConfig struct {
 	Controller  grpc.ControllerServiceClientConfig `mapstructure:"controller" yaml:"controller"`
 	Priority    int                                `mapstructure:"priority" yaml:"priority"`
 	StepTimeout string                             `mapstructure:"stepTimeout" yaml:"stepTimeout"`
+	Mock        bool                               `mapstructure:"mock" yaml:"mock"`
 }
 
 type ControllerConfig struct {

--- a/cmd/wire.go
+++ b/cmd/wire.go
@@ -17,6 +17,8 @@ import (
 	"github.com/traPtitech/neoshowcase/pkg/domain"
 	"github.com/traPtitech/neoshowcase/pkg/infrastructure/backend/dockerimpl"
 	"github.com/traPtitech/neoshowcase/pkg/infrastructure/backend/k8simpl"
+	ubuilder "github.com/traPtitech/neoshowcase/pkg/usecase/builder"
+	buildermock "github.com/traPtitech/neoshowcase/pkg/usecase/builder/mock"
 )
 
 func NewAuthDev(c Config) (component, error) {
@@ -28,9 +30,29 @@ func NewAuthDev(c Config) (component, error) {
 }
 
 func NewBuilder(c Config) (component, error) {
+	if c.Components.Builder.Mock {
+		return newMockBuilder(c)
+	} else {
+		return newBuilder(c)
+	}
+}
+
+func newBuilder(c Config) (component, error) {
 	wire.Build(
 		providers,
 		wire.FieldsOf(new(BuilderConfig), "Buildpack"),
+		wire.Bind(new(ubuilder.Service), new(*ubuilder.ServiceImpl)),
+		wire.Bind(new(component), new(*builder.Server)),
+		wire.Struct(new(builder.Server), "*"),
+	)
+	return nil, nil
+}
+
+func newMockBuilder(c Config) (component, error) {
+	wire.Build(
+		providers,
+		buildermock.NewBuilderServiceMock,
+		wire.Bind(new(ubuilder.Service), new(*buildermock.BuilderServiceMock)),
 		wire.Bind(new(component), new(*builder.Server)),
 		wire.Struct(new(builder.Server), "*"),
 	)

--- a/pkg/usecase/builder/build.go
+++ b/pkg/usecase/builder/build.go
@@ -19,7 +19,7 @@ import (
 	"github.com/traPtitech/neoshowcase/pkg/util/cli"
 )
 
-func (s *builderService) startBuild(req *domain.StartBuildRequest) error {
+func (s *ServiceImpl) startBuild(req *domain.StartBuildRequest) error {
 	s.statusLock.Lock()
 	defer s.statusLock.Unlock()
 
@@ -67,7 +67,7 @@ type buildStep struct {
 	fn   func(ctx context.Context) error
 }
 
-func (s *builderService) buildSteps(st *state) ([]buildStep, error) {
+func (s *ServiceImpl) buildSteps(st *state) ([]buildStep, error) {
 	var steps []buildStep
 
 	steps = append(steps, buildStep{"Repository Clone", func(ctx context.Context) error {
@@ -147,7 +147,7 @@ func (s *builderService) buildSteps(st *state) ([]buildStep, error) {
 	return steps, nil
 }
 
-func (s *builderService) process(ctx context.Context, st *state) domain.BuildStatus {
+func (s *ServiceImpl) process(ctx context.Context, st *state) domain.BuildStatus {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	go s.buildPingLoop(ctx, st.build.ID)
@@ -195,7 +195,7 @@ func (s *builderService) process(ctx context.Context, st *state) domain.BuildSta
 	return domain.BuildStatusSucceeded
 }
 
-func (s *builderService) buildPingLoop(ctx context.Context, buildID string) {
+func (s *ServiceImpl) buildPingLoop(ctx context.Context, buildID string) {
 	ticker := time.NewTicker(3 * time.Second)
 	defer ticker.Stop()
 	for {
@@ -211,7 +211,7 @@ func (s *builderService) buildPingLoop(ctx context.Context, buildID string) {
 	}
 }
 
-func (s *builderService) finalize(ctx context.Context, st *state, status domain.BuildStatus) {
+func (s *ServiceImpl) finalize(ctx context.Context, st *state, status domain.BuildStatus) {
 	err := s.client.SaveBuildLog(ctx, st.build.ID, st.logWriter.buf.Bytes())
 	if err != nil {
 		log.Errorf("failed to save build log: %+v", err)
@@ -231,7 +231,7 @@ func (s *builderService) finalize(ctx context.Context, st *state, status domain.
 	}
 }
 
-func (s *builderService) fetchImageSize(ctx context.Context, st *state) (int64, error) {
+func (s *ServiceImpl) fetchImageSize(ctx context.Context, st *state) (int64, error) {
 	r := s.imageConfig.NewRegistry()
 	ref, err := ref.New(s.destImage(st.app, st.build))
 	if err != nil {

--- a/pkg/usecase/builder/build_buildkit.go
+++ b/pkg/usecase/builder/build_buildkit.go
@@ -93,7 +93,7 @@ func dockerignoreExists(dir string) bool {
 	return err == nil && !info.IsDir()
 }
 
-func (s *builderService) authSessions() []session.Attachable {
+func (s *ServiceImpl) authSessions() []session.Attachable {
 	if s.imageConfig.Registry.Username == "" && s.imageConfig.Registry.Password == "" {
 		return nil
 	}
@@ -107,7 +107,7 @@ func (s *builderService) authSessions() []session.Attachable {
 	}, nil)}
 }
 
-func (s *builderService) solveDockerfile(
+func (s *ServiceImpl) solveDockerfile(
 	ctx context.Context,
 	dest string,
 	contextDir string,
@@ -161,7 +161,7 @@ func (s *builderService) solveDockerfile(
 	return err
 }
 
-func (s *builderService) buildRuntimeCmd(
+func (s *ServiceImpl) buildRuntimeCmd(
 	ctx context.Context,
 	st *state,
 	ch chan *buildkit.SolveStatus,
@@ -222,7 +222,7 @@ func (s *builderService) buildRuntimeCmd(
 	)
 }
 
-func (s *builderService) buildRuntimeDockerfile(
+func (s *ServiceImpl) buildRuntimeDockerfile(
 	ctx context.Context,
 	st *state,
 	ch chan *buildkit.SolveStatus,
@@ -240,7 +240,7 @@ func (s *builderService) buildRuntimeDockerfile(
 	)
 }
 
-func (s *builderService) buildStaticCmd(
+func (s *ServiceImpl) buildStaticCmd(
 	ctx context.Context,
 	st *state,
 	ch chan *buildkit.SolveStatus,
@@ -302,7 +302,7 @@ func (s *builderService) buildStaticCmd(
 	)
 }
 
-func (s *builderService) buildStaticDockerfile(
+func (s *ServiceImpl) buildStaticDockerfile(
 	ctx context.Context,
 	st *state,
 	ch chan *buildkit.SolveStatus,

--- a/pkg/usecase/builder/build_buildpack.go
+++ b/pkg/usecase/builder/build_buildpack.go
@@ -9,7 +9,7 @@ import (
 	"github.com/traPtitech/neoshowcase/pkg/domain"
 )
 
-func (s *builderService) buildRuntimeBuildpack(
+func (s *ServiceImpl) buildRuntimeBuildpack(
 	ctx context.Context,
 	st *state,
 	bc *domain.BuildConfigRuntimeBuildpack,
@@ -20,7 +20,7 @@ func (s *builderService) buildRuntimeBuildpack(
 	return err
 }
 
-func (s *builderService) buildStaticBuildpackPack(
+func (s *ServiceImpl) buildStaticBuildpackPack(
 	ctx context.Context,
 	st *state,
 	bc *domain.BuildConfigStaticBuildpack,

--- a/pkg/usecase/builder/build_clone.go
+++ b/pkg/usecase/builder/build_clone.go
@@ -14,7 +14,7 @@ import (
 	"github.com/traPtitech/neoshowcase/pkg/domain"
 )
 
-func (s *builderService) cloneRepository(ctx context.Context, st *state) error {
+func (s *ServiceImpl) cloneRepository(ctx context.Context, st *state) error {
 	repo, err := git.PlainInit(st.repositoryTempDir, false)
 	if err != nil {
 		return errors.Wrap(err, "failed to init repository")

--- a/pkg/usecase/builder/build_save_artifact.go
+++ b/pkg/usecase/builder/build_save_artifact.go
@@ -12,7 +12,7 @@ import (
 	"github.com/traPtitech/neoshowcase/pkg/domain"
 )
 
-func (s *builderService) saveArtifact(ctx context.Context, st *state) error {
+func (s *ServiceImpl) saveArtifact(ctx context.Context, st *state) error {
 	// Open artifact
 	filename := st.artifactTempFile.Name()
 	stat, err := os.Stat(filename)

--- a/pkg/usecase/builder/build_static.go
+++ b/pkg/usecase/builder/build_static.go
@@ -11,7 +11,7 @@ import (
 	"github.com/tonistiigi/fsutil"
 )
 
-func (s *builderService) buildStaticExtract(
+func (s *ServiceImpl) buildStaticExtract(
 	ctx context.Context,
 	st *state,
 	ch chan *buildkit.SolveStatus,
@@ -46,7 +46,7 @@ func (s *builderService) buildStaticExtract(
 	return err
 }
 
-func (s *builderService) buildStaticCleanup(
+func (s *ServiceImpl) buildStaticCleanup(
 	ctx context.Context,
 	st *state,
 ) error {

--- a/pkg/usecase/builder/mock/builder.go
+++ b/pkg/usecase/builder/mock/builder.go
@@ -1,0 +1,61 @@
+package mock
+
+import (
+	"context"
+
+	"github.com/traPtitech/neoshowcase/pkg/domain"
+	"github.com/traPtitech/neoshowcase/pkg/infrastructure/grpc/pb"
+	"github.com/traPtitech/neoshowcase/pkg/util/retry"
+)
+
+type BuilderServiceMock struct {
+	client   domain.ControllerBuilderServiceClient
+	response chan *pb.BuilderResponse
+
+	close func()
+}
+
+func NewBuilderServiceMock(client domain.ControllerBuilderServiceClient) *BuilderServiceMock {
+	return &BuilderServiceMock{
+		client: client,
+	}
+}
+
+func (bs *BuilderServiceMock) Start(_ context.Context) error {
+	ctx, cancel := context.WithCancel(context.Background())
+	bs.close = func() {
+		cancel()
+	}
+	bs.response = make(chan *pb.BuilderResponse)
+	retry.Do(ctx, func(ctx context.Context) error {
+		return bs.client.ConnectBuilder(ctx, bs.onRequest, bs.response)
+	}, "connect to controller")
+	return nil
+}
+
+func (bs *BuilderServiceMock) Shutdown(ctx context.Context) error {
+	bs.close()
+	return nil
+}
+
+func (bs *BuilderServiceMock) onRequest(req *pb.BuilderRequest) {
+	// always cancel build
+	switch req.Type {
+	case pb.BuilderRequest_START_BUILD:
+		b := req.Body.(*pb.BuilderRequest_StartBuild).StartBuild
+		bs.response <- &pb.BuilderResponse{
+			Type: pb.BuilderResponse_BUILD_SETTLED,
+			Body: &pb.BuilderResponse_Settled{
+				Settled: &pb.BuildSettled{
+					BuildId: b.Build.Id,
+					Status:  pb.BuildStatus_CANCELLED,
+				},
+			},
+		}
+		bs.client.SaveBuildLog(context.Background(), b.Build.Id, []byte("skip build"))
+	case pb.BuilderRequest_CANCEL_BUILD:
+		// no-op
+	default:
+		panic("unexpected request type")
+	}
+}


### PR DESCRIPTION
## なぜやるか
configテーブルの定義が変わると、全アプリのビルドが走ってしまうのに対応するため、一時的にすべてのビルドをキャンセルするmockを作成する。

## やったこと
configファイルで
```yaml
components:
    builder:
        mock: true
```
としたときに、mockを使うようにした

## やらなかったこと

## 資料

## メモ
できれば、config table変更時に何もしなくてもいい仕組みを作りたい
