### PR TITLE
builder作成時に必要なssh keyをns-controllerから受け取るように修正

### DIFF
--- a/cmd/wire_gen.go
+++ b/cmd/wire_gen.go
@@ -73,16 +73,7 @@ func newBuilder(c Config) (component, error) {
 	buildpackConfig := mainBuilderConfig.Buildpack
 	buildpackHelperServiceClient := provideBuildpackHelperClient(c)
 	buildpackBackend := buildpack.NewBuildpackBackend(buildpackConfig, buildpackHelperServiceClient)
-	privateKey, err := provideRepositoryPrivateKey(c)
-	if err != nil {
-		return nil, err
-	}
-	publicKeys, err := domain.IntoPublicKey(privateKey)
-	if err != nil {
-		return nil, err
-	}
-	gitService := git.NewService(publicKeys)
-	serviceImpl, err := builder.NewService(builderConfig, controllerBuilderServiceClient, client, buildpackBackend, gitService)
+	serviceImpl, err := builder.NewService(builderConfig, controllerBuilderServiceClient, client, buildpackBackend)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## なぜやるか
#1022 で builder作成時に必要なssh keyを、ローカルから取得するようにしてしまったので、ns-controllerのものを使うように挙動を元に戻す。

## やったこと
直した

## やらなかったこと
本来はDIにより外部からgit serviceを注入したいが、keyはns-controller client作成後にしか取得できないので、今回は実行時にgit serviceを作成するようにした。

## 資料
