### PR TITLE
downgrade modular forms

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -39,7 +39,7 @@
     "@connectrpc/connect": "2.0.2",
     "@connectrpc/connect-web": "2.0.2",
     "@kobalte/core": "0.13.9",
-    "@modular-forms/solid": "0.25.1",
+    "@modular-forms/solid": "0.25.0",
     "@solid-primitives/refs": "1.1.0",
     "@solidjs/meta": "0.29.4",
     "@solidjs/router": "0.15.3",

--- a/dashboard/yarn.lock
+++ b/dashboard/yarn.lock
@@ -1267,14 +1267,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@modular-forms/solid@npm:0.25.1":
-  version: 0.25.1
-  resolution: "@modular-forms/solid@npm:0.25.1"
+"@modular-forms/solid@npm:0.25.0":
+  version: 0.25.0
+  resolution: "@modular-forms/solid@npm:0.25.0"
   dependencies:
     valibot: "npm:^1.0.0-beta.6"
   peerDependencies:
     solid-js: ^1.3.1
-  checksum: 10c0/3667273dbb49b191ab128890e88c38e0ef150b8267d74e8c421badd4385db761f46493a35f51ee1934a6171bb9edd52476e059e1d2f5bbf893dfb5eb8e663ccc
+  checksum: 10c0/853853f95c1f18c5b6f6a0adb771090029930b6e535b9d9d10ab14fa1295d295a4dfe1d9cebf1bd6fd1591ae4addb73a3bf7b2631457338bbcac6c31880e7179
   languageName: node
   linkType: hard
 
@@ -4116,7 +4116,7 @@ __metadata:
     "@connectrpc/connect-web": "npm:2.0.2"
     "@iconify-json/material-symbols": "npm:1.2.14"
     "@kobalte/core": "npm:0.13.9"
-    "@modular-forms/solid": "npm:0.25.1"
+    "@modular-forms/solid": "npm:0.25.0"
     "@solid-primitives/refs": "npm:1.1.0"
     "@solidjs/meta": "npm:0.29.4"
     "@solidjs/router": "npm:0.15.3"


### PR DESCRIPTION
## なぜやるか
アプリ作成ができなくなる不具合を直すため
https://q.trap.jp/messages/01955c82-83f2-7870-8d9c-536873c7ae1d

## やったこと
`@modular-forms/solid` を `0.25.1` から `0.25.0` にダウングレード

## やらなかったこと
本質的な問題の探索 (やるべきなので、後でやりたい、これは暫定対処)

## 資料
