### PR TITLE
chore: remove the unused replace blocks from go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -268,15 +268,6 @@ require (
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 
-// github.com/traefik/traefik
-replace (
-	github.com/abbot/go-http-auth => github.com/containous/go-http-auth v0.4.1-0.20200324110947-a37a7636d23e
-	github.com/go-check/check => github.com/containous/check v0.0.0-20170915194414-ca0bf163426a
-)
-
-// github.com/cert-manager/cert-manager
-replace github.com/Venafi/vcert/v4 => github.com/jetstack/vcert/v4 v4.9.6-0.20230127103832-3aa3dfd6613d
-
 tool (
 	github.com/google/wire/cmd/wire
 	github.com/matryer/moq


### PR DESCRIPTION
## なぜやるか
使われてなくてもrenovateの管理対象になっていたため

## やったこと
タイトル通り

## やらなかったこと

## 資料


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **チョア**
  * モジュール管理の置換ディレクティブを削除しました。これにより、複数の外部ライブラリの依存関係解決がより標準的な方法で行われるようになります。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/traPtitech/NeoShowcase/pull/1242?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->