### PR TITLE
feat(dashboard): Build Status アイコンをより区別しやすいように

### DIFF
--- a/dashboard/src/components/templates/build/BuildStatusIcon.tsx
+++ b/dashboard/src/components/templates/build/BuildStatusIcon.tsx
@@ -24,7 +24,7 @@ const components: Record<BuildStatus, (size: IconProps) => JSXElement> = {
     <div class="i-material-symbols:error shrink-0 text-accent-error" style={{ 'font-size': `${props.size}px` }} />
   ),
   [BuildStatus.CANCELLED]: (props) => (
-    <div class="i-material-symbols:cancel shrink-0 text-accent-error" style={{ 'font-size': `${props.size}px` }} />
+    <div class="i-material-symbols:cancel shrink-0 text-text-disabled" style={{ 'font-size': `${props.size}px` }} />
   ),
   [BuildStatus.SKIPPED]: (props) => (
     <div class="i-material-symbols:skip-next shrink-0 text-text-disabled" style={{ 'font-size': `${props.size}px` }} />

--- a/dashboard/src/components/templates/build/BuildStatusIcon.tsx
+++ b/dashboard/src/components/templates/build/BuildStatusIcon.tsx
@@ -9,10 +9,7 @@ interface IconProps {
 }
 const components: Record<BuildStatus, (size: IconProps) => JSXElement> = {
   [BuildStatus.QUEUED]: (props) => (
-    <div
-      class="i-material-symbols:schedule shrink-0 text-blue-500"
-      style={{ 'font-size': `${props.size}px` }}
-    />
+    <div class="i-material-symbols:schedule shrink-0 text-blue-500" style={{ 'font-size': `${props.size}px` }} />
   ),
   [BuildStatus.BUILDING]: (props) => (
     <div class="i-material-symbols:offline-bolt shrink-0 text-accent-warn" style={{ 'font-size': `${props.size}px` }} />
@@ -27,16 +24,10 @@ const components: Record<BuildStatus, (size: IconProps) => JSXElement> = {
     <div class="i-material-symbols:error shrink-0 text-accent-error" style={{ 'font-size': `${props.size}px` }} />
   ),
   [BuildStatus.CANCELLED]: (props) => (
-    <div
-    class="i-material-symbols:cancel shrink-0 text-accent-error"
-    style={{ 'font-size': `${props.size}px` }}
-    />
+    <div class="i-material-symbols:cancel shrink-0 text-accent-error" style={{ 'font-size': `${props.size}px` }} />
   ),
   [BuildStatus.SKIPPED]: (props) => (
-    <div
-      class="i-material-symbols:skip-next shrink-0 text-text-disabled"
-      style={{ 'font-size': `${props.size}px` }}
-    />
+    <div class="i-material-symbols:skip-next shrink-0 text-text-disabled" style={{ 'font-size': `${props.size}px` }} />
   ),
 }
 

--- a/dashboard/src/components/templates/build/BuildStatusIcon.tsx
+++ b/dashboard/src/components/templates/build/BuildStatusIcon.tsx
@@ -10,7 +10,7 @@ interface IconProps {
 const components: Record<BuildStatus, (size: IconProps) => JSXElement> = {
   [BuildStatus.QUEUED]: (props) => (
     <div
-      class="i-material-symbols:do-not-disturb-on shrink-0 text-text-disabled"
+      class="i-material-symbols:schedule shrink-0 text-blue-500"
       style={{ 'font-size': `${props.size}px` }}
     />
   ),
@@ -28,13 +28,13 @@ const components: Record<BuildStatus, (size: IconProps) => JSXElement> = {
   ),
   [BuildStatus.CANCELLED]: (props) => (
     <div
-      class="i-material-symbols:do-not-disturb-on shrink-0 text-text-disabled"
-      style={{ 'font-size': `${props.size}px` }}
+    class="i-material-symbols:cancel shrink-0 text-accent-error"
+    style={{ 'font-size': `${props.size}px` }}
     />
   ),
   [BuildStatus.SKIPPED]: (props) => (
     <div
-      class="i-material-symbols:do-not-disturb-on shrink-0 text-text-disabled"
+      class="i-material-symbols:skip-next shrink-0 text-text-disabled"
       style={{ 'font-size': `${props.size}px` }}
     />
   ),


### PR DESCRIPTION
## なぜやるか
QUQUED/CANCELED/SKIPPED のアイコンが同じで区別しづらかったため

## やったこと
それぞれ別のアイコンにした

## やらなかったこと

## 資料
