### PR TITLE
fix: ブランチが存在しないエラーの擬陽性を排除

### DIFF
--- a/dashboard/src/features/application/components/form/general/BranchField.tsx
+++ b/dashboard/src/features/application/components/form/general/BranchField.tsx
@@ -22,6 +22,10 @@ const BranchField: Component<Props> = (props) => {
       'form.refName',
     )
     if (refName !== undefined && !branches().includes(refName)) {
+      // まだ読み込まれていない場合は何もしない
+      // (ブランチが真に存在しない場合も含まれるが、普通に使っているときは起こり得ないので無視する)
+      if (branches().length === 0) return;
+      
       // 下の refName に対する setValue により、もともと設定されていたブランチ名が空文字列に上書きされるため
       // refName が空でない(=refName がもともと設定されていたブランチ名になっている)とき、それを使ってエラーを表示する
       if (refName !== '') {


### PR DESCRIPTION
## なぜやるか
UX向上のため

## やったこと
SSIA

## やらなかったこと
なし

## メモ
ブランチが真に存在しない場合に変な挙動を示す可能性があるが、普通に使っている時にそうはならないので無視する