### PR TITLE
chore(renovate): configure schedule

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -16,5 +16,7 @@
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "Node.js minor & patch dependencies"
     }
-  ]
+  ],
+  "schedule": ["* 9-23 1 * *"],
+  "timezone": "Asia/Tokyo"
 }


### PR DESCRIPTION
## なぜやるか
月一で十分だから

## やったこと
renovateの更新を月一で実行するようにした

## やらなかったこと

## 資料


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 依存関係の更新スケジュール設定を更新しました。日本時間で毎月1日の9時～23時に実行されるよう調整されています。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/traPtitech/NeoShowcase/pull/1245?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->