### PR TITLE
feat(helm): make imagePullPolicy configurable for ns components

### DIFF
--- a/.local-manifest/ns-system/values.yaml
+++ b/.local-manifest/ns-system/values.yaml
@@ -1,5 +1,7 @@
 global:
   appVersionOverride: main
+  image:
+    pullPolicy: Never
 
 common:
   logLevel: debug
@@ -88,12 +90,12 @@ builder:
     buildkitd.toml: |
       [registry."registry.local"]
       http = true
-      
+
       [worker.oci]
       enabled = true
       gc = true
       gckeepstorage = 9000
-      
+
       [[worker.oci.gcpolicy]]
       all = true
       keepBytes = 1024000000

--- a/charts/neoshowcase/templates/builder/deployment.yaml
+++ b/charts/neoshowcase/templates/builder/deployment.yaml
@@ -56,7 +56,7 @@ spec:
       initContainers:
         - name: buildpack-install
           image: {{ include "image.builder" $ }}
-          imagePullPolicy: Always
+          imagePullPolicy: {{ .imagePullPolicy | default $.Values.global.image.pullPolicy }}
           command:
             - cp
             - /app/ns
@@ -68,7 +68,7 @@ spec:
       containers:
         - name: buildpack
           image: {{ .buildpack.image }}
-          imagePullPolicy: Always
+          imagePullPolicy: {{ .buildpack.imagePullPolicy | default $.Values.global.image.pullPolicy }}
           command:
             - /ns-bin/ns
             - buildpack-helper
@@ -88,7 +88,7 @@ spec:
 
         - name: buildkit
           image: {{ .buildkit.image }}
-          imagePullPolicy: Always
+          imagePullPolicy: {{ .buildkit.imagePullPolicy | default $.Values.global.image.pullPolicy }}
           args:
             - --addr
             - unix:///run/user/1000/buildkit/buildkitd.sock
@@ -127,7 +127,7 @@ spec:
 
         - name: builder
           image: {{ include "image.builder" $ }}
-          imagePullPolicy: Always
+          imagePullPolicy: {{ .imagePullPolicy | default $.Values.global.image.pullPolicy }}
           args:
             - --loglevel={{ $.Values.common.logLevel }}
             - --config=/opt/config/ns.yaml

--- a/charts/neoshowcase/templates/controller/deployment.yaml
+++ b/charts/neoshowcase/templates/controller/deployment.yaml
@@ -51,7 +51,7 @@ spec:
       containers:
         - name: controller
           image: {{ include "image.controller" $ }}
-          imagePullPolicy: Always
+          imagePullPolicy: {{ .imagePullPolicy | default $.Values.global.image.pullPolicy }}
           args:
             - --loglevel={{ $.Values.common.logLevel }}
             - --config=/opt/config/ns.yaml

--- a/charts/neoshowcase/templates/dashboard/deployment.yaml
+++ b/charts/neoshowcase/templates/dashboard/deployment.yaml
@@ -33,7 +33,7 @@ spec:
       containers:
         - name: dashboard
           image: {{ include "image.dashboard" $ }}
-          imagePullPolicy: Always
+          imagePullPolicy: {{ .imagePullPolicy | default $.Values.global.image.pullPolicy }}
           ports:
             - name: http
               containerPort: 80

--- a/charts/neoshowcase/templates/gateway/deployment.yaml
+++ b/charts/neoshowcase/templates/gateway/deployment.yaml
@@ -50,7 +50,7 @@ spec:
       containers:
         - name: gateway
           image: {{ include "image.gateway" $ }}
-          imagePullPolicy: Always
+          imagePullPolicy: {{ .imagePullPolicy | default $.Values.global.image.pullPolicy }}
           args:
             - --loglevel={{ $.Values.common.logLevel }}
             - --config=/opt/config/ns.yaml

--- a/charts/neoshowcase/templates/gitea-integration/stateful-set.yaml
+++ b/charts/neoshowcase/templates/gitea-integration/stateful-set.yaml
@@ -46,7 +46,7 @@ spec:
       containers:
         - name: gitea-integration
           image: {{ include "image.gitea-integration" $ }}
-          imagePullPolicy: Always
+          imagePullPolicy: {{ .imagePullPolicy | default $.Values.global.image.pullPolicy }}
           args:
             - --loglevel={{ $.Values.common.logLevel }}
             - --config=/opt/config/ns.yaml

--- a/charts/neoshowcase/templates/sablier/deployment.yaml
+++ b/charts/neoshowcase/templates/sablier/deployment.yaml
@@ -41,6 +41,7 @@ spec:
       containers:
         - name: sablier
           image: {{ include "image.sablier" $ }}
+          imagePullPolicy: {{ .imagePullPolicy | default $.Values.global.image.pullPolicy }}
           ports:
             - name: http
               containerPort: 10000

--- a/charts/neoshowcase/templates/ssgen/stateful-set.yaml
+++ b/charts/neoshowcase/templates/ssgen/stateful-set.yaml
@@ -63,7 +63,7 @@ spec:
       containers:
         - name: ssgen
           image: {{ include "image.ssgen" $ }}
-          imagePullPolicy: Always
+          imagePullPolicy: {{ .imagePullPolicy | default $.Values.global.image.pullPolicy }}
           args:
             - --loglevel={{ $.Values.common.logLevel }}
             - --config=/opt/config/ns.yaml
@@ -125,7 +125,7 @@ spec:
 
         - name: caddy
           image: {{ .caddy.image }}
-          imagePullPolicy: Always
+          imagePullPolicy: {{ .caddy.imagePullPolicy | default $.Values.global.image.pullPolicy }}
           ports:
             - name: http
               containerPort: 80

--- a/charts/neoshowcase/values.yaml
+++ b/charts/neoshowcase/values.yaml
@@ -3,6 +3,8 @@ global:
   image:
     repository: ghcr.io/traptitech/
     prefix: ns-
+    # Default image pull policy for all NeoShowcase components
+    pullPolicy: Always
   # If specified, overrides the chart app version.
   # Used by NeoShowcase image tags.
   appVersionOverride: ""
@@ -215,12 +217,18 @@ builder:
   tolerations: []
   topologySpreadConstraints: []
   resources: {}
+  # imagePullPolicy for builder component
+  imagePullPolicy: ""
   buildpack:
     image: paketobuildpacks/builder:full
     resources: {}
+    # imagePullPolicy for buildpack image (defaults to Always for build images)
+    imagePullPolicy: Always
   buildkit:
     image: moby/buildkit:rootless
     resources: {}
+    # imagePullPolicy for buildkit image (defaults to Always for build images)
+    imagePullPolicy: Always
     buildkitd.toml: ""
 
 # ns-controller component
@@ -230,6 +238,8 @@ controller:
   tolerations: []
   topologySpreadConstraints: []
   resources: {}
+  # imagePullPolicy for controller component
+  imagePullPolicy: ""
   ssh:
     host: ns.trap.jp
     port: 2201
@@ -241,6 +251,8 @@ dashboard:
   tolerations: []
   topologySpreadConstraints: []
   resources: {}
+  # imagePullPolicy for dashboard component
+  imagePullPolicy: ""
 
 # ns-gateway component
 gateway:
@@ -249,6 +261,8 @@ gateway:
   tolerations: []
   topologySpreadConstraints: []
   resources: {}
+  # imagePullPolicy for gateway component
+  imagePullPolicy: ""
 
 # ns-gitea-integration component
 giteaIntegration:
@@ -257,6 +271,8 @@ giteaIntegration:
   tolerations: []
   topologySpreadConstraints: []
   resources: {}
+  # imagePullPolicy for gitea-integration component
+  imagePullPolicy: ""
   url: https://git.trap.jp
 
 # sablier component starts user pods on demand.
@@ -267,6 +283,8 @@ sablier:
   tolerations: []
   topologySpreadConstraints: []
   resources: {}
+  # imagePullPolicy for sablier component
+  imagePullPolicy: ""
   sessionDuration: 1h
   dynamic:
     theme: neoshowcase
@@ -280,12 +298,16 @@ ssgen:
   tolerations: []
   topologySpreadConstraints: []
   resources: {}
+  # imagePullPolicy for ssgen component
+  imagePullPolicy: ""
   pvc:
     storageClassName: ""
     storage: 1Gi
   caddy:
     image: caddy:2-alpine
     resources: {}
+    # imagePullPolicy for caddy image (defaults to Always)
+    imagePullPolicy: Always
 
 # ingressRoute renders IngressRoute resource, if enabled.
 ingressRoute:


### PR DESCRIPTION
## なぜやるか
手元でk3dを使って開発をする際、imagePullPolicyがAlwaysだと、手元でビルドしたものではなく、registryの最新のイメージをpullして使用してしまうため。

## やったこと
imagePullPolicyを設定できるようにした

## やらなかったこと

## 資料
