### PR TITLE
正しくログを出力できるように

### DIFF
--- a/dashboard/src/components/templates/app/ContainerLogExport.tsx
+++ b/dashboard/src/components/templates/app/ContainerLogExport.tsx
@@ -1,7 +1,6 @@
 import { fromJsonString, toJsonString } from '@bufbuild/protobuf'
 import { type Timestamp, TimestampSchema } from '@bufbuild/protobuf/wkt'
 import { type Component, Show, createSignal } from 'solid-js'
-import toast from 'solid-toast'
 import type { Application, ApplicationOutput } from '/@/api/neoshowcase/protobuf/gateway_pb'
 import { Button } from '/@/components/UI/Button'
 import { TextField } from '/@/components/UI/TextField'
@@ -96,34 +95,28 @@ const exportBefore = async (
   setProgressMessage: (message: string) => void,
 ) => {
   if (Number.isNaN(days)) {
-    toast.error('日数に整数を指定してください')
-    return
+    throw new Error('日数に整数を指定してください')
   }
   if (days <= 0) {
-    toast.error('1日以上を指定してください')
-    return
+    throw new Error('1日以上を指定してください')
   }
   if (days > maxExportDays) {
-    toast.error(`${maxExportDays} 日以下を指定してください`)
-    return
+    throw new Error(`${maxExportDays} 日以下を指定してください`)
   }
   if (Number.isNaN(lines)) {
-    toast.error('行に整数を指定してください')
-    return
+    throw new Error('行に整数を指定してください')
   }
   if (lines <= 0) {
-    toast.error('1行以上を指定してください')
-    return
+    throw new Error('1行以上を指定してください')
   }
   if (lines > maxExportLines) {
-    toast.error(`${maxExportLines} 行以下を指定してください`)
-    return
+    throw new Error(`${maxExportLines} 行以下を指定してください`)
   }
   try {
     fromJsonString(TimestampSchema, beforeStr)
   } catch (e) {
-    toast.error('日付フォーマットが正しくありません')
-    return
+    console.error(e)
+    throw new Error('日付フォーマットが正しくありません')
   }
 
   const logLines = await getLogsBefore(app.id, beforeStr, days, lines, setProgressMessage)
@@ -157,10 +150,12 @@ export const ContainerLogExport: Component<Props> = (props) => {
     setExporting(true)
     try {
       await run()
+      setProgressMessage('エクスポート完了！')
     } catch (e) {
       handleAPIError(e, 'ログのエクスポートに失敗しました')
+    } finally {
+      setExporting(false)
     }
-    setProgressMessage('エクスポート完了！')
     setExporting(false)
   }
 

--- a/dashboard/src/components/templates/app/ContainerLogExport.tsx
+++ b/dashboard/src/components/templates/app/ContainerLogExport.tsx
@@ -1,5 +1,5 @@
-import { fromJsonString, toJsonString } from '@bufbuild/protobuf'
-import { type Timestamp, TimestampSchema } from '@bufbuild/protobuf/wkt'
+import { toJsonString } from '@bufbuild/protobuf'
+import { type Timestamp, timestampFromDate, TimestampSchema } from '@bufbuild/protobuf/wkt'
 import { type Component, Show, createSignal } from 'solid-js'
 import type { Application, ApplicationOutput } from '/@/api/neoshowcase/protobuf/gateway_pb'
 import { Button } from '/@/components/UI/Button'
@@ -25,7 +25,7 @@ const getLogsBefore = async (
   setProgressMessage: (message: string) => void,
 ): Promise<ApplicationOutput[]> => {
   let remainingLines = lines
-  const firstBefore: Timestamp = fromJsonString(TimestampSchema, before)
+  const firstBefore: Timestamp = timestampFromDate(new Date(before))
   let nextBefore = firstBefore
   let logLines: ApplicationOutput[] = []
   while (remainingLines > 0 && firstBefore.seconds - nextBefore.seconds < days * secondsPerDay) {
@@ -111,10 +111,8 @@ const exportBefore = async (
   if (lines > maxExportLines) {
     throw new Error(`${maxExportLines} 行以下を指定してください`)
   }
-  try {
-    fromJsonString(TimestampSchema, beforeStr)
-  } catch (e) {
-    console.error(e)
+  const date = new Date(beforeStr)
+  if (Number.isNaN(date)) {
     throw new Error('日付フォーマットが正しくありません')
   }
 

--- a/dashboard/src/components/templates/app/ContainerLogExport.tsx
+++ b/dashboard/src/components/templates/app/ContainerLogExport.tsx
@@ -31,7 +31,6 @@ const getLogsBefore = async (
   while (remainingLines > 0 && firstBefore.seconds - nextBefore.seconds < days * secondsPerDay) {
     const msg = `${toJsonString(TimestampSchema, nextBefore)} より前のログを取得中、残り ${remainingLines} 行 ...`
     setProgressMessage(msg)
-    console.log(msg)
 
     const res = await client.getOutput({
       applicationId: appID,


### PR DESCRIPTION
## なぜやるか
close #987

## やったこと
SSIA + 若干のエラーハンドリング改善

根本的な原因: `fromJsonString` で  `2024-01-01T00:00:00.000Z` をパースしようとしているが、内部で `JSON.parse` が呼ばれていて、それがコケる

## やらなかったこと
エラー時にダイアログの後ろにトーストが表示されてしまう現象の改善
