### PR TITLE
Add helm CI

### DIFF
--- a/.github/workflows/ci-helm.yaml
+++ b/.github/workflows/ci-helm.yaml
@@ -16,6 +16,8 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@v4
 
+      # Python is required because `ct lint` runs Yamale (https://github.com/23andMe/Yamale) and
+      # yamllint (https://github.com/adrienverge/yamllint) which require Python
       - uses: actions/setup-python@v5
         with:
           python-version: '3.x'


### PR DESCRIPTION
## なぜやるか
helm chartに間違いがあっても気づかずリリースしてしまうことがある
これをCIで防ぐようにするため

## やったこと
`chart-testing`を使用して、lintを実行する

## やらなかったこと

## 資料
