### PR TITLE
fix(ui): fix background color of text field

### DIFF
--- a/dashboard/src/components/UI/TextField.tsx
+++ b/dashboard/src/components/UI/TextField.tsx
@@ -65,8 +65,8 @@ export const TextField: Component<Props> = (props) => {
                   class={clsx(
                     'flex h-12 w-full gap-1 border-none bg-ui-primary px-4 text-regular text-text-black outline outline-1 outline-ui-border',
                     'focus-within:outline-2 focus-within:outline-primary-main',
-                    'data-[disabled]:has-[.input]:cursor-not-allowed data-[disabled]:has-[.input]:bg-ui-tertiary',
                     'data-[invalid]:has-[.input]:outline-2 data-[invalid]:has-[.input]:outline-accent-error',
+                    props.disabled ? 'cursor-not-allowed bg-ui-tertiary' : '',
                     props.copyable ? 'rounded-l-lg' : 'rounded-lg',
                   )}
                 >
@@ -74,7 +74,7 @@ export const TextField: Component<Props> = (props) => {
                     <Icon>{props.leftIcon}</Icon>
                   </Show>
                   <KTextField.Input
-                    class="input h-full w-full border-none p-0 placeholder-text-disabled focus-visible:outline-none"
+                    class="input h-full w-full border-none p-0 bg-transparent placeholder-text-disabled focus-visible:outline-none"
                     {...inputProps}
                     type={props.type}
                   />


### PR DESCRIPTION
## なぜやるか
`TextField`の背景色が変なことになってた

## やったこと
直した

## やらなかったこと

## 資料


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * テキスト入力フィールドの無効状態・無効化状態でのスタイリングを改善しました。

* **Style**
  * 複数行入力フィールドのクラス組み立てロジックを調整し、コピー機能を持つ際の角丸表示の一貫性を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->