### PR TITLE
update CI configuration and golangci-lint settings

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,14 +49,8 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: ./go.mod
-      - name: Install reviewdog
-        run: curl -sfL https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh | sh -s -- -b $(go env GOPATH)/bin
-      - name: Install golangci-lint
-        run: curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin
-      - name: Run golangci-lint
-        run: golangci-lint run --out-format=line-number | reviewdog -f=golangci-lint -name=golangci-lint -reporter=github-check
-        env:
-          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
 
   test:
     name: Test

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,11 @@
-run:
-  skip-files:
-    - ".*\\.pb\\.go$"
-  skip-dirs:
-    - pkg/infrastructure/repository/models
+linters:
+  enable-all: false
+  disable-all: true
+  enable:
+    - errcheck
+    - gosimple
+    - govet
+    - staticcheck
+    - ineffassign
+    - unused
+    - gosec

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,12 @@
+run:
+  timeout: 10m
+
+issues:
+  exclude-files:
+    - ".*\\.pb\\.go$"
+  exclude-dirs:
+    - pkg/infrastructure/repository/models
+
 linters:
   enable-all: false
   disable-all: true


### PR DESCRIPTION
golangci-lintが動いてなかったので、更新する

http://github.com/traPtitech/NeoShowcase/actions/runs/14029523999/job/39274062277
> /home/runner/work/_temp/0f63b566-cc1c-472e-a199-d774f13741ab.sh: line 1: golangci-lint: command not found