### PR TITLE
fix(preview-workflows): on pull_request_targetからpull_requestに変更

### DIFF
--- a/.github/workflows/preview-comment.yaml
+++ b/.github/workflows/preview-comment.yaml
@@ -1,8 +1,7 @@
 name: Comment preview environment URL
 
 on:
-  # pull_request_target を使うにあたって https://securitylab.github.com/research/github-actions-preventing-pwn-requests/ の一読を推奨
-  pull_request_target:
+  pull_request:
     types:
       - opened
 

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -1,8 +1,7 @@
 name: Preview
 
 on:
-  # pull_request_target を使うにあたって https://securitylab.github.com/research/github-actions-preventing-pwn-requests/ の一読を推奨
-  pull_request_target:
+  pull_request:
 
 permissions:
   packages: write
@@ -16,9 +15,6 @@ jobs:
         run: echo "PR_NUMBER=${{ github.event.number }}" >> $GITHUB_ENV
 
       - uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          persist-credentials: false
       - run: echo "APP_VERSION=preview-${{ env.PR_NUMBER }}" >> $GITHUB_ENV
       - run: echo "APP_REVISION=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
 


### PR DESCRIPTION
## なぜやるか
セキュリティリスクのわりに、外部からのPRはそこまで多くない

## やったこと
タイトル通り

## やらなかったこと

## 資料


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * GitHub Actionsワークフローの設定を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->