### PR TITLE
fix renovate schedule

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -18,6 +18,6 @@
       "minimumReleaseAge": "7d"
     }
   ],
-  "schedule": ["* 9-23 1 * *"],
+  "schedule": ["* * 1 * *"],
   "timezone": "Asia/Tokyo"
 }


### PR DESCRIPTION
## なぜやるか
renovateは朝5時に回るのに9-23時にしかPRを出さない設定になってた

## やったこと
直した

## やらなかったこと

## 資料


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * 自動更新機能のスケジュール設定を更新しました。毎月1日の更新実行に関する時間帯の制限を緩和し、より広い時間枠で自動更新が行われるようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->