### PR TITLE
fix: add SSH key loading for helm chart push

### DIFF
--- a/.github/workflows/release-helm.yaml
+++ b/.github/workflows/release-helm.yaml
@@ -58,6 +58,16 @@ jobs:
           VERSION=$(grep '^version:' ./charts/${{ inputs.chart }}/Chart.yaml | cut -d ' ' -f 2 | tr -d '"')
           echo "new-raw=${VERSION}" >> $GITHUB_OUTPUT
 
+      - name: Load push key
+        run: |
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          echo "${{ secrets.HELM_PUSH_KEY }}" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+
+          # Use ssh instead of https (github token)
+          git remote set-url origin git@github.com:${{ github.repository }}.git
+
       - name: Commit and push helm changes
         run: |
           git add charts/${{ inputs.chart }}/Chart.yaml


### PR DESCRIPTION
## なぜやるか
https://github.com/traPtitech/NeoShowcase/actions/runs/16960526932/job/48072020853

## やったこと
SSH鍵をsecretとdeploy keyに登録して、pushにその鍵を使うようにした
https://github.com/traPtitech/NeoShowcase/pull/1095#issuecomment-3187860363

## やらなかったこと

## 資料