### PR TITLE
不要な close 関数を削除した

### DIFF
--- a/dashboard/src/features/application/components/form/website/WebsiteFieldGroup.tsx
+++ b/dashboard/src/features/application/components/form/website/WebsiteFieldGroup.tsx
@@ -41,7 +41,6 @@ const WebsiteFieldGroup: Component<Props> = (props) => {
 
   const handleDelete = () => {
     remove(formStore, 'form.websites', { at: props.index })
-    close()
   }
 
   return (


### PR DESCRIPTION
<!-- この形のコメントは消してね -->

## なぜやるか
<!-- このPRが必要な理由を簡潔に説明してね -->
<!-- ref: #123, closes #123 などissueがある場合それを引用する形でも良いよ -->
feedback で特定の条件のみ、 URL delete ボタンで windowclose 関数が発動していた
fix #999

特定の条件というのは、 app/{appId} の URL パスに対して新規ウィンドウでアクセスした場合のみ、

- JavaScriptによって開かれた場合
- 履歴が1つしかないトップレベルブラウジングコンテキストの場合

の発動条件のうち後者に該当してしまうため発火していた
https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-window-close

これ以外の場合は本来設定されていた関数が発動されていなかっただけなので想定は window を閉じることであるように見受けられるが、使用感や今回上がった feedback からそもそも閉じないほうが便利だと考えたので閉じる関数の廃止に至った

## やったこと
<!-- このPRで何をやったかを簡潔に説明してね -->
閉じないほうが便利そうだったので、その記述自体を削除した

## やらなかったこと
<!-- 次に回したことなど、あえてやらなかったことがあれば説明してね -->
特になし

## 資料
<!-- 参考資料へのリンクなど -->
<!-- 例: Figmaの該当デザインのリンク、issueへのリンク、その他ディスカッションへのリンク -->