### PR TITLE
change renovate default log level from debug to info

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -13,7 +13,7 @@ on:
         required: false
       logLevel:
         description: Log-Level
-        default: debug
+        default: info
         required: false
   # For auto-merge - should exclude non-renovate branch dispatches in job definitions below
   workflow_run:
@@ -29,7 +29,7 @@ on:
     branches: ["main"]
 
 env:
-  LOG_LEVEL: debug
+  LOG_LEVEL: info
   RENOVATE_DRY_RUN: false
   RENOVATE_CONFIG_FILE: .github/renovate-bot.json5
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * ワークフロー設定のログレベル既定値を `debug` から `info` に調整しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->