### PR TITLE
fix: mise setup

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -13,7 +13,7 @@ tbls = "1.94.5"
 buf = "1.70.0"
 "go:github.com/aarondl/sqlboiler/v4" = "4.19.7"
 "go:github.com/aarondl/sqlboiler/v4/drivers/sqlboiler-mysql" = "4.19.7"
-"go:github.com/sqldef/sqldef/cmd/mysqldef" = "3.11.13"
+"go:github.com/sqldef/sqldef/v3/cmd/mysqldef" = "3.11.13"
 
 [env]
 APP_VERSION = "dev"


### PR DESCRIPTION
## なぜやるか
`mise install` が通らなかったため、直した

## やったこと
mysqldef の install path の修正

## やらなかったこと

## 資料


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * MySQL向けデータベース定義ツールの参照先を更新しました。
  * 使用するバージョンは従来と同じです。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->