### PR TITLE
golangci-lintでformatterを指定

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,5 +14,8 @@ linters:
       - legacy
       - std-error-handling
 formatters:
+  enable:
+    - gofmt
+    - goimports
   exclusions:
     generated: lax

--- a/cmd/providers.go
+++ b/cmd/providers.go
@@ -3,13 +3,10 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/traPtitech/neoshowcase/pkg/infrastructure/log/victorialogs"
 	"net/http"
 	"os"
 	"strings"
 	"time"
-
-	"github.com/traPtitech/neoshowcase/pkg/usecase/systeminfo"
 
 	"connectrpc.com/connect"
 	"github.com/friendsofgo/errors"
@@ -24,6 +21,7 @@ import (
 	"github.com/traPtitech/neoshowcase/pkg/infrastructure/grpc"
 	"github.com/traPtitech/neoshowcase/pkg/infrastructure/grpc/pb/pbconnect"
 	"github.com/traPtitech/neoshowcase/pkg/infrastructure/log/loki"
+	"github.com/traPtitech/neoshowcase/pkg/infrastructure/log/victorialogs"
 	"github.com/traPtitech/neoshowcase/pkg/infrastructure/metrics/prometheus"
 	"github.com/traPtitech/neoshowcase/pkg/infrastructure/staticserver/builtin"
 	"github.com/traPtitech/neoshowcase/pkg/infrastructure/staticserver/caddy"
@@ -32,6 +30,7 @@ import (
 	giteaintegration "github.com/traPtitech/neoshowcase/pkg/usecase/gitea-integration"
 	"github.com/traPtitech/neoshowcase/pkg/usecase/healthcheck"
 	"github.com/traPtitech/neoshowcase/pkg/usecase/ssgen"
+	"github.com/traPtitech/neoshowcase/pkg/usecase/systeminfo"
 )
 
 func provideRepositoryPrivateKey(c Config) (domain.PrivateKey, error) {

--- a/pkg/infrastructure/buildpack/backend.go
+++ b/pkg/infrastructure/buildpack/backend.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	log "github.com/sirupsen/logrus"
 	"io"
 	"os"
 	"path/filepath"
@@ -13,6 +12,7 @@ import (
 	"github.com/docker/cli/cli/config/configfile"
 	types2 "github.com/docker/cli/cli/config/types"
 	"github.com/friendsofgo/errors"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/traPtitech/neoshowcase/pkg/domain"
 	"github.com/traPtitech/neoshowcase/pkg/domain/builder"

--- a/pkg/infrastructure/grpc/buildpack_helper_service_client.go
+++ b/pkg/infrastructure/grpc/buildpack_helper_service_client.go
@@ -1,11 +1,12 @@
 package grpc
 
 import (
-	"connectrpc.com/connect"
 	"context"
+	"io"
+
+	"connectrpc.com/connect"
 	"github.com/friendsofgo/errors"
 	"github.com/samber/lo"
-	"io"
 
 	"github.com/traPtitech/neoshowcase/pkg/domain"
 	"github.com/traPtitech/neoshowcase/pkg/domain/web"

--- a/pkg/infrastructure/grpc/controller_service.go
+++ b/pkg/infrastructure/grpc/controller_service.go
@@ -2,7 +2,6 @@ package grpc
 
 import (
 	"context"
-	"github.com/traPtitech/neoshowcase/pkg/usecase/systeminfo"
 
 	"connectrpc.com/connect"
 	"github.com/friendsofgo/errors"
@@ -15,6 +14,7 @@ import (
 	"github.com/traPtitech/neoshowcase/pkg/usecase/cdservice"
 	"github.com/traPtitech/neoshowcase/pkg/usecase/logstream"
 	"github.com/traPtitech/neoshowcase/pkg/usecase/repofetcher"
+	"github.com/traPtitech/neoshowcase/pkg/usecase/systeminfo"
 )
 
 type ControllerService struct {

--- a/pkg/infrastructure/grpc/token_auth_interceptor.go
+++ b/pkg/infrastructure/grpc/token_auth_interceptor.go
@@ -1,10 +1,11 @@
 package grpc
 
 import (
-	"connectrpc.com/connect"
 	"context"
-	"github.com/friendsofgo/errors"
 	"net/http"
+
+	"connectrpc.com/connect"
+	"github.com/friendsofgo/errors"
 )
 
 type TokenAuthInterceptor struct {

--- a/pkg/infrastructure/log/victorialogs/streamer.go
+++ b/pkg/infrastructure/log/victorialogs/streamer.go
@@ -4,14 +4,16 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/friendsofgo/errors"
-	"github.com/samber/lo/mutable"
-	log "github.com/sirupsen/logrus"
-	"github.com/traPtitech/neoshowcase/pkg/domain"
 	"io"
 	"net/http"
 	"text/template"
 	"time"
+
+	"github.com/friendsofgo/errors"
+	"github.com/samber/lo/mutable"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/traPtitech/neoshowcase/pkg/domain"
 )
 
 type Config struct {

--- a/pkg/infrastructure/log/victorialogs/types.go
+++ b/pkg/infrastructure/log/victorialogs/types.go
@@ -2,10 +2,11 @@ package victorialogs
 
 import (
 	"encoding/json"
-	"github.com/traPtitech/neoshowcase/pkg/domain"
 	"io"
 	"iter"
 	"time"
+
+	"github.com/traPtitech/neoshowcase/pkg/domain"
 )
 
 const (

--- a/pkg/infrastructure/repository/repository_commit.go
+++ b/pkg/infrastructure/repository/repository_commit.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"context"
 	"database/sql"
+
 	"github.com/friendsofgo/errors"
 	"github.com/volatiletech/sqlboiler/v4/boil"
 

--- a/pkg/infrastructure/webhook/gitea.go
+++ b/pkg/infrastructure/webhook/gitea.go
@@ -1,13 +1,13 @@
 package webhook
 
 import (
-	log "github.com/sirupsen/logrus"
 	"net/http"
 
 	"github.com/friendsofgo/errors"
 	"github.com/go-playground/webhooks/v6/gitea"
 	"github.com/labstack/echo/v4"
 	"github.com/samber/lo"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/traPtitech/neoshowcase/pkg/infrastructure/grpc/pb"
 )

--- a/pkg/usecase/gitea-integration/integration.go
+++ b/pkg/usecase/gitea-integration/integration.go
@@ -3,10 +3,10 @@ package giteaintegration
 import (
 	"context"
 	"fmt"
-	log "github.com/sirupsen/logrus"
 	"time"
 
 	"code.gitea.io/sdk/gitea"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/traPtitech/neoshowcase/pkg/domain"
 	"github.com/traPtitech/neoshowcase/pkg/infrastructure/grpc/pb"

--- a/pkg/usecase/systeminfo/service.go
+++ b/pkg/usecase/systeminfo/service.go
@@ -2,6 +2,7 @@ package systeminfo
 
 import (
 	"context"
+
 	"github.com/go-git/go-git/v5/plumbing/transport/ssh"
 	"github.com/traPtitech/neoshowcase/pkg/domain"
 	"github.com/traPtitech/neoshowcase/pkg/util/cli"

--- a/pkg/util/ds/slice_test.go
+++ b/pkg/util/ds/slice_test.go
@@ -1,8 +1,9 @@
 package ds
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestHasPrefix(t *testing.T) {

--- a/pkg/util/tarfs/extract.go
+++ b/pkg/util/tarfs/extract.go
@@ -2,12 +2,13 @@ package tarfs
 
 import (
 	"archive/tar"
-	"github.com/friendsofgo/errors"
-	log "github.com/sirupsen/logrus"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/friendsofgo/errors"
+	log "github.com/sirupsen/logrus"
 )
 
 func isValidRelPath(relPath string) bool {


### PR DESCRIPTION
## なぜやるか
formatの形式をそろえておく。vscodeでのデフォルトにしておいた。

## やったこと
golangci-lintでformatterを指定

## やらなかったこと

## 資料
