### PR TITLE
SPA向けのCaddyの設定を修正

### DIFF
--- a/pkg/infrastructure/staticserver/caddy/server.go
+++ b/pkg/infrastructure/staticserver/caddy/server.go
@@ -47,15 +47,13 @@ file_server @%v {
 
 const siteTemplateSPA = `@%v {
 	header %v %v
-	file {
-		root %v
-		try_files {path} {path}.html {path}/ {path}/index.html /index.html =404
-	}
 }
-rewrite @%v {file_match.relative}
-file_server @%v {
-	root %v
-	precompressed br gzip zstd
+handle @%v {
+	root * %v
+	try_files {path} {path}.html {path}/ {path}/index.html /index.html =404
+	file_server {
+		precompressed br gzip zstd
+	}
 }
 `
 
@@ -88,8 +86,6 @@ func (s *server) Reconcile(sites []*domain.StaticSite) error {
 			fmt.Fprintf(&b, siteTemplateSPA,
 				matcherName,
 				web.HeaderNameSSGenAppID, site.Application.ID,
-				filepath.Join(s.c.DocsRoot, site.ArtifactID),
-				matcherName,
 				matcherName,
 				filepath.Join(s.c.DocsRoot, site.ArtifactID))
 		} else {


### PR DESCRIPTION
## なぜやるか
index.htmlが存在しないSPAがあると、そのアプリに対応するmatcherを評価した時点で404を返してしまっていた

## やったこと
直した

## やらなかったこと

## 資料


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善**
  - SPA（シングルページアプリケーション）のルーティング処理を改善し、ページの直接アクセスや再読み込み時に適切なコンテンツが表示されるようになりました。
  - 圧縮済みの静的ファイルを優先して配信できるようになり、対応環境では読み込みの効率が向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->