### PR TITLE
fix: inherit secrets

### DIFF
--- a/.github/workflows/release-helm.yaml
+++ b/.github/workflows/release-helm.yaml
@@ -74,3 +74,18 @@ jobs:
         run: |
           cd charts
           ./publish.sh ${{ inputs.chart }} oci://ghcr.io/${{ env.REGISTRY_USER }}/charts
+
+  dispatch-renovate:
+    runs-on: ubuntu-latest
+    needs: [ release ]
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.DISPATCH_PAT }}
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: 'traPtitech',
+              repo: 'manifest',
+              workflow_id: 'renovate.yaml',
+              ref: 'main'
+            })

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -97,19 +97,3 @@ jobs:
           # tag_name will default in the current branch name for workflow_dispatch via workflow_call, so we're passing tag value via inputs manually.
           tag_name: ${{ inputs.ref_name || github.ref_name }}
           generate_release_notes: true
-
-  dispatch-renovate:
-    name: Dispatch Renovate
-    runs-on: ubuntu-latest
-    needs: [ image, release ]
-    steps:
-      - uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.DISPATCH_PAT }}
-          script: |
-            await github.rest.actions.createWorkflowDispatch({
-              owner: 'traPtitech',
-              repo: 'manifest',
-              workflow_id: 'renovate.yaml',
-              ref: 'main'
-            })

--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -77,6 +77,7 @@ jobs:
     uses: ./.github/workflows/release.yaml
     with:
       ref_name: ${{ needs.tag.outputs.new-tag }}
+    secrets: inherit
 
   # Bump and release helm chart on app release
   helm-tag:
@@ -84,3 +85,4 @@ jobs:
     uses: ./.github/workflows/release-helm.yaml
     with:
       strategy: ${{ inputs.strategy }}
+    secrets: inherit


### PR DESCRIPTION

## なぜやるか
https://github.com/traPtitech/NeoShowcase/actions/runs/16960526932/job/48072361393

## やったこと
- secretsを参照していたのを忘れていたのでsecrets: inheritをとりあえずして参照できるように
- dispatch renovateをhelmリリース後のところへ移動 (https://github.com/traPtitech/manifest/pull/1051 がマージされる前提だが、renovateが更新するのはdockerのタグではなくhelmのバージョンになっていくため)

## やらなかったこと
<!-- 次に回したことなど、あえてやらなかったことがあれば説明してね -->

## 資料
<!-- 参考資料へのリンクなど -->
<!-- 例: Figmaの該当デザインのリンク、issueへのリンク、その他ディスカッションへのリンク -->
