### PR TITLE
helmチャートのドキュメントを追加

### DIFF
--- a/charts/neoshowcase/README.md
+++ b/charts/neoshowcase/README.md
@@ -1,0 +1,44 @@
+# neoshowcase
+
+![Version: 1.9.4](https://img.shields.io/badge/Version-1.9.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.9.4](https://img.shields.io/badge/AppVersion-1.9.4-informational?style=flat-square)
+
+NeoShowcase is a PaaS application for Digital Creators Club traP.
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| app | object | `{"imagePullSecret":"","labels":[],"namespace":"ns-apps","nodeSelector":{},"resources":{},"routing":{"traefik":{"priorityOffset":0},"type":"traefik"},"service":{"ipFamilies":[],"ipFamilyPolicy":""},"tolerations":[],"topologySpreadConstraints":[]}` | app defines user app pod configurations. |
+| auth | object | `{"avatarBaseURL":"https://q.trap.jp/api/v3/public/icon/","header":"X-Forwarded-User"}` | auth defines user authentication. |
+| auth.avatarBaseURL | string | `"https://q.trap.jp/api/v3/public/icon/"` | avatarBaseURL is used to display user icons in the dashboard. |
+| auth.header | string | `"X-Forwarded-User"` | header defines the name of the header auth. |
+| builder | object | `{"buildkit":{"buildkitd.toml":"","image":"moby/buildkit:rootless","resources":{}},"buildpack":{"image":"paketobuildpacks/builder:full","resources":{}},"nodeSelector":{},"replicas":1,"resources":{},"tolerations":[],"topologySpreadConstraints":[]}` | ns-builder component |
+| common | object | `{"additionalLinks":[{"name":"Wiki","url":"https://wiki.trap.jp/services/NeoShowcase"},{"name":"DB Admin","url":"https://adminer.ns.trap.jp/"}],"additionalVolumeMounts":[],"additionalVolumes":[],"db":{"database":"neoshowcase","host":"mariadb.db.svc.cluster.local","port":3306,"username":"root"},"image":{"namePrefix":"ns-apps/","registry":{"addr":"registry.ns.trap.jp","scheme":"https","username":"robot$neoshowcase"},"tmpNamePrefix":"ns-apps-tmp/"},"logLevel":"info","storage":{"local":{"dir":"/data"},"s3":{"bucket":"neoshowcase","region":"ap-northeast-1"},"type":"s3"}}` | common defines various settings for use by all NeoShowcase components. |
+| common.additionalLinks | list | `[{"name":"Wiki","url":"https://wiki.trap.jp/services/NeoShowcase"},{"name":"DB Admin","url":"https://adminer.ns.trap.jp/"}]` | Links to be displayed in the dashboard. |
+| common.additionalVolumes | list | `[]` | Additional mounts to NeoShowcase component containers |
+| common.db | object | `{"database":"neoshowcase","host":"mariadb.db.svc.cluster.local","port":3306,"username":"root"}` | db is used by NeoShowcase system components |
+| common.image | object | `{"namePrefix":"ns-apps/","registry":{"addr":"registry.ns.trap.jp","scheme":"https","username":"robot$neoshowcase"},"tmpNamePrefix":"ns-apps-tmp/"}` | image is used to store user app images. |
+| common.logLevel | string | `"info"` | Available log levels: trace, debug, info, warn, or error |
+| common.storage | object | `{"local":{"dir":"/data"},"s3":{"bucket":"neoshowcase","region":"ap-northeast-1"},"type":"s3"}` | storage is used by NeoShowcase system components |
+| controller | object | `{"nodeSelector":{},"replicas":1,"resources":{},"ssh":{"host":"ns.trap.jp","port":2201},"tolerations":[],"topologySpreadConstraints":[]}` | ns-controller component |
+| dashboard | object | `{"nodeSelector":{},"replicas":1,"resources":{},"tolerations":[],"topologySpreadConstraints":[]}` | ns-dashboard component |
+| domains | list | `[]` | domains define available domains to be used by user apps. For more, see pkg/infrastructure/k8simpl/config.go. |
+| gateway | object | `{"nodeSelector":{},"replicas":1,"resources":{},"tolerations":[],"topologySpreadConstraints":[]}` | ns-gateway component |
+| giteaIntegration | object | `{"enabled":false,"nodeSelector":{},"resources":{},"tolerations":[],"topologySpreadConstraints":[],"url":"https://git.trap.jp"}` | ns-gitea-integration component |
+| global.appVersionOverride | string | `""` | If specified, overrides the chart app version. Used by NeoShowcase image tags. |
+| global.image | object | `{"prefix":"ns-","repository":"ghcr.io/traptitech/"}` | image defines NeoShowcase image config. |
+| ingressRoute | object | `{"enabled":true,"entrypoints":["web"],"host":"ns.trap.jp","middlewares":[],"tls":{"secretName":""}}` | ingressRoute renders IngressRoute resource, if enabled. |
+| known_hosts | object | `{"additionalContent":""}` | known_hosts is mounted into builder, controller, and gateway to clone user repositories. |
+| observability | object | `{"log":{"loki":{"endpoint":"http://loki.monitor.svc.cluster.local:3100","queryTemplate":"{namespace=\"ns-apps\",pod=\"nsapp-{{ .App.ID }}-0\"}"},"type":"victorialogs","victorialogs":{"endpoint":"http://vl-victoria-logs-single-server.victoria-logs.svc.cluster.local:9428","queryTemplate":"{namespace=\"ns-apps\",pod=\"nsapp-{{ .App.ID }}-0\"}"}},"metrics":{"prometheus":{"endpoint":"http://victoria-metrics.monitor.svc.cluster.local:8428","queries":[{"name":"CPU","template":"rate(container_cpu_user_seconds_total{namespace=\"ns-apps\", pod=\"nsapp-{{ .App.ID }}-0\", container=\"app\"}[5m]) + rate(container_cpu_system_seconds_total{namespace=\"ns-apps\", pod=\"nsapp-{{ .App.ID }}-0\", container=\"app\"}[5m])"},{"name":"Memory","template":"container_memory_usage_bytes{namespace=\"ns-apps\", pod=\"nsapp-{{ .App.ID }}-0\", container=\"app\"} + container_memory_swap{namespace=\"ns-apps\", pod=\"nsapp-{{ .App.ID }}-0\", container=\"app\"}"}]},"type":"prometheus"}}` | observability (o11y) defines user apps' o11y configuration to be viewed from the dashboard. |
+| ports | list | `[]` | ports define available port-forward ports to be used by user apps. For more, see pkg/infrastructure/k8simpl/config.go. |
+| sablier | object | `{"blocking":{"timeout":"1m"},"dynamic":{"theme":"neoshowcase"},"enabled":true,"nodeSelector":{},"resources":{},"sessionDuration":"1h","tolerations":[],"topologySpreadConstraints":[]}` | sablier component starts user pods on demand. |
+| secret | object | `{"keys":{"existingName":"ns-keys","keyName":"id_ed25519"},"ns":{"existingName":"ns"}}` | secret defines secret names to be used by NeoShowcase components. |
+| secret.keys | object | `{"existingName":"ns-keys","keyName":"id_ed25519"}` | Keys are used by gateway and controller to clone user repositories. The corresponding public key is intended to be set to an admin deploy-key of an external Gitea instance. |
+| secret.keys.keyName | string | `"id_ed25519"` | Only ed25519 type is supported for now. |
+| ssgen | object | `{"caddy":{"image":"caddy:2-alpine","resources":{}},"nodeSelector":{},"pvc":{"storage":"1Gi","storageClassName":""},"replicas":2,"resources":{},"tolerations":[],"topologySpreadConstraints":[]}` | ns-ssgen component |
+| tls | object | `{"certManager":{"issuer":{"kind":"ClusterIssuer","name":"cluster-issuer"},"wildcard":{"domains":[]}},"type":"cert-manager"}` | tls defines tls setting for user app ingress. For more, see pkg/infrastructure/k8simpl/config.go. |
+| userMariaDB | object | `{"adminUser":"root","host":"mariadb.db.svc.cluster.local","port":3306}` | userMariaDB is used by user apps. |
+| userMongoDB | object | `{"adminUser":"root","host":"mongo.db.svc.cluster.local","port":27017}` | userMongoDB is used by user apps. |
+
+----------------------------------------------
+Autogenerated from chart metadata using [helm-docs v1.14.2](https://github.com/norwoodj/helm-docs/releases/v1.14.2)

--- a/charts/neoshowcase/values.yaml
+++ b/charts/neoshowcase/values.yaml
@@ -1,24 +1,25 @@
 global:
-  # image defines NeoShowcase image config.
+  # -- image defines NeoShowcase image config.
   image:
     repository: ghcr.io/traptitech/
     prefix: ns-
-  # If specified, overrides the chart app version.
+  # -- If specified, overrides the chart app version.
   # Used by NeoShowcase image tags.
   appVersionOverride: ""
 
-# common defines various settings for use by all NeoShowcase components.
+# -- common defines various settings for use by all NeoShowcase components.
 common:
-  # Available log levels: trace, debug, info, warn, or error
+  # -- Available log levels: trace, debug, info, warn, or error
   logLevel: info
 
+  # -- Links to be displayed in the dashboard.
   additionalLinks:
     - name: Wiki
       url: https://wiki.trap.jp/services/NeoShowcase
     - name: DB Admin
       url: https://adminer.ns.trap.jp/
 
-  # db is used by NeoShowcase system components
+  # -- db is used by NeoShowcase system components
   db:
     host: mariadb.db.svc.cluster.local
     port: 3306
@@ -26,7 +27,7 @@ common:
     # password: <defined by secret>
     database: neoshowcase
 
-  # storage is used by NeoShowcase system components
+  # -- storage is used by NeoShowcase system components
   storage:
     type: s3
     local:
@@ -38,7 +39,7 @@ common:
       region: ap-northeast-1
       # endpoint: https://example.com
 
-  # image is used to store user app images.
+  # -- image is used to store user app images.
   image:
     registry:
       scheme: https
@@ -48,38 +49,40 @@ common:
     namePrefix: ns-apps/
     tmpNamePrefix: ns-apps-tmp/
 
-  # Additional mounts to NeoShowcase component containers
-  additionalVolumes: []
+  # -- Additional mounts to NeoShowcase component containers
+  additionalVolumes:
+    []
     # - name: project
     #   hostPath:
     #     path: /work
-  additionalVolumeMounts: []
+  additionalVolumeMounts:
+    []
     # - name: project
     #   subPath: .local-dev/local-storage
     #   mountPath: /data
 
-# auth defines user authentication.
+# -- auth defines user authentication.
 auth:
-  # header defines the name of the header auth.
+  # -- header defines the name of the header auth.
   header: X-Forwarded-User
-  # avatarBaseURL is used to display user icons in the dashboard.
+  # -- avatarBaseURL is used to display user icons in the dashboard.
   avatarBaseURL: https://q.trap.jp/api/v3/public/icon/
 
-# userMariaDB is used by user apps.
+# -- userMariaDB is used by user apps.
 userMariaDB:
   host: mariadb.db.svc.cluster.local
   port: 3306
   adminUser: root
   # adminPassword: <defined by secret>
 
-# userMongoDB is used by user apps.
+# -- userMongoDB is used by user apps.
 userMongoDB:
   host: mongo.db.svc.cluster.local
   port: 27017
   adminUser: root
   # adminPassword: <defined by secret>
 
-# secret defines secret names to be used by NeoShowcase components.
+# -- secret defines secret names to be used by NeoShowcase components.
 secret:
   # Expected keys:
   #  db-password: Used by NeoShowcase system
@@ -92,18 +95,18 @@ secret:
   #  controller-token: Token used by components to access ns-controller
   ns:
     existingName: ns
-  # Keys are used by gateway and controller to clone user repositories.
+  # -- Keys are used by gateway and controller to clone user repositories.
   # The corresponding public key is intended to be set to an admin deploy-key of an external Gitea instance.
   keys:
     existingName: ns-keys
-    # Only ed25519 type is supported for now.
+    # -- Only ed25519 type is supported for now.
     keyName: id_ed25519
 
-# known_hosts is mounted into builder, controller, and gateway to clone user repositories.
+# -- known_hosts is mounted into builder, controller, and gateway to clone user repositories.
 known_hosts:
   additionalContent: ""
 
-# domains define available domains to be used by user apps.
+# -- domains define available domains to be used by user apps.
 # For more, see pkg/infrastructure/k8simpl/config.go.
 domains: []
 #  - domain: "*.trap.show"
@@ -117,7 +120,7 @@ domains: []
 #        - name: auth-trap-show-hard
 #          namespace: auth
 
-# tls defines tls setting for user app ingress.
+# -- tls defines tls setting for user app ingress.
 # For more, see pkg/infrastructure/k8simpl/config.go.
 tls:
   type: cert-manager
@@ -126,10 +129,11 @@ tls:
       kind: ClusterIssuer
       name: cluster-issuer
     wildcard:
-      domains: []
+      domains:
+        []
         # - "*.trap.show"
 
-# ports define available port-forward ports to be used by user apps.
+# -- ports define available port-forward ports to be used by user apps.
 # For more, see pkg/infrastructure/k8simpl/config.go.
 ports: []
 #  - startPort: 39000
@@ -139,7 +143,7 @@ ports: []
 #    endPort: 39999
 #    protocol: udp
 
-# observability (o11y) defines user apps' o11y configuration to be viewed from the dashboard.
+# -- observability (o11y) defines user apps' o11y configuration to be viewed from the dashboard.
 observability:
   log:
     type: victorialogs
@@ -165,22 +169,26 @@ observability:
             container_memory_usage_bytes{namespace="ns-apps", pod="nsapp-{{ .App.ID }}-0", container="app"}
             + container_memory_swap{namespace="ns-apps", pod="nsapp-{{ .App.ID }}-0", container="app"}
 
-# app defines user app pod configurations.
+# -- app defines user app pod configurations.
 app:
   namespace: ns-apps
-  imagePullSecret: ''
-  labels: []
+  imagePullSecret: ""
+  labels:
+    []
     # Example to enable ArgoCD orphaned resource monitoring:
     # - key: app.kubernetes.io/instance
     #   value: ns-apps
-  nodeSelector: {}
+  nodeSelector:
+    {}
     # - key: kubernetes.io/arch
     #   value: amd64
-  tolerations: []
+  tolerations:
+    []
     # - key: ns.trap.jp/worker
     #   operator: Exists
     #   effect: NoSchedule
-  topologySpreadConstraints: []
+  topologySpreadConstraints:
+    []
     # - maxSkew: 1
     #   topologyKey: kubernetes.io/hostname
     #   whenUnsatisfiable: DoNotSchedule
@@ -190,7 +198,8 @@ app:
     #         value: "true"
     #   nodeAffinityPolicy: Honor
     #   nodeTaintsPolicy: Ignore
-  resources: {}
+  resources:
+    {}
     # requests:
     #   cpu: 10m
     #   memory: 50Mi
@@ -198,7 +207,8 @@ app:
     #   cpu: "1.6"
     #   memory: 1Gi
   service:
-    ipFamilies: []
+    ipFamilies:
+      []
       # - IPv4
       # - IPv6
     # Allowed values: "", "SingleStack", "PreferDualStack", "RequireDualStack"
@@ -208,7 +218,7 @@ app:
     traefik:
       priorityOffset: 0
 
-# ns-builder component
+# -- ns-builder component
 builder:
   replicas: 1
   nodeSelector: {}
@@ -223,7 +233,7 @@ builder:
     resources: {}
     buildkitd.toml: ""
 
-# ns-controller component
+# -- ns-controller component
 controller:
   replicas: 1
   nodeSelector: {}
@@ -234,7 +244,7 @@ controller:
     host: ns.trap.jp
     port: 2201
 
-# ns-dashboard component
+# -- ns-dashboard component
 dashboard:
   replicas: 1
   nodeSelector: {}
@@ -242,7 +252,7 @@ dashboard:
   topologySpreadConstraints: []
   resources: {}
 
-# ns-gateway component
+# -- ns-gateway component
 gateway:
   replicas: 1
   nodeSelector: {}
@@ -250,7 +260,7 @@ gateway:
   topologySpreadConstraints: []
   resources: {}
 
-# ns-gitea-integration component
+# -- ns-gitea-integration component
 giteaIntegration:
   enabled: false
   nodeSelector: {}
@@ -259,7 +269,7 @@ giteaIntegration:
   resources: {}
   url: https://git.trap.jp
 
-# sablier component starts user pods on demand.
+# -- sablier component starts user pods on demand.
 sablier:
   # If enabled, requires "experimental.plugins.sablier" configuration on the traefik instance.
   enabled: true
@@ -273,7 +283,7 @@ sablier:
   blocking:
     timeout: 1m
 
-# ns-ssgen component
+# -- ns-ssgen component
 ssgen:
   replicas: 2
   nodeSelector: {}
@@ -287,7 +297,7 @@ ssgen:
     image: caddy:2-alpine
     resources: {}
 
-# ingressRoute renders IngressRoute resource, if enabled.
+# -- ingressRoute renders IngressRoute resource, if enabled.
 ingressRoute:
   enabled: true
   host: ns.trap.jp
@@ -297,6 +307,7 @@ ingressRoute:
     # secretName defines IngressRoute tls.secretName.
     # Set to empty string to disable tls config.
     secretName: ""
-  middlewares: []
+  middlewares:
+    []
     # - name: ns-auth-dev
     #   namespace: auth


### PR DESCRIPTION
<!-- この形のコメントは消してね -->

## なぜやるか

values.yamlを直接見るより、mdを見たほうがわかりやすいから。

## やったこと

values.yamlのコメントを調整し、[helm-docs](https://github.com/norwoodj/helm-docs)を用いてドキュメントを生成した。

## やらなかったこと

もし実用するなら、CIや[Pre-commit hook](https://github.com/norwoodj/helm-docs#pre-commit-hook)を用いてドキュメントを最新の状態に保つ必要がある。

## 資料

[norwoodj/helm-docs](https://github.com/norwoodj/helm-docs)
