### PR TITLE
フォーカス周りの改善

### DIFF
--- a/dashboard/src/components/UI/TextField.tsx
+++ b/dashboard/src/components/UI/TextField.tsx
@@ -83,13 +83,15 @@ export const TextField: Component<Props> = (props) => {
                   </Show>
                 </div>
                 <Show when={props.copyable}>
-                  <button
-                    class="inline-grid w-12 shrink-0 cursor-pointer place-content-center rounded-r-lg border-none bg-black-alpha-100 text-text-black leading-4 outline outline-1 outline-ui-border hover:bg-black-alpha-200 active:bg-black-alpha-300"
-                    onClick={handleCopy}
-                    type="button"
-                  >
-                    <div class="shrink-0 text-2xl/6 i-material-symbols:content-copy-outline" />
-                  </button>
+                  <div class="w-12 shrink-0 rounded-r-lg focus-within:outline focus-within:outline-2 focus-within:outline-primary-main">
+                    <button
+                      class="inline-grid h-full w-full cursor-pointer place-content-center rounded-r-lg border-none bg-black-alpha-100 text-text-black leading-4 outline outline-1 outline-ui-border hover:bg-black-alpha-200 active:bg-black-alpha-300"
+                      onClick={handleCopy}
+                      type="button"
+                    >
+                      <div class="shrink-0 text-2xl/6 i-material-symbols:content-copy-outline" />
+                    </button>
+                  </div>
                 </Show>
               </div>
             </ToolTip>

--- a/dashboard/src/components/templates/CheckBox.tsx
+++ b/dashboard/src/components/templates/CheckBox.tsx
@@ -32,7 +32,7 @@ const Option: Component<Props> = (props) => {
   )
 
   return (
-    <KCheckbox.Root {...rootProps} validationState={props.error ? 'invalid' : 'valid'}>
+    <KCheckbox.Root {...rootProps} class='rounded-lg focus-within:outline focus-within:outline-3 focus-within:outline-primary-main w-fit' validationState={props.error ? 'invalid' : 'valid'}>
       <KCheckbox.Input {...inputProps} />
       <ToolTip {...props.tooltip}>
         <KCheckbox.Label

--- a/dashboard/src/components/templates/CheckBox.tsx
+++ b/dashboard/src/components/templates/CheckBox.tsx
@@ -32,7 +32,11 @@ const Option: Component<Props> = (props) => {
   )
 
   return (
-    <KCheckbox.Root {...rootProps} class='rounded-lg focus-within:outline focus-within:outline-3 focus-within:outline-primary-main w-fit' validationState={props.error ? 'invalid' : 'valid'}>
+    <KCheckbox.Root
+      {...rootProps}
+      class="w-fit rounded-lg focus-within:outline focus-within:outline-3 focus-within:outline-primary-main"
+      validationState={props.error ? 'invalid' : 'valid'}
+    >
       <KCheckbox.Input {...inputProps} />
       <ToolTip {...props.tooltip}>
         <KCheckbox.Label

--- a/dashboard/src/components/templates/Header.tsx
+++ b/dashboard/src/components/templates/Header.tsx
@@ -22,12 +22,12 @@ export const Header: Component = () => {
       </A>
       <div class="flex items-center gap-2 max-md:hidden">
         <A href="/apps">
-          <Button size="medium" variants="text">
+          <Button size="medium" variants="text" tabIndex={-1}>
             Apps
           </Button>
         </A>
         <A href="/builds">
-          <Button size="medium" variants="text">
+          <Button size="medium" variants="text" tabIndex={-1}>
             Queue
           </Button>
         </A>

--- a/dashboard/src/components/templates/RadioGroups.tsx
+++ b/dashboard/src/components/templates/RadioGroups.tsx
@@ -64,7 +64,11 @@ export const RadioGroup = <T extends string>(props: Props<T>): JSX.Element => {
             {(option) => (
               <KRadioGroup.Item
                 value={option.value}
-                class={clsx('min-w-[min(200px,100%)]', props.full ? 'w-full' : 'w-fit')}
+                class={clsx(
+                  'min-w-[min(200px,100%)]',
+                  'rounded-lg focus-within:outline focus-within:outline-3 focus-within:outline-primary-main',
+                  props.full ? 'w-full' : 'w-fit',
+                )}
               >
                 <KRadioGroup.ItemInput {...inputProps} />
                 <KRadioGroup.ItemLabel


### PR DESCRIPTION
<!-- この形のコメントは消してね -->

## なぜやるか
fix #819

## やったこと
- TextField のコピーボタン / RadioGroups / Checkbox に focus outline を付けた
- Header の button にフォーカスできないようにした

## やらなかったこと
その他コンポーネントのフォーカス周りの改善

## 資料
