### PR TITLE
context cancled errorに対してerror logを出さないようにする

### DIFF
--- a/pkg/infrastructure/log/loki/streamer.go
+++ b/pkg/infrastructure/log/loki/streamer.go
@@ -136,7 +136,9 @@ func (l *lokiStreamer) Stream(ctx context.Context, app *domain.Application, begi
 		for {
 			logSeq, err := l.readStream(ctx, logQL, lastSeenTime)
 			if err != nil {
-				slog.ErrorContext(ctx, "failed to read log stream", "error", err)
+				if !errors.Is(err, context.Canceled) {
+					slog.ErrorContext(ctx, "failed to read log stream", "error", err)
+				}
 				return
 			}
 			for l, err := range logSeq {


### PR DESCRIPTION
## なぜやるか
ユーザーの行動の結果なのでエラーとして扱うべきでない

## やったこと
タイトル通り

## やらなかったこと

## 資料


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * ストリーム処理の中断時に、`context.Canceled` による終了ではエラーログを出さないように改善しました。
  * 実際の異常終了時のみエラーログが出力されるため、不要なノイズが減ります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->