### PR TITLE
change the git fetch error log level to warn

### DIFF
--- a/pkg/usecase/commit-fetcher/service.go
+++ b/pkg/usecase/commit-fetcher/service.go
@@ -123,7 +123,7 @@ func (s *service) fetchLoop(ctx context.Context, fetcher <-chan queueItem) {
 		case item := <-fetcher:
 			err := s.fetchOne(ctx, item.repositoryID, item.hashes)
 			if err != nil {
-				slog.ErrorContext(ctx, "failed to fetch commits for repository", "count", len(item.hashes), "repository_id", item.repositoryID, "error", err)
+				slog.WarnContext(ctx, "failed to fetch commits for repository", "count", len(item.hashes), "repository_id", item.repositoryID, "error", err)
 			}
 		case <-ctx.Done():
 			return


### PR DESCRIPTION
## なぜやるか
基本的に`git fetch`でエラーが出てもこちら側で対処しようがない（リポジトリが無い・branchが無いなど）。
エラーログがでてもうるさいだけ

## やったこと
warnに落とした

## やらなかったこと

## 資料

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * エラーログの記録レベルを調整しました。これにより、特定のエラー条件下でのログ出力がより適切に分類されるようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->