### PR TITLE
StatefulSet置き換え処理の修正

### DIFF
--- a/pkg/infrastructure/backend/k8simpl/helper.go
+++ b/pkg/infrastructure/backend/k8simpl/helper.go
@@ -3,11 +3,15 @@ package k8simpl
 import (
 	"context"
 	"encoding/json"
+	"time"
 
+	"github.com/friendsofgo/errors"
 	"github.com/samber/lo"
 	log "github.com/sirupsen/logrus"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/traPtitech/neoshowcase/pkg/util/discovery"
 	"github.com/traPtitech/neoshowcase/pkg/util/hash"
@@ -44,6 +48,7 @@ func hashResource(rc apiResource) (string, error) {
 }
 
 type syncer[T apiResource] interface {
+	Get(ctx context.Context, name string, opts metav1.GetOptions) (T, error)
 	Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subResources ...string) (result T, err error)
 	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
 }
@@ -81,10 +86,8 @@ func syncResources[T apiResource](ctx context.Context, cluster *discovery.Cluste
 		_, err = s.Patch(ctx, rc.GetName(), types.ApplyPatchType, b, metav1.PatchOptions{Force: lo.ToPtr(true), FieldManager: fieldManager})
 		// For StatefulSets, delete the resource before applying again - StatefulSet has many immutable fields
 		// Example: StatefulSet.apps "nsapp-add177a080c4c78936e192" is invalid: spec: Forbidden: updates to statefulset spec for fields other than 'replicas', 'ordinals', 'template', 'updateStrategy', 'revisionHistoryLimit', 'persistentVolumeClaimRetentionPolicy' and 'minReadySeconds' are forbidden
-		if replace && err != nil {
-			_ = s.Delete(ctx, rc.GetName(), metav1.DeleteOptions{PropagationPolicy: lo.ToPtr(metav1.DeletePropagationForeground)})
-			// Try again
-			_, err = s.Patch(ctx, rc.GetName(), types.ApplyPatchType, b, metav1.PatchOptions{Force: lo.ToPtr(true), FieldManager: fieldManager})
+		if err != nil && replace {
+			err = replaceResource(ctx, rc, b, s)
 		}
 		if err != nil {
 			log.WithError(err).Errorf("failed to patch %s/%s", rcName, rc.GetName())
@@ -113,5 +116,34 @@ func syncResources[T apiResource](ctx context.Context, cluster *discovery.Cluste
 	if patched > 0 || pruned > 0 {
 		log.Debugf("patched %v %v, pruned %v %v", patched, rcName, pruned, rcName)
 	}
+	return nil
+}
+
+func replaceResource[T apiResource](ctx context.Context, rc T, data []byte, s syncer[T]) error {
+	err := s.Delete(ctx, rc.GetName(), metav1.DeleteOptions{PropagationPolicy: lo.ToPtr(metav1.DeletePropagationForeground)})
+	if err != nil {
+		return errors.Wrapf(err, "delete %s/%s before re-apply", rc.GetName(), rc.GetLabels()[resourceHashAnnotation])
+	}
+
+	// Wait for the resource to be deleted
+	interval := 100 * time.Millisecond
+	timeout := 30 * time.Second
+	err = wait.PollUntilContextTimeout(ctx, interval, timeout, true, func(ctx context.Context) (bool, error) {
+		_, err := s.Get(ctx, rc.GetName(), metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			return true, nil // Resource is deleted
+		}
+		return false, err
+	})
+	if err != nil {
+		return errors.Wrapf(err, "waiting for %s/%s to be deleted", rc.GetName(), rc.GetLabels()[resourceHashAnnotation])
+	}
+
+	// Try again
+	_, err = s.Patch(ctx, rc.GetName(), types.ApplyPatchType, data, metav1.PatchOptions{Force: lo.ToPtr(true), FieldManager: fieldManager})
+	if err != nil {
+		return errors.Wrapf(err, "re-apply %s/%s after deletion", rc.GetName(), rc.GetLabels()[resourceHashAnnotation])
+	}
+
 	return nil
 }


### PR DESCRIPTION
## なぜやるか
statefulsetには変更不可なフィールドがあるため、デプロイ時には削除してから再作成するようにしている。しかし、削除は非同期で行われるため、削除しきる前に変更不可フィールドを変更しようとしてエラーになることがあった。

## やったこと
リソースが削除されたことを確認できるまで待つようにした

## やらなかったこと

## 資料
