### PR TITLE
リソース置き換えの修正

### DIFF
--- a/pkg/infrastructure/backend/k8simpl/helper.go
+++ b/pkg/infrastructure/backend/k8simpl/helper.go
@@ -3,6 +3,7 @@ package k8simpl
 import (
 	"context"
 	"encoding/json"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -10,10 +11,9 @@ import (
 	"github.com/samber/lo"
 	log "github.com/sirupsen/logrus"
 	"github.com/sourcegraph/conc/pool"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/watch"
 
 	"github.com/traPtitech/neoshowcase/pkg/util/discovery"
 	"github.com/traPtitech/neoshowcase/pkg/util/hash"
@@ -49,81 +49,160 @@ func hashResource(rc apiResource) (string, error) {
 	return hash.XXH3Hex(b), nil
 }
 
+func setResourceHashAnnotation[T apiResource](rc T, hash string) {
+	labels := rc.GetLabels()
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+	labels[resourceHashAnnotation] = hash
+	rc.SetLabels(labels)
+}
+
 type syncer[T apiResource] interface {
-	Get(ctx context.Context, name string, opts metav1.GetOptions) (T, error)
+	Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error)
 	Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subResources ...string) (result T, err error)
 	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
 }
 
-func syncResources[T apiResource](ctx context.Context, cluster *discovery.Cluster, rcName string, existing []T, next []T, s syncer[T], replace bool) error {
-	var patched, pruned int
-	var replaced atomic.Int64
-	replacePool := pool.New().WithMaxGoroutines(10)
+type deletionNotifier struct {
+	mu      sync.Mutex
+	waiters map[string]chan struct{}
+}
+
+func newDeletionNotifier() *deletionNotifier {
+	return &deletionNotifier{
+		waiters: make(map[string]chan struct{}),
+	}
+}
+
+func (n *deletionNotifier) add(name string) <-chan struct{} {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	ch := make(chan struct{})
+	n.waiters[name] = ch
+	return ch
+}
+
+func (n *deletionNotifier) notify(name string) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	if ch, ok := n.waiters[name]; ok {
+		close(ch)
+		delete(n.waiters, name)
+	}
+}
+
+func syncResources[T apiResource](ctx context.Context, cluster *discovery.Cluster, rcName string, existing []T, next []T, s syncer[T]) error {
+	var patched int
 	oldHashes := lo.SliceToMap(existing, func(rc T) (string, string) {
 		return rc.GetName(), rc.GetLabels()[resourceHashAnnotation]
 	})
 
 	// Apply new / existing resources
 	for _, rc := range next {
-		// Compute hash before applying annotation
 		h, err := hashResource(rc)
 		if err != nil {
 			return err
 		}
 		if h == oldHashes[rc.GetName()] {
-			// No need to apply
 			continue
 		}
-
-		// Set label, and apply
-		labels := rc.GetLabels()
-		if labels == nil {
-			labels = make(map[string]string)
-		}
-		labels[resourceHashAnnotation] = h
-		rc.SetLabels(labels)
+		setResourceHashAnnotation(rc, h)
 
 		b, err := marshalResource(rc)
 		if err != nil {
 			return err
 		}
 		_, err = s.Patch(ctx, rc.GetName(), types.ApplyPatchType, b, metav1.PatchOptions{Force: lo.ToPtr(true), FieldManager: fieldManager})
+		if err != nil {
+			log.WithError(err).Errorf("failed to patch %s/%s", rcName, rc.GetName())
+			continue // skip this resource if patch fails
+		}
+		patched++
+	}
+
+	pruned := pruneResources(ctx, cluster, rcName, existing, next, s)
+
+	if patched > 0 || pruned > 0 {
+		log.Debugf("patched %v %v, pruned %v %v", patched, rcName, pruned, rcName)
+	}
+	return nil
+}
+
+func syncResourcesWithReplace[T apiResource](ctx context.Context, cluster *discovery.Cluster, rcName string, existing []T, next []T, s syncer[T]) error {
+	var patched int
+	var replaced atomic.Int64
+	replacePool := pool.New().WithErrors().WithContext(ctx).WithMaxGoroutines(10)
+	oldHashes := lo.SliceToMap(existing, func(rc T) (string, string) {
+		return rc.GetName(), rc.GetLabels()[resourceHashAnnotation]
+	})
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	notifier := newDeletionNotifier()
+	watcher, err := s.Watch(ctx, metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+	defer watcher.Stop()
+	go func() {
+		for {
+			select {
+			case event := <-watcher.ResultChan():
+				if event.Type == watch.Deleted {
+					obj, ok := event.Object.(apiResource)
+					if !ok {
+						continue
+					}
+					notifier.notify(obj.GetName())
+				}
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	// Apply new / existing resources
+	for _, rc := range next {
+		h, err := hashResource(rc)
+		if err != nil {
+			return err
+		}
+		if h == oldHashes[rc.GetName()] {
+			continue
+		}
+		setResourceHashAnnotation(rc, h)
+
+		b, err := marshalResource(rc)
+		if err != nil {
+			return err
+		}
 		// For StatefulSets, delete the resource before applying again - StatefulSet has many immutable fields
 		// Example: StatefulSet.apps "nsapp-add177a080c4c78936e192" is invalid: spec: Forbidden: updates to statefulset spec for fields other than 'replicas', 'ordinals', 'template', 'updateStrategy', 'revisionHistoryLimit', 'persistentVolumeClaimRetentionPolicy' and 'minReadySeconds' are forbidden
+		_, err = s.Patch(ctx, rc.GetName(), types.ApplyPatchType, b, metav1.PatchOptions{Force: lo.ToPtr(true), FieldManager: fieldManager})
 		if err != nil {
-			if replace {
-				// replace may take a while, so run it in a goroutine
-				replacePool.Go(func() {
-					if err := replaceResource(ctx, rc, b, s); err != nil {
-						log.WithError(err).Errorf("failed to replace %s/%s", rcName, rc.GetName())
-					}
-					replaced.Add(1)
-				})
-			} else {
-				log.WithError(err).Errorf("failed to patch %s/%s", rcName, rc.GetName())
-			}
+			// Try to replace the resource if patch fails.
+			// This may take a while, so run it in a goroutine.
+			replacePool.Go(func(ctx context.Context) error {
+				err := replaceResource(ctx, rc, s, b, notifier)
+				if err != nil {
+					return err
+				}
+				replaced.Add(1)
+				return nil
+			})
 		} else {
 			patched++
 		}
 	}
 
-	replacePool.Wait()
-
-	// Prune old resources
-	for _, rc := range diff(existing, next) {
-		// On the controller cluster scale-up, ensure this shard does not delete resources controlled by a new shard
-		appID, ok := rc.GetLabels()[appIDLabel]
-		if ok && cluster.AssignedShardIndex(appID) != cluster.MyShardIndex() {
-			continue
-		}
-
-		err := s.Delete(ctx, rc.GetName(), metav1.DeleteOptions{PropagationPolicy: lo.ToPtr(metav1.DeletePropagationForeground)})
-		if err != nil {
-			log.WithError(err).Errorf("failed to delete %s/%s", rcName, rc.GetName())
-			continue // Skip if error occurred
-		}
-		pruned++
+	if err := replacePool.Wait(); err != nil {
+		log.WithError(err).Error("error occurred while waiting for replace")
+		// no return here, continue to prune old resources
 	}
+
+	pruned := pruneResources(ctx, cluster, rcName, existing, next, s)
 
 	if patched > 0 || replaced.Load() > 0 || pruned > 0 {
 		log.Debugf("patched %v %v, replaced %v %v, pruned %v %v", patched, rcName, replaced.Load(), rcName, pruned, rcName)
@@ -131,31 +210,44 @@ func syncResources[T apiResource](ctx context.Context, cluster *discovery.Cluste
 	return nil
 }
 
-func replaceResource[T apiResource](ctx context.Context, rc T, data []byte, s syncer[T]) error {
-	err := s.Delete(ctx, rc.GetName(), metav1.DeleteOptions{PropagationPolicy: lo.ToPtr(metav1.DeletePropagationForeground)})
-	if err != nil {
-		return errors.Wrapf(err, "delete %s/%s before re-apply", rc.GetName(), rc.GetLabels()[resourceHashAnnotation])
-	}
-
-	// Wait for the resource to be deleted
-	interval := 100 * time.Millisecond
-	timeout := 30 * time.Second
-	err = wait.PollUntilContextTimeout(ctx, interval, timeout, true, func(ctx context.Context) (bool, error) {
-		_, err := s.Get(ctx, rc.GetName(), metav1.GetOptions{})
-		if apierrors.IsNotFound(err) {
-			return true, nil // Resource is deleted
+func pruneResources[T apiResource](ctx context.Context, cluster *discovery.Cluster, rcName string, existing []T, next []T, s syncer[T]) int {
+	pruned := 0
+	for _, rc := range diff(existing, next) {
+		appID, ok := rc.GetLabels()[appIDLabel]
+		if ok && cluster.AssignedShardIndex(appID) != cluster.MyShardIndex() {
+			continue
 		}
-		return false, err
-	})
-	if err != nil {
-		return errors.Wrapf(err, "waiting for %s/%s to be deleted", rc.GetName(), rc.GetLabels()[resourceHashAnnotation])
+		err := s.Delete(ctx, rc.GetName(), metav1.DeleteOptions{PropagationPolicy: lo.ToPtr(metav1.DeletePropagationForeground)})
+		if err != nil {
+			log.WithError(err).Errorf("failed to delete %s/%s", rcName, rc.GetName())
+			continue // skip this resource if delete fails
+		}
+		pruned++
+	}
+	return pruned
+}
+
+func replaceResource[T apiResource](
+	ctx context.Context,
+	rc T,
+	s syncer[T],
+	data []byte,
+	notifier *deletionNotifier,
+) error {
+	ch := notifier.add(rc.GetName())
+	_ = s.Delete(ctx, rc.GetName(), metav1.DeleteOptions{PropagationPolicy: lo.ToPtr(metav1.DeletePropagationForeground)})
+
+	select {
+	case <-ch: // Wait for the resource to be deleted
+	// 2 minutes timeout
+	// This timeout provides sufficient buffer for most deletion scenarios while
+	// preventing indefinite waits for stuck resources.
+	case <-time.After(2 * time.Minute):
+		return errors.New("timeout while waiting for resource to be deleted")
+	case <-ctx.Done():
+		return ctx.Err()
 	}
 
-	// Try again
-	_, err = s.Patch(ctx, rc.GetName(), types.ApplyPatchType, data, metav1.PatchOptions{Force: lo.ToPtr(true), FieldManager: fieldManager})
-	if err != nil {
-		return errors.Wrapf(err, "re-apply %s/%s after deletion", rc.GetName(), rc.GetLabels()[resourceHashAnnotation])
-	}
-
-	return nil
+	_, err := s.Patch(ctx, rc.GetName(), types.ApplyPatchType, data, metav1.PatchOptions{Force: lo.ToPtr(true), FieldManager: fieldManager})
+	return err
 }

--- a/pkg/infrastructure/backend/k8simpl/synchronize.go
+++ b/pkg/infrastructure/backend/k8simpl/synchronize.go
@@ -94,23 +94,23 @@ func (b *Backend) Synchronize(ctx context.Context, s *domain.DesiredState) error
 	}
 
 	// Synchronize resources
-	err = syncResources[*appsv1.StatefulSet](ctx, b.cluster, "statefulsets", old.statefulSets, next.statefulSets, b.client.AppsV1().StatefulSets(b.config.Namespace), true)
+	err = syncResourcesWithReplace[*appsv1.StatefulSet](ctx, b.cluster, "statefulsets", old.statefulSets, next.statefulSets, b.client.AppsV1().StatefulSets(b.config.Namespace))
 	if err != nil {
 		return errors.Wrap(err, "failed to sync stateful sets")
 	}
-	err = syncResources[*v1.Secret](ctx, b.cluster, "secrets", old.secrets, next.secrets, b.client.CoreV1().Secrets(b.config.Namespace), false)
+	err = syncResources[*v1.Secret](ctx, b.cluster, "secrets", old.secrets, next.secrets, b.client.CoreV1().Secrets(b.config.Namespace))
 	if err != nil {
 		return errors.Wrap(err, "failed to sync secrets")
 	}
-	err = syncResources[*v1.Service](ctx, b.cluster, "services", old.services, next.services, b.client.CoreV1().Services(b.config.Namespace), false)
+	err = syncResources[*v1.Service](ctx, b.cluster, "services", old.services, next.services, b.client.CoreV1().Services(b.config.Namespace))
 	if err != nil {
 		return errors.Wrap(err, "failed to sync services")
 	}
-	err = syncResources[*traefikv1alpha1.Middleware](ctx, b.cluster, "middlewares", old.middlewares, next.middlewares, b.traefikClient.Middlewares(b.config.Namespace), false)
+	err = syncResources[*traefikv1alpha1.Middleware](ctx, b.cluster, "middlewares", old.middlewares, next.middlewares, b.traefikClient.Middlewares(b.config.Namespace))
 	if err != nil {
 		return errors.Wrap(err, "failed to sync middlewares")
 	}
-	err = syncResources[*traefikv1alpha1.IngressRoute](ctx, b.cluster, "ingressroutes", old.ingressRoutes, next.ingressRoutes, b.traefikClient.IngressRoutes(b.config.Namespace), false)
+	err = syncResources[*traefikv1alpha1.IngressRoute](ctx, b.cluster, "ingressroutes", old.ingressRoutes, next.ingressRoutes, b.traefikClient.IngressRoutes(b.config.Namespace))
 	if err != nil {
 		return errors.Wrap(err, "failed to sync ingressroutes")
 	}
@@ -130,7 +130,7 @@ func (b *Backend) SynchronizeShared(ctx context.Context, s *domain.DesiredStateL
 	}
 
 	// Synchronize resources
-	err = syncResources[*certmanagerv1.Certificate](ctx, b.cluster, "certificates", old.certificates, next.certificates, b.certManagerClient.CertmanagerV1().Certificates(b.config.Namespace), false)
+	err = syncResources[*certmanagerv1.Certificate](ctx, b.cluster, "certificates", old.certificates, next.certificates, b.certManagerClient.CertmanagerV1().Certificates(b.config.Namespace))
 	if err != nil {
 		return errors.Wrap(err, "failed to sync certificates")
 	}


### PR DESCRIPTION
## なぜやるか
#1090 で修正したつもりだったが、リソースが削除されたかの確認にpollingを使う実装だとRate Limitに引っかかってしまった
```
time="2025-08-07T08:50:41Z" level=error msg="failed to replace statefulsets/nsapp-a27937f8d6b9f224fcbff8" error="waiting for nsapp-a27937f8d6b9f224fcbff8/695551d624ea1e5a to be deleted: client rate limiter Wait returned an error: rate: Wait(n=1) would exceed context deadline"
```

## やったこと
pollingをやめ、watch APIを使い、リソースの削除を監視する

## やらなかったこと

## 資料
