### PR TITLE
Feature: アプリケーション作成時に環境変数を設定できるようにする

### DIFF
--- a/dashboard/src/features/application/components/form/CreateAppForm.tsx
+++ b/dashboard/src/features/application/components/form/CreateAppForm.tsx
@@ -114,7 +114,13 @@ const CreateAppForm: Component = () => {
                 ),
             )
           } catch (e) {
-            handleAPIError(e, '環境変数の設定に失敗しました')
+            toast.error(
+              <p>
+                環境変数の設定に失敗しました (<a href={`/apps/${createdApp.id}/settings/envVars`}>再設定</a>)
+                <br />
+                {e instanceof Error ? e.message : '不明なエラー'}
+              </p>,
+            )
           }
         })
 

--- a/dashboard/src/features/application/components/form/CreateAppForm.tsx
+++ b/dashboard/src/features/application/components/form/CreateAppForm.tsx
@@ -32,7 +32,7 @@ enum formStep {
 
 const CreateAppForm: Component = () => {
   const { formStore } = useApplicationForm()
-  const { formStore: envVarsFormStore } = useEnvVarConfigForm()
+  const { formStore: envVarConfigFormStore } = useEnvVarConfigForm()
 
   // `reset` doesn't work on first render when the Field not rendered
   // see: https://github.com/fabian-hiller/modular-forms/issues/157#issuecomment-1848567069
@@ -101,7 +101,7 @@ const CreateAppForm: Component = () => {
       try {
         const createdApp = await client.createApplication(output)
 
-        await handleSubmitEnvVarForm(getValues(envVarsFormStore) as EnvVarInput, async ({ variables }) => {
+        await handleSubmitEnvVarForm(getValues(envVarConfigFormStore) as EnvVarInput, async ({ variables }) => {
           try {
             await Promise.all(
               variables

--- a/dashboard/src/features/application/components/form/GeneralStep.tsx
+++ b/dashboard/src/features/application/components/form/GeneralStep.tsx
@@ -1,13 +1,15 @@
-import { Field, getValue } from '@modular-forms/solid'
-import { type Component, Show } from 'solid-js'
+import { Field, getValue, setValues } from '@modular-forms/solid'
+import { type Component, onMount, Show } from 'solid-js'
 import type { Repository } from '/@/api/neoshowcase/protobuf/gateway_pb'
 import { CheckBox } from '/@/components/templates/CheckBox'
 import { FormItem } from '/@/components/templates/FormItem'
 import { Button } from '/@/components/UI/Button'
 import { originToIcon, repositoryURLToOrigin } from '/@/libs/application'
 import { useApplicationForm } from '../../provider/applicationFormProvider'
+import { useEnvVarConfigForm } from '../../provider/envVarConfigFormProvider'
 import BuildTypeField from './config/BuildTypeField'
 import ConfigField from './config/ConfigField'
+import EnvVarConfigField from './config/EnvVarConfigField'
 import BranchField from './general/BranchField'
 import NameField from './general/NameField'
 
@@ -17,6 +19,11 @@ const GeneralStep: Component<{
   proceedToWebsiteStep: () => void
 }> = (props) => {
   const { formStore } = useApplicationForm()
+  const { formStore: envVarConfigFormStore } = useEnvVarConfigForm()
+
+  onMount(() => {
+    setValues(envVarConfigFormStore, 'variables', [])
+  })
 
   return (
     <div class="flex w-full flex-col items-center gap-10">
@@ -45,7 +52,6 @@ const GeneralStep: Component<{
                   content: (
                     <>
                       <div>この設定で今すぐ起動するかどうか</div>
-                      <div>(環境変数はアプリ作成後設定可能になります)</div>
                     </>
                   ),
                 },
@@ -54,12 +60,16 @@ const GeneralStep: Component<{
               <CheckBox.Option
                 {...fieldProps}
                 label="今すぐ起動する"
-                checked={field.value ?? false}
+                checked={field.value ?? true}
                 error={field.error}
               />
             </FormItem>
           )}
         </Field>
+
+        <FormItem title="環境変数">
+          <EnvVarConfigField />
+        </FormItem>
       </div>
       <div class="flex gap-5">
         <Button

--- a/dashboard/src/features/application/components/form/config/EnvVarConfigField.tsx
+++ b/dashboard/src/features/application/components/form/config/EnvVarConfigField.tsx
@@ -1,0 +1,94 @@
+import { Field, FieldArray, getValue, getValues, insert, remove } from '@modular-forms/solid'
+import { type Component, createReaction, For, onMount } from 'solid-js'
+import { TextField } from '/@/components/UI/TextField'
+import { useEnvVarConfigForm } from '../../../provider/envVarConfigFormProvider'
+
+const EnvVarConfigField: Component = () => {
+  const { formStore } = useEnvVarConfigForm()
+
+  // keyとvalueが空となるenv varを削除し、最後に空のenv varを追加する
+  const stripEnvVars = () => {
+    const envVars = getValues(formStore).variables ?? []
+
+    for (let i = envVars.length - 1; i >= 0; i--) {
+      if (envVars[i]?.key === '' && envVars[i]?.value === '') {
+        remove(formStore, 'variables', { at: i })
+      }
+    }
+
+    // add empty env var
+    insert(formStore, 'variables', {
+      value: { key: '', value: '', system: false },
+    })
+
+    // 次にvariablesが変更された時に1度だけ再度stripする
+    track(() => getValues(formStore, 'variables'))
+  }
+
+  const track = createReaction(() => {
+    stripEnvVars()
+  })
+
+  onMount(() => {
+    stripEnvVars()
+  })
+
+  return (
+    <div class="grid w-full grid-cols-2 gap-col-6 gap-row-2 text-bold text-text-black">
+      <div>Key</div>
+      <div>Value</div>
+      <FieldArray of={formStore} name="variables">
+        {(fieldArray) => (
+          <For each={fieldArray.items}>
+            {(_, index) => {
+              const isSystem = () =>
+                getValue(formStore, `variables.${index()}.system`, {
+                  shouldActive: false,
+                })
+
+              return (
+                <>
+                  <Field of={formStore} name={`variables.${index()}.key`}>
+                    {(field, fieldProps) => (
+                      <TextField
+                        tooltip={{
+                          props: {
+                            content: 'システム環境変数は変更できません',
+                          },
+                          disabled: !isSystem(),
+                        }}
+                        {...fieldProps}
+                        value={field.value ?? ''}
+                        error={field.error}
+                        disabled={isSystem()}
+                      />
+                    )}
+                  </Field>
+                  <Field of={formStore} name={`variables.${index()}.value`}>
+                    {(field, fieldProps) => (
+                      <TextField
+                        tooltip={{
+                          props: {
+                            content: 'システム環境変数は変更できません',
+                          },
+                          disabled: !isSystem(),
+                        }}
+                        {...fieldProps}
+                        value={field.value ?? ''}
+                        error={field.error}
+                        disabled={isSystem()}
+                        copyable
+                      />
+                    )}
+                  </Field>
+                </>
+              )
+            }}
+          </For>
+        )}
+      </FieldArray>
+    </div>
+  )
+}
+
+export default EnvVarConfigField

--- a/dashboard/src/features/application/provider/applicationFormProvider.tsx
+++ b/dashboard/src/features/application/provider/applicationFormProvider.tsx
@@ -1,4 +1,4 @@
-import { useFormContext } from '../../../libs/useFormContext'
+import { useFormContext } from '/@/libs/useFormContext'
 import { createOrUpdateApplicationSchema } from '../schema/applicationSchema'
 
 export const { FormProvider: ApplicationFormProvider, useForm: useApplicationForm } = useFormContext(

--- a/dashboard/src/features/application/provider/envVarConfigFormProvider.tsx
+++ b/dashboard/src/features/application/provider/envVarConfigFormProvider.tsx
@@ -1,0 +1,4 @@
+import { useFormContext } from '/@/libs/useFormContext'
+import { envVarSchema } from '../schema/envVarSchema'
+
+export const { FormProvider: EnvVarConfigFormProvider, useForm: useEnvVarConfigForm } = useFormContext(envVarSchema)

--- a/dashboard/src/features/repository/provider/repositoryFormProvider.tsx
+++ b/dashboard/src/features/repository/provider/repositoryFormProvider.tsx
@@ -1,4 +1,4 @@
-import { useFormContext } from '../../../libs/useFormContext'
+import { useFormContext } from '/@/libs/useFormContext'
 import { createOrUpdateRepositorySchema } from '../schema/repositorySchema'
 
 export const { FormProvider: RepositoryFormProvider, useForm: useRepositoryForm } =

--- a/dashboard/src/pages/apps/[id]/settings/envVars.tsx
+++ b/dashboard/src/pages/apps/[id]/settings/envVars.tsx
@@ -1,6 +1,7 @@
 import { createResource, Show } from 'solid-js'
 import { DataTable } from '/@/components/layouts/DataTable'
 import EnvVarConfigForm from '/@/features/application/components/form/EnvVarConfigForm'
+import { EnvVarConfigFormProvider } from '/@/features/application/provider/envVarConfigFormProvider'
 import { client } from '/@/libs/api'
 import { useApplicationData } from '/@/routes'
 
@@ -27,7 +28,9 @@ export default () => {
         }
       >
         <Show when={loaded()}>
-          <EnvVarConfigForm appId={app()!.id} envVars={envVars()!} refetch={refetch} />
+          <EnvVarConfigFormProvider>
+            <EnvVarConfigForm appId={app()!.id} envVars={envVars()!} refetch={refetch} />
+          </EnvVarConfigFormProvider>
         </Show>
       </Show>
     </DataTable.Container>

--- a/dashboard/src/pages/apps/new.tsx
+++ b/dashboard/src/pages/apps/new.tsx
@@ -4,6 +4,7 @@ import { WithNav } from '/@/components/layouts/WithNav'
 import { Nav } from '/@/components/templates/Nav'
 import CreateAppForm from '/@/features/application/components/form/CreateAppForm'
 import { ApplicationFormProvider } from '/@/features/application/provider/applicationFormProvider'
+import { EnvVarConfigFormProvider } from '/@/features/application/provider/envVarConfigFormProvider'
 
 export default () => {
   return (
@@ -15,7 +16,9 @@ export default () => {
       <WithNav.Body>
         <MainViewContainer background="grey">
           <ApplicationFormProvider>
-            <CreateAppForm />
+            <EnvVarConfigFormProvider>
+              <CreateAppForm />
+            </EnvVarConfigFormProvider>
           </ApplicationFormProvider>
         </MainViewContainer>
       </WithNav.Body>


### PR DESCRIPTION
## なぜやるか
Closes: #1058 

## やったこと
- `EnvVarConfigForm` の Field 部分を `EnvVarConfigField` として分離
  - `stripEnvVars` を `EnvVarConfigField` 下に移動
  - `FormStore<EnvVarInput>` を Context で与える形式に変更
- `GeneralStep` に `EnvVarConfigField` を追加
- `CreateAppForm` の `handleSubmit` に `setEnvVar` の call を追加
- 「今すぐ起動する」の初期値を `true` に変更

## やらなかったこと
- アプリケーション作成時の環境変数設定欄には「Discard Changes」がないので，消去が少々手間．全消去ボタンや各行に破棄ボタンを設けてもよいかもしれない．
