### PR TITLE
fix(docker-compose): fix cadvisor image tag

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -367,7 +367,7 @@ services:
       - ./.local-dev/victoria-metrics:/data
 
   cadvisor:
-    image: ghcr.io/google/cadvisor:v0.54
+    image: ghcr.io/google/cadvisor:0.54
     privileged: true
     devices:
       - /dev/kmsg


### PR DESCRIPTION
## なぜやるか
`compose.yaml`内のcadvisorのタグが間違っていた

## やったこと
直した

## やらなかったこと

## 資料
