### PR TITLE
refactor(errors): migrate to friendsofgo/errors and error-handling guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ Quick start: run `mise trust && mise run up`.
 
 See [development.md](./docs/development.md) for more.
 
+## Coding guidelines
+
+See [docs/guidelines/](./docs/guidelines/):
+- [error-handling.md](./docs/guidelines/error-handling.md) for the error-handling rules
+
 ## Architecture
 
 See:

--- a/cmd/providers.go
+++ b/cmd/providers.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"os"
 	"strings"
@@ -53,7 +52,7 @@ func provideStorage(c domain.StorageConfig) (domain.Storage, error) {
 	case "swift":
 		return storage.NewSwiftStorage(c.Swift.Container, c.Swift.UserName, c.Swift.APIKey, c.Swift.TenantName, c.Swift.TenantID, c.Swift.AuthURL)
 	default:
-		return nil, fmt.Errorf("unknown storage: %s", c.Type)
+		return nil, errors.Errorf("unknown storage: %s", c.Type)
 	}
 }
 
@@ -108,7 +107,7 @@ func provideBuilderConfig(c Config) (*ubuilder.Config, error) {
 	stepTimeoutStr := c.Components.Builder.StepTimeout
 	stepTimeout, err := time.ParseDuration(stepTimeoutStr)
 	if err != nil {
-		return nil, errors.Wrap(err, fmt.Sprintf("failed to parse components.builder.stepTimeout value: %s", stepTimeoutStr))
+		return nil, errors.Wrapf(err, "parsing components.builder.stepTimeout value: %s", stepTimeoutStr)
 	}
 	if stepTimeout <= 0 {
 		return nil, errors.Errorf("components.builder.stepTimeout must be positive: %s", stepTimeoutStr)

--- a/cmd/providers.go
+++ b/cmd/providers.go
@@ -38,7 +38,7 @@ import (
 func provideRepositoryPrivateKey(c Config) (domain.PrivateKey, error) {
 	bytes, err := os.ReadFile(c.PrivateKeyFile)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to open private key file")
+		return nil, errors.Wrap(err, "opening private key file")
 	}
 	return bytes, nil
 }
@@ -123,7 +123,7 @@ func provideBuildkitClient(c Config) (*buildkit.Client, error) {
 	defer cancel()
 	client, err := buildkit.New(ctx, cc.Buildkit.Address)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to initialize Buildkit Client")
+		return nil, errors.Wrap(err, "initializing Buildkit Client")
 	}
 	return client, nil
 }

--- a/docs/guidelines/error-handling.md
+++ b/docs/guidelines/error-handling.md
@@ -1,0 +1,232 @@
+# Error Handling
+
+## Why this document exists
+
+This document defines **one** set of rules for error handling so that it is
+uniform and, above all, **easy to investigate when something breaks in
+production**.
+
+Optimizing for debuggability is the guiding principle here. Every rule below is
+justified by the same question: *when an incident happens, can an engineer get
+from a symptom to the root cause quickly?*
+
+These rules are **binding** (MUST, unless stated otherwise). All code must follow
+them.
+
+## Rules at a glance
+
+1. **One library.** Use `github.com/friendsofgo/errors` everywhere. It preserves
+   stack traces. Do not create errors with the standard `errors.New` / `fmt.Errorf`.
+2. **Wrap with context, don't log while propagating.** As an error travels up,
+   add context (IDs, state) to the *message*. Never log an error you are also
+   returning.
+3. **Log once, where the error stops.** The single place that handles an error
+   terminally (an interceptor, a reconcile loop tick) logs it once — with the full
+   wrap chain, stack trace, `trace_id`, and `user_id`.
+4. **`Error` means "a human must look."** Reserve the `Error` level for the
+   unexpected. Expected/transient failures are `Warn`; normal events are `Info`.
+5. **Classify at the usecase layer.** The usecase layer tags errors with a
+   business meaning (bad request, not found, ...). The transport boundary maps the
+   tag to a Connect code; anything untagged is `Internal`.
+6. **Don't leak internals.** `Internal` errors return only a generic message to the
+   client. The detail lives in the logs.
+7. **Loops log-and-continue.** Reconcile loops never add their own retry/compensation.
+8. **`panic` is for programmer errors and startup only.**
+
+The rest of this document explains each rule and shows the intended shape of the code.
+
+## 1. Error library and stack traces
+
+Use `github.com/friendsofgo/errors` (a `pkg/errors` fork) as the **only** error
+constructor library. It attaches a stack trace at the point the error is created or
+wrapped, which is the single most valuable thing for locating where a failure
+originated.
+
+- **MUST** create and wrap errors with `errors.New`, `errors.Wrap`, and
+  `errors.Wrapf` from this package.
+- **MUST NOT** use the standard library's `errors.New` or `fmt.Errorf` to create or
+  wrap errors — they discard the stack trace and are the reason the two libraries
+  currently mix.
+- Inspecting errors with the standard `errors.Is` / `errors.As` is fine;
+  `friendsofgo/errors` exposes the same functions and chains interoperate.
+
+**Capture the stack once, at the origin.** Wrap an external/library error the moment
+it enters our code so the stack points at the boundary where it happened. Higher up,
+keep adding *context* with `Wrap`, but do not re-wrap an error without adding new
+information — that only adds noise to the chain.
+
+```go
+// Good: the DB error is wrapped as it enters our code; the stack is captured here.
+row, err := models.Applications(...).One(ctx, db)
+if err != nil {
+    return errors.Wrap(err, "querying application")
+}
+```
+
+## 2. Creating and wrapping errors
+
+As an error propagates, attach the **local context** that will matter during an
+investigation — identifiers and relevant state — onto the wrap message, not into a
+separate log line. One log at the boundary then carries everything.
+
+```go
+// Good: app_id and step are on the message; no local log needed.
+if err := b.updateApp(ctx, appID); err != nil {
+    return errors.Wrapf(err, "updating app (app_id=%s, step=%s)", appID, step)
+}
+```
+
+### Message style
+
+Wrap and error messages **MUST**:
+
+- be written as a **gerund phrase** describing the operation: `"syncing deployments"`,
+  `"updating app"`, `"querying repository"`.
+- start with a lowercase letter and have **no** trailing punctuation.
+- **not** include `"failed to"`. Wrapping already means "this failed"; adding it to
+  every layer produces `failed to sync: failed to update: failed to query`, whereas
+  gerunds read as a clean path: `syncing deployments: updating app: querying db`.
+
+```go
+// Good
+return errors.Wrap(err, "reading docs root")
+return errors.Wrapf(err, "resolving ref (ref=%s, app_id=%s)", ref, appID)
+
+// Bad
+return errors.Wrap(err, "Failed to read docs root.")   // "failed to", capitalized, punctuation
+return fmt.Errorf("read docs root: %w", err)            // stdlib, no stack trace
+```
+
+## 3. Where to log: log once, at the point the error stops
+
+The biggest obstacle to investigation is the **same failure logged in several
+places** with partial context. To prevent it:
+
+- **MUST** log an error only at the point where it is *terminally handled* — i.e.
+  where you stop returning it to the caller (you swallow it, or you translate it into
+  a response). In practice these points are:
+  - the gRPC/Connect **interceptor** (`pkg/infrastructure/grpc/log_interceptor.go`),
+    which logs every request error once, and
+  - the **top of a reconcile loop tick**, which logs a failure and moves on.
+- **MUST NOT** log an error that you are also returning. If you `return err`, the
+  caller (ultimately the boundary) owns logging it.
+
+Because context is carried on the wrap message (rule 2), the single boundary log
+still contains every ID and every step — plus the stack trace, `trace_id`, and
+`user_id`. Nothing is lost by not logging locally.
+
+```go
+// Bad: logs here AND returns → the boundary logs it again (double log).
+if err != nil {
+    slog.ErrorContext(ctx, "updating app", "app_id", appID, "error", err)
+    return err
+}
+
+// Good: attach context, return; the boundary logs it exactly once.
+if err != nil {
+    return errors.Wrapf(err, "updating app (app_id=%s)", appID)
+}
+```
+
+## 4. Log levels
+
+Levels carry meaning. Keeping `Error` pure is what makes it a usable alert signal.
+The interceptor already derives the level from the Connect code; that mapping is the
+project-wide standard.
+
+- **`Error`** — unexpected; a human should look. Internal failures, bugs, broken
+  external dependencies. Connect codes `Internal`, `Unknown`, `Unavailable`,
+  `DeadlineExceeded`, `Unimplemented`, `DataLoss`.
+- **`Warn`** — expected but noteworthy. Client errors (`InvalidArgument`,
+  `NotFound`, `PermissionDenied`, ...) and transient failures a loop will retry.
+- **`Info`** — normal events: a successful request, a loop making normal progress.
+
+A per-item failure inside a loop that the next tick will retry is `Warn`, not `Error`
+— it is expected and self-healing.
+
+## 5. Classifying errors and mapping them to transport codes
+
+Deciding that a failure is "not found" or "bad request" requires knowing the business
+intent, so **classification is the usecase layer's job**.
+
+- **Infrastructure and domain layers** return plain wrapped errors. They do not know
+  or decide HTTP/Connect semantics.
+- **The usecase layer** tags an error with its business meaning using the helper in
+  `pkg/usecase/apiserver/errors.go` (`newError(ErrorType..., "message", cause)`).
+  Use `errors.Is` to detect a known low-level condition and translate it into a tag.
+- **The transport boundary** (`handleUseCaseError` in
+  `pkg/infrastructure/grpc/api_service.go`) decomposes the tag and maps it to a
+  Connect code. **Anything untagged maps to `Internal`** — an untagged error is by
+  definition something we did not anticipate.
+
+```go
+// usecase layer: detect a known condition and classify it.
+app, err := s.appRepo.GetApp(ctx, id)
+if errors.Is(err, repository.ErrNotFound) {
+    return nil, newError(ErrorTypeNotFound, "application not found", err)
+}
+if err != nil {
+    return nil, errors.Wrap(err, "getting application") // stays Internal at the boundary
+}
+```
+
+Add new `ErrorType` values when a genuinely new category of client-facing outcome
+appears — keep the set small and meaningful.
+
+## 6. What the client sees
+
+Split what the client receives from what we record:
+
+- **Classified errors** (bad request, not found, forbidden, already exists) **MUST**
+  return their message to the client — the user can act on it.
+- **`Internal` errors MUST return only a generic message** (e.g. "internal server
+  error"). The wrapped detail — DB errors, file paths, internal state — stays in the
+  logs only, never in the response. The full detail is already captured by the single
+  boundary log (rule 3), correlated by `user_id`, `procedure`, and timestamp.
+
+## 7. Reconcile loops
+
+NeoShowcase is built on reconciliation loops (see `docs/architecture.md`). Errors in a
+loop are transient by design: the next tick reads desired state from the DB and tries
+again.
+
+- **MUST** log a failure and continue — do **not** abort the whole system on one
+  error.
+- When processing many items in one tick, a single item's failure **MUST NOT** abort
+  the remaining items. Log that item (`Warn` if the next tick will retry) and keep
+  going.
+- **MUST NOT** add bespoke retry, backoff, or compensation logic. The loop *is* the
+  retry mechanism; adding more only hides problems and duplicates machinery.
+
+```go
+for _, app := range apps {
+    if err := s.reconcileApp(ctx, app); err != nil {
+        // log-and-continue: the next tick retries this app.
+        slog.WarnContext(ctx, "reconciling app", "app_id", app.ID, "error", err)
+        continue
+    }
+}
+```
+
+## 8. panic
+
+- **MUST** return an `error` for anything that can happen at runtime — request
+  handling, loop bodies, I/O.
+- `panic` is allowed **only** for:
+  - **programmer errors** — an invariant that cannot be violated unless the code is
+    wrong (e.g. an impossible `switch` branch), and
+  - **unrecoverable startup/initialization failures**, where the process cannot
+    sensibly run (config that fails to load, a required dependency that fails to
+    construct).
+- **MUST NOT** `panic` inside a goroutine for control flow — an unrecovered goroutine
+  panic takes the whole process down.
+
+## 9. Structured logging
+
+- **MUST** use `slog` with the `Context` variants (`slog.ErrorContext`,
+  `slog.WarnContext`, `slog.InfoContext`) so that `trace_id` and `user_id`, injected
+  by the interceptor, travel with every line.
+- **MUST** pass the error as a structured attribute: `slog.ErrorContext(ctx, "…",
+  "error", err)`. Do not format the error into the message string.
+- Prefer stable, queryable attribute keys (`app_id`, `build_id`, `procedure`) over
+  interpolated prose.

--- a/docs/guidelines/error-handling.md
+++ b/docs/guidelines/error-handling.md
@@ -87,6 +87,12 @@ Wrap and error messages **MUST**:
   every layer produces `failed to sync: failed to update: failed to query`, whereas
   gerunds read as a clean path: `syncing deployments: updating app: querying db`.
 
+This style applies to **wrap and internal error messages**. It does **not** apply to
+the classified, client-facing messages produced at the usecase layer (rule 5) or the
+generic message returned to the client (rule 6): those describe a *condition*, not an
+operation, and are written as plain phrases — `"application not found"`,
+`"internal server error"` — never gerunds.
+
 ```go
 // Good
 return errors.Wrap(err, "reading docs root")

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,6 @@ require (
 	github.com/moby/moby/client v0.5.0
 	github.com/motoki317/sc v1.8.2
 	github.com/ncw/swift/v2 v2.0.5
-	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/common v0.70.0
 	github.com/regclient/regclient v0.11.5
@@ -189,6 +188,7 @@ require (
 	github.com/patrickmn/go-cache v2.1.0+incompatible // indirect
 	github.com/pelletier/go-toml/v2 v2.3.1 // indirect
 	github.com/pjbgf/sha1cd v0.6.0 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect

--- a/pkg/domain/app_environment.go
+++ b/pkg/domain/app_environment.go
@@ -1,8 +1,9 @@
 package domain
 
 import (
-	"fmt"
 	"regexp"
+
+	"github.com/friendsofgo/errors"
 )
 
 type Environment struct {
@@ -20,7 +21,7 @@ var environmentVariableKeyFormat = regexp.MustCompile(`^[A-Z_][A-Z0-9_]*$`)
 
 func (e *Environment) Validate() error {
 	if !environmentVariableKeyFormat.MatchString(e.Key) {
-		return fmt.Errorf("bad key format: %s", e.Key)
+		return errors.Errorf("bad key format: %s", e.Key)
 	}
 	return nil
 }

--- a/pkg/domain/storage.go
+++ b/pkg/domain/storage.go
@@ -35,7 +35,7 @@ func SaveBuildLog(s Storage, buildID string, src io.Reader) error {
 func GetBuildLog(s Storage, buildID string) ([]byte, error) {
 	r, err := s.Open(buildLogPath(buildID))
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to open build log")
+		return nil, errors.Wrap(err, "opening build log")
 	}
 	defer r.Close()
 	return io.ReadAll(r)
@@ -44,7 +44,7 @@ func GetBuildLog(s Storage, buildID string) ([]byte, error) {
 func DeleteBuildLog(s Storage, buildID string) error {
 	err := s.Delete(buildLogPath(buildID))
 	if err != nil {
-		return errors.Wrap(err, "failed to delete build log")
+		return errors.Wrap(err, "deleting build log")
 	}
 	return nil
 }
@@ -60,7 +60,7 @@ func artifactFilename(artifactID string) string {
 // SaveArtifact Artifactをtar形式で保存する
 func SaveArtifact(s Storage, artifactID string, src io.Reader) error {
 	if err := s.Save(artifactPath(artifactID), src); err != nil {
-		return errors.Wrap(err, "failed to save artifact")
+		return errors.Wrap(err, "saving artifact")
 	}
 	return nil
 }
@@ -68,7 +68,7 @@ func SaveArtifact(s Storage, artifactID string, src io.Reader) error {
 func GetArtifact(s Storage, artifactID string) (r io.ReadCloser, err error) {
 	r, err = s.Open(artifactPath(artifactID))
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to open artifact")
+		return nil, errors.Wrap(err, "opening artifact")
 	}
 	return r, nil
 }
@@ -76,7 +76,7 @@ func GetArtifact(s Storage, artifactID string) (r io.ReadCloser, err error) {
 func DeleteArtifact(s Storage, artifactID string) error {
 	err := s.Delete(artifactPath(artifactID))
 	if err != nil {
-		return errors.Wrap(err, "failed to delete artifact")
+		return errors.Wrap(err, "deleting artifact")
 	}
 	return nil
 }

--- a/pkg/infrastructure/backend/dockerimpl/backend.go
+++ b/pkg/infrastructure/backend/dockerimpl/backend.go
@@ -70,7 +70,7 @@ func NewDockerBackend(
 func (b *Backend) Start(ctx context.Context) error {
 	// showcase用のネットワークを用意
 	if err := b.initNetworks(ctx); err != nil {
-		return errors.Wrap(err, "failed to init networks")
+		return errors.Wrap(err, "initializing networks")
 	}
 
 	eventCtx, eventCancel := context.WithCancel(context.Background())
@@ -135,7 +135,7 @@ func (b *Backend) ListenContainerEvents() (sub <-chan *domain.ContainerEvent, un
 func (b *Backend) initNetworks(ctx context.Context) error {
 	networks, err := b.c.NetworkList(ctx, client.NetworkListOptions{})
 	if err != nil {
-		return errors.Wrap(err, "failed to list networks")
+		return errors.Wrap(err, "listing networks")
 	}
 	for _, network := range networks.Items {
 		if network.Name == b.config.Network {

--- a/pkg/infrastructure/backend/dockerimpl/ingress.go
+++ b/pkg/infrastructure/backend/dockerimpl/ingress.go
@@ -1,6 +1,7 @@
 package dockerimpl
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"maps"
@@ -40,7 +41,7 @@ func (b *Backend) routerBase(app *domain.Application, website *domain.Website, s
 			middlewareNames = append(middlewareNames, authConfig.Hard...)
 		}
 	} else if website.Authentication != domain.AuthenticationTypeOff {
-		slog.Warn("auth config not available", "fqdn", website.FQDN)
+		slog.WarnContext(context.Background(), "auth config not available", "fqdn", website.FQDN)
 	}
 
 	if b.useSablier(app) {
@@ -151,7 +152,7 @@ func (b *runtimeConfigBuilder) build() m {
 func (b *Backend) writeConfig(filename string, config any) error {
 	file, err := os.OpenFile(filepath.Join(b.config.ConfDir, filename), os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644)
 	if err != nil {
-		return errors.Wrap(err, "failed to open config file")
+		return errors.Wrap(err, "opening config file")
 	}
 	defer file.Close()
 	enc := yaml.NewEncoder(file)

--- a/pkg/infrastructure/backend/dockerimpl/list_containers.go
+++ b/pkg/infrastructure/backend/dockerimpl/list_containers.go
@@ -20,7 +20,7 @@ func (b *Backend) GetContainer(ctx context.Context, appID string) (*domain.Conta
 			Add("label", fmt.Sprintf("%s=true", appLabel), fmt.Sprintf("%s=%s", appIDLabel, appID)),
 	})
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to fetch containers")
+		return nil, errors.Wrap(err, "fetching containers")
 	}
 
 	if len(containers.Items) == 0 {
@@ -43,7 +43,7 @@ func (b *Backend) ListContainers(ctx context.Context) ([]*domain.Container, erro
 		Filters: make(client.Filters).Add("label", fmt.Sprintf("%s=true", appLabel)),
 	})
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to fetch containers")
+		return nil, errors.Wrap(err, "fetching containers")
 	}
 
 	result := ds.Map(containers.Items, func(c container.Summary) *domain.Container {

--- a/pkg/infrastructure/backend/dockerimpl/synchronize_runtime.go
+++ b/pkg/infrastructure/backend/dockerimpl/synchronize_runtime.go
@@ -31,7 +31,7 @@ func (b *Backend) syncAppContainer(ctx context.Context, app *domain.RuntimeDesir
 			Force:         true,
 		})
 		if err != nil {
-			return errors.Wrap(err, "failed to remove old container")
+			return errors.Wrap(err, "removing old container")
 		}
 	}
 
@@ -120,12 +120,12 @@ func (b *Backend) syncAppContainer(ctx context.Context, app *domain.RuntimeDesir
 		Name:             containerName(app.App.ID),
 	})
 	if err != nil {
-		return errors.Wrap(err, "failed to create container")
+		return errors.Wrap(err, "creating container")
 	}
 
 	_, err = b.c.ContainerStart(ctx, cont.ID, client.ContainerStartOptions{})
 	if err != nil {
-		return errors.Wrap(err, "failed to start container")
+		return errors.Wrap(err, "starting container")
 	}
 	return nil
 }
@@ -137,7 +137,7 @@ func (b *Backend) synchronizeRuntime(ctx context.Context, apps []*domain.Runtime
 		Filters: make(client.Filters).Add("label", fmt.Sprintf("%s=true", appLabel)),
 	})
 	if err != nil {
-		return errors.Wrap(err, "failed to list containers")
+		return errors.Wrap(err, "listing containers")
 	}
 	oldContainersMap := lo.SliceToMap(oldContainers.Items, func(c container.Summary) (string, *container.Summary) {
 		return c.Labels[appIDLabel], &c
@@ -147,7 +147,7 @@ func (b *Backend) synchronizeRuntime(ctx context.Context, apps []*domain.Runtime
 	for _, app := range apps {
 		err = b.syncAppContainer(ctx, app, oldContainersMap[app.App.ID])
 		if err != nil {
-			slog.ErrorContext(ctx, "failed to sync app", "error", err)
+			slog.WarnContext(ctx, "failed to sync app", "app_id", app.App.ID, "error", err)
 			continue // fail-safe
 		}
 	}
@@ -161,7 +161,7 @@ func (b *Backend) synchronizeRuntime(ctx context.Context, apps []*domain.Runtime
 	}
 	err = b.writeConfig(traefikRuntimeFilename, cb.build())
 	if err != nil {
-		return errors.Wrap(err, "failed to write runtime ingress config")
+		return errors.Wrap(err, "writing runtime ingress config")
 	}
 
 	// Prune old resources
@@ -177,7 +177,7 @@ func (b *Backend) synchronizeRuntime(ctx context.Context, apps []*domain.Runtime
 			Force:         true,
 		})
 		if err != nil {
-			slog.ErrorContext(ctx, "failed to remove old container", "error", err)
+			slog.WarnContext(ctx, "failed to remove old container", "app_id", appID, "container_id", oldContainer.ID, "error", err)
 			continue // fail-safe
 		}
 	}

--- a/pkg/infrastructure/backend/k8simpl/backend.go
+++ b/pkg/infrastructure/backend/k8simpl/backend.go
@@ -91,7 +91,7 @@ func (b *Backend) eventListener(ctx context.Context) error {
 		}}),
 	})
 	if err != nil {
-		return errors.Wrap(err, "failed to watch pods")
+		return errors.Wrap(err, "watching pods")
 	}
 	defer podWatcher.Stop()
 

--- a/pkg/infrastructure/backend/k8simpl/helper.go
+++ b/pkg/infrastructure/backend/k8simpl/helper.go
@@ -116,7 +116,7 @@ func syncResources[T apiResource](ctx context.Context, cluster *discovery.Cluste
 		}
 		_, err = s.Patch(ctx, rc.GetName(), types.ApplyPatchType, b, metav1.PatchOptions{Force: lo.ToPtr(true), FieldManager: fieldManager})
 		if err != nil {
-			slog.ErrorContext(ctx, "failed to patch", "resource", rcName+"/"+rc.GetName(), "error", err)
+			slog.WarnContext(ctx, "failed to patch", "resource", rcName+"/"+rc.GetName(), "error", err)
 			continue // skip this resource if patch fails
 		}
 		patched++
@@ -209,7 +209,7 @@ func syncResourcesWithReplace[T apiResource](
 	}
 
 	if err := replacePool.Wait(); err != nil {
-		slog.ErrorContext(ctx, "error occurred while waiting for replace", "error", err)
+		slog.WarnContext(ctx, "error occurred while waiting for replace", "error", err)
 		// no return here, continue to prune old resources
 	}
 
@@ -230,7 +230,7 @@ func pruneResources[T apiResource](ctx context.Context, cluster *discovery.Clust
 		}
 		err := s.Delete(ctx, rc.GetName(), metav1.DeleteOptions{PropagationPolicy: lo.ToPtr(metav1.DeletePropagationForeground)})
 		if err != nil {
-			slog.ErrorContext(ctx, "failed to delete resource", "resource", rcName+"/"+rc.GetName(), "error", err)
+			slog.WarnContext(ctx, "failed to delete resource", "resource", rcName+"/"+rc.GetName(), "error", err)
 			continue // skip this resource if delete fails
 		}
 		pruned++

--- a/pkg/infrastructure/backend/k8simpl/ingress.go
+++ b/pkg/infrastructure/backend/k8simpl/ingress.go
@@ -1,6 +1,7 @@
 package k8simpl
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -153,7 +154,7 @@ func (b *Backend) ingressRoute(
 			}
 		}
 	} else if website.Authentication != domain.AuthenticationTypeOff {
-		slog.Warn("auth config not available", "fqdn", website.FQDN)
+		slog.WarnContext(context.Background(), "auth config not available", "fqdn", website.FQDN)
 	}
 
 	var rule string

--- a/pkg/infrastructure/backend/k8simpl/list_containers.go
+++ b/pkg/infrastructure/backend/k8simpl/list_containers.go
@@ -20,7 +20,7 @@ func (b *Backend) GetContainer(ctx context.Context, appID string) (*domain.Conta
 		LabelSelector: toSelectorString(appSelector(appID)),
 	})
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to fetch pods")
+		return nil, errors.Wrap(err, "fetching pods")
 	}
 
 	if len(list.Items) == 0 {
@@ -42,7 +42,7 @@ func (b *Backend) ListContainers(ctx context.Context) ([]*domain.Container, erro
 		LabelSelector: toSelectorString(b.shardedAllSelector()),
 	})
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to fetch pods")
+		return nil, errors.Wrap(err, "fetching pods")
 	}
 
 	result := ds.Map(list.Items, func(pod v1.Pod) *domain.Container {

--- a/pkg/infrastructure/backend/k8simpl/synchronize.go
+++ b/pkg/infrastructure/backend/k8simpl/synchronize.go
@@ -32,31 +32,31 @@ func (b *Backend) listCurrentResources(ctx context.Context) (*resources, error) 
 
 	ss, err := b.client.AppsV1().StatefulSets(b.config.Namespace).List(ctx, listOpt)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to get stateful sets")
+		return nil, errors.Wrap(err, "getting stateful sets")
 	}
 	rsc.statefulSets = ds.SliceOfPtr(ss.Items)
 
 	secrets, err := b.client.CoreV1().Secrets(b.config.Namespace).List(ctx, listOpt)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to get secrets")
+		return nil, errors.Wrap(err, "getting secrets")
 	}
 	rsc.secrets = ds.SliceOfPtr(secrets.Items)
 
 	svc, err := b.client.CoreV1().Services(b.config.Namespace).List(ctx, listOpt)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to get services")
+		return nil, errors.Wrap(err, "getting services")
 	}
 	rsc.services = ds.SliceOfPtr(svc.Items)
 
 	mw, err := b.traefikClient.Middlewares(b.config.Namespace).List(ctx, listOpt)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to get middlewares")
+		return nil, errors.Wrap(err, "getting middlewares")
 	}
 	rsc.middlewares = ds.SliceOfPtr(mw.Items)
 
 	ir, err := b.traefikClient.IngressRoutes(b.config.Namespace).List(ctx, listOpt)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to get ingress routes")
+		return nil, errors.Wrap(err, "getting ingress routes")
 	}
 	rsc.ingressRoutes = ds.SliceOfPtr(ir.Items)
 
@@ -70,7 +70,7 @@ func (b *Backend) listCurrentSharedResources(ctx context.Context) (*sharedResour
 	if b.config.TLS.Type == tlsTypeCertManager {
 		certs, err := b.certManagerClient.CertmanagerV1().Certificates(b.config.Namespace).List(ctx, listOpt)
 		if err != nil {
-			return nil, errors.Wrap(err, "failed to get certificates")
+			return nil, errors.Wrap(err, "getting certificates")
 		}
 		rsc.certificates = ds.SliceOfPtr(certs.Items)
 	}
@@ -96,23 +96,23 @@ func (b *Backend) Synchronize(ctx context.Context, s *domain.DesiredState) error
 	// Synchronize resources
 	err = syncResourcesWithReplace[*appsv1.StatefulSet](ctx, b.cluster, "statefulsets", old.statefulSets, next.statefulSets, b.client.AppsV1().StatefulSets(b.config.Namespace))
 	if err != nil {
-		return errors.Wrap(err, "failed to sync stateful sets")
+		return errors.Wrap(err, "syncing stateful sets")
 	}
 	err = syncResources[*v1.Secret](ctx, b.cluster, "secrets", old.secrets, next.secrets, b.client.CoreV1().Secrets(b.config.Namespace))
 	if err != nil {
-		return errors.Wrap(err, "failed to sync secrets")
+		return errors.Wrap(err, "syncing secrets")
 	}
 	err = syncResources[*v1.Service](ctx, b.cluster, "services", old.services, next.services, b.client.CoreV1().Services(b.config.Namespace))
 	if err != nil {
-		return errors.Wrap(err, "failed to sync services")
+		return errors.Wrap(err, "syncing services")
 	}
 	err = syncResources[*traefikv1alpha1.Middleware](ctx, b.cluster, "middlewares", old.middlewares, next.middlewares, b.traefikClient.Middlewares(b.config.Namespace))
 	if err != nil {
-		return errors.Wrap(err, "failed to sync middlewares")
+		return errors.Wrap(err, "syncing middlewares")
 	}
 	err = syncResources[*traefikv1alpha1.IngressRoute](ctx, b.cluster, "ingressroutes", old.ingressRoutes, next.ingressRoutes, b.traefikClient.IngressRoutes(b.config.Namespace))
 	if err != nil {
-		return errors.Wrap(err, "failed to sync ingressroutes")
+		return errors.Wrap(err, "syncing ingressroutes")
 	}
 
 	return nil
@@ -132,7 +132,7 @@ func (b *Backend) SynchronizeShared(ctx context.Context, s *domain.DesiredStateL
 	// Synchronize resources
 	err = syncResources[*certmanagerv1.Certificate](ctx, b.cluster, "certificates", old.certificates, next.certificates, b.certManagerClient.CertmanagerV1().Certificates(b.config.Namespace))
 	if err != nil {
-		return errors.Wrap(err, "failed to sync certificates")
+		return errors.Wrap(err, "syncing certificates")
 	}
 
 	return nil

--- a/pkg/infrastructure/buildpack/backend.go
+++ b/pkg/infrastructure/buildpack/backend.go
@@ -89,7 +89,7 @@ func (b *backend) prepareDir(ctx context.Context, localName, remoteName string) 
 	cleanup = func() {
 		err := b.exec(context.Background(), b.config.RemoteDir, []string{"rm", "-r", remotePath}, nil, io.Discard)
 		if err != nil {
-			slog.ErrorContext(ctx, "failed to remove tmp repo dir", "error", err)
+			slog.WarnContext(ctx, "failed to remove tmp repo dir", "error", err)
 		}
 	}
 

--- a/pkg/infrastructure/buildpack/backend.go
+++ b/pkg/infrastructure/buildpack/backend.go
@@ -60,7 +60,7 @@ func (b *backend) exec(ctx context.Context, workDir string, cmd []string, env ma
 		return err
 	}
 	if code != 0 {
-		return fmt.Errorf("command exited with code %d", code)
+		return errors.Errorf("command exited with code %d", code)
 	}
 	return nil
 }

--- a/pkg/infrastructure/dbmanager/mariadb.go
+++ b/pkg/infrastructure/dbmanager/mariadb.go
@@ -38,11 +38,11 @@ func NewMariaDBManager(c MariaDBConfig) (domain.MariaDBManager, error) {
 	// DB接続
 	connector, err := mysql.NewConnector(conf)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to create new connector")
+		return nil, errors.Wrap(err, "creating new connector")
 	}
 	db := sql.OpenDB(connector)
 	if err := db.Ping(); err != nil {
-		return nil, errors.Wrap(err, "failed to ping db")
+		return nil, errors.Wrap(err, "pinging db")
 	}
 	db.SetMaxOpenConns(1024)
 	db.SetMaxIdleConns(1024)

--- a/pkg/infrastructure/dbmanager/mariadb.go
+++ b/pkg/infrastructure/dbmanager/mariadb.go
@@ -58,7 +58,7 @@ func (m *mariaDBManagerImpl) GetHost() (host string, port int) {
 
 func (m *mariaDBManagerImpl) Create(ctx context.Context, args domain.CreateArgs) error {
 	if strings.ContainsRune(args.Database, '`') {
-		return fmt.Errorf("backtick(`) in database name are not permitted")
+		return errors.New("backtick(`) in database name are not permitted")
 	}
 	if _, err := m.db.ExecContext(ctx, fmt.Sprintf("CREATE DATABASE IF NOT EXISTS `%s`", args.Database)); err != nil {
 		return err
@@ -74,7 +74,7 @@ func (m *mariaDBManagerImpl) Create(ctx context.Context, args domain.CreateArgs)
 
 func (m *mariaDBManagerImpl) Delete(ctx context.Context, args domain.DeleteArgs) error {
 	if strings.ContainsRune(args.Database, '`') {
-		return fmt.Errorf("backtick(`) in database name are not permitted")
+		return errors.New("backtick(`) in database name are not permitted")
 	}
 	if _, err := m.db.ExecContext(ctx, fmt.Sprintf("DROP DATABASE IF EXISTS `%s`", args.Database)); err != nil {
 		return err

--- a/pkg/infrastructure/dbmanager/mongodb.go
+++ b/pkg/infrastructure/dbmanager/mongodb.go
@@ -31,7 +31,7 @@ func NewMongoDBManager(config MongoDBConfig) (domain.MongoDBManager, error) {
 		options.Client().ApplyURI(fmt.Sprintf("mongodb://%s:%s@%s:%d", config.AdminUser, config.AdminPassword, config.Host, config.Port)),
 	)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to create new client")
+		return nil, errors.Wrap(err, "creating new client")
 	}
 
 	return &mongoDBManagerImpl{client: client, c: config}, nil

--- a/pkg/infrastructure/grpc/api_app_build_service.go
+++ b/pkg/infrastructure/grpc/api_app_build_service.go
@@ -83,7 +83,7 @@ func (s *APIService) GetBuildLogStream(ctx context.Context, req *connect.Request
 	for l := range ch {
 		err = st.Send(l)
 		if err != nil {
-			return errors.New("failed to send event")
+			return errors.Wrap(err, "sending event")
 		}
 	}
 	return nil

--- a/pkg/infrastructure/grpc/controller_builder_service.go
+++ b/pkg/infrastructure/grpc/controller_builder_service.go
@@ -3,7 +3,6 @@ package grpc
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"io"
 	"log/slog"
 	"slices"
@@ -297,7 +296,7 @@ func (s *ControllerBuilderService) startBuild(ctx context.Context, conn *builder
 	// Construct payload to send to builder
 	req, err := s.startBuildPayload(ctx, buildID)
 	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("failed to construct start build payload for %v", buildID))
+		return errors.Wrapf(err, "constructing start build payload (build_id=%v)", buildID)
 	}
 	// Send payload to builder
 	conn.Send(&pb.BuilderRequest{
@@ -329,7 +328,7 @@ func (s *ControllerBuilderService) finishBuild(ctx context.Context, buildID stri
 		return err
 	}
 	if n == 0 {
-		return fmt.Errorf("failed to change build status from builing to finished for %v - builder scheduling may be malfunctioning", buildID)
+		return errors.Errorf("changing build status from building to finished (build_id=%v): no row updated, builder scheduling may be malfunctioning", buildID)
 	}
 
 	// metrics

--- a/pkg/infrastructure/grpc/controller_builder_service.go
+++ b/pkg/infrastructure/grpc/controller_builder_service.go
@@ -125,7 +125,8 @@ func (s *ControllerBuilderService) StreamBuildLog(ctx context.Context, st *conne
 		s.logStream.AppendBuildLog(msg.BuildId, msg.Log)
 	}
 	if err := st.Err(); err != nil {
-		slog.ErrorContext(ctx, "receiving build log", "error", err)
+		// This service has no log interceptor, so this is the terminal log for the error.
+		slog.WarnContext(ctx, "receiving build log", "error", err)
 		return nil, errors.Wrap(err, "receiving build log")
 	}
 	res := connect.NewResponse(&emptypb.Empty{})
@@ -371,7 +372,7 @@ func (s *ControllerBuilderService) StartBuilds(ctx context.Context, buildIDs []s
 			// It is possible that some other controller has acquired build lock first
 			slog.DebugContext(ctx, "failed to acquire build lock", "build_id", buildID)
 		} else {
-			slog.ErrorContext(ctx, "error starting build", "error", err)
+			slog.WarnContext(ctx, "error starting build", "error", err)
 		}
 	}
 }

--- a/pkg/infrastructure/grpc/controller_service.go
+++ b/pkg/infrastructure/grpc/controller_service.go
@@ -148,7 +148,7 @@ loop:
 			}
 			err := c2.Send(&pb.BuildLog{Log: l})
 			if err != nil {
-				return errors.New("failed to send message")
+				return errors.Wrap(err, "sending message")
 			}
 		case <-ctx.Done():
 			break loop

--- a/pkg/infrastructure/grpc/controller_service_client.go
+++ b/pkg/infrastructure/grpc/controller_service_client.go
@@ -101,7 +101,7 @@ func (c *ControllerServiceClient) StreamBuildLog(ctx context.Context, address st
 			ch <- st.Msg()
 		}
 		if err := st.Err(); err != nil && !errors.Is(err, context.Canceled) {
-			slog.ErrorContext(ctx, "failed to receive build log stream", "error", err)
+			slog.WarnContext(ctx, "failed to receive build log stream", "error", err)
 		}
 	}()
 	return ch, nil

--- a/pkg/infrastructure/log/loki/streamer.go
+++ b/pkg/infrastructure/log/loki/streamer.go
@@ -137,7 +137,7 @@ func (l *lokiStreamer) Stream(ctx context.Context, app *domain.Application, begi
 			logSeq, err := l.readStream(ctx, logQL, lastSeenTime)
 			if err != nil {
 				if !errors.Is(err, context.Canceled) {
-					slog.ErrorContext(ctx, "failed to read log stream", "error", err)
+					slog.WarnContext(ctx, "failed to read log stream", "error", err)
 				}
 				return
 			}
@@ -193,12 +193,12 @@ func (l *lokiStreamer) readStream(ctx context.Context, query string, start time.
 				var res streamResponse
 				err := json.Unmarshal(b, &res)
 				if err != nil {
-					slog.ErrorContext(ctx, "failed to decode ws message", "error", err)
+					slog.WarnContext(ctx, "failed to decode ws message", "error", err)
 					continue // fail-safe
 				}
 				logs, err := res.Streams.toSortedResponse(true)
 				if err != nil {
-					slog.ErrorContext(ctx, "failed to decode ws message", "error", err)
+					slog.WarnContext(ctx, "failed to decode ws message", "error", err)
 					continue // fail-safe
 				}
 				for _, l := range logs {

--- a/pkg/infrastructure/log/loki/streamer.go
+++ b/pkg/infrastructure/log/loki/streamer.go
@@ -85,7 +85,7 @@ func (l *lokiStreamer) LogLimit() int {
 func (l *lokiStreamer) Get(ctx context.Context, app *domain.Application, before time.Time, limit int) ([]*domain.ContainerLog, error) {
 	req, err := http.NewRequestWithContext(ctx, "GET", l.queryRangeEndpoint(), nil)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to create http request")
+		return nil, errors.Wrap(err, "creating http request")
 	}
 	logQL, err := l.logQL(app)
 	if err != nil {
@@ -101,12 +101,12 @@ func (l *lokiStreamer) Get(ctx context.Context, app *domain.Application, before 
 
 	hres, err := l.client.Do(req)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to perform http request")
+		return nil, errors.Wrap(err, "performing http request")
 	}
 	var res queryRangeResponse
 	err = json.NewDecoder(hres.Body).Decode(&res)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to decode response")
+		return nil, errors.Wrap(err, "decoding response")
 	}
 
 	if res.Status != "success" {

--- a/pkg/infrastructure/log/loki/types.go
+++ b/pkg/infrastructure/log/loki/types.go
@@ -69,7 +69,7 @@ func (values streamValues) toSortedResponse(asc bool) ([]*domain.ContainerLog, e
 		for _, v := range sv.Values {
 			logTime, err := v.time()
 			if err != nil {
-				return nil, errors.Wrap(err, "failed to decode response time")
+				return nil, errors.Wrap(err, "decoding response time")
 			}
 			logs = append(logs, &domain.ContainerLog{
 				Time: logTime,

--- a/pkg/infrastructure/log/victorialogs/streamer.go
+++ b/pkg/infrastructure/log/victorialogs/streamer.go
@@ -101,7 +101,7 @@ func (l *victoriaLogsStreamer) Get(ctx context.Context, app *domain.Application,
 	defer res.Body.Close()
 	if res.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(res.Body)
-		return nil, fmt.Errorf("request failed with status %d: %s", res.StatusCode, string(body))
+		return nil, errors.Errorf("request failed with status %d: %s", res.StatusCode, string(body))
 	}
 
 	var lines []*domain.ContainerLog
@@ -134,7 +134,7 @@ func (l *victoriaLogsStreamer) Stream(ctx context.Context, app *domain.Applicati
 	}
 	if res.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(res.Body)
-		return nil, fmt.Errorf("request failed with status %d: %s", res.StatusCode, string(body))
+		return nil, errors.Errorf("request failed with status %d: %s", res.StatusCode, string(body))
 	}
 
 	ch := make(chan *domain.ContainerLog, 100)

--- a/pkg/infrastructure/log/victorialogs/streamer.go
+++ b/pkg/infrastructure/log/victorialogs/streamer.go
@@ -81,7 +81,7 @@ func (l *victoriaLogsStreamer) LogLimit() int {
 func (l *victoriaLogsStreamer) Get(ctx context.Context, app *domain.Application, before time.Time, limit int) ([]*domain.ContainerLog, error) {
 	req, err := http.NewRequestWithContext(ctx, "GET", l.queryEndpoint(), nil)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to create http request")
+		return nil, errors.Wrap(err, "creating http request")
 	}
 	logsQL, err := l.logsQL(app)
 	if err != nil {
@@ -118,7 +118,7 @@ func (l *victoriaLogsStreamer) Get(ctx context.Context, app *domain.Application,
 func (l *victoriaLogsStreamer) Stream(ctx context.Context, app *domain.Application, begin time.Time) (<-chan *domain.ContainerLog, error) {
 	req, err := http.NewRequestWithContext(ctx, "GET", l.tailEndpoint(), nil)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to create http request")
+		return nil, errors.Wrap(err, "creating http request")
 	}
 	logsQL, err := l.logsQL(app)
 	if err != nil {

--- a/pkg/infrastructure/log/victorialogs/streamer.go
+++ b/pkg/infrastructure/log/victorialogs/streamer.go
@@ -146,7 +146,7 @@ func (l *victoriaLogsStreamer) Stream(ctx context.Context, app *domain.Applicati
 
 		for line, err := range decodeQuery(res.Body) {
 			if err != nil {
-				slog.ErrorContext(ctx, "failed to decode query response", "error", err)
+				slog.WarnContext(ctx, "failed to decode query response", "error", err)
 				return
 			}
 			select {

--- a/pkg/infrastructure/registry/registry.go
+++ b/pkg/infrastructure/registry/registry.go
@@ -3,7 +3,7 @@ package registry
 import (
 	"context"
 
-	"github.com/pkg/errors"
+	"github.com/friendsofgo/errors"
 	"github.com/regclient/regclient"
 	"github.com/regclient/regclient/config"
 	"github.com/regclient/regclient/scheme"
@@ -44,11 +44,11 @@ func NewClient(conf builder.ImageConfig) builder.RegistryClient {
 func (c *client) DeleteImage(ctx context.Context, image, tag string) error {
 	ref, err := ref.New(image + ":" + tag)
 	if err != nil {
-		return errors.Wrap(err, "invalid image reference")
+		return errors.Wrap(err, "parsing image reference")
 	}
 	err = c.regclient.TagDelete(ctx, ref)
 	if err != nil {
-		return errors.Wrap(err, "delete image")
+		return errors.Wrap(err, "deleting image")
 	}
 	return nil
 }
@@ -56,7 +56,7 @@ func (c *client) DeleteImage(ctx context.Context, image, tag string) error {
 func (c *client) GetTags(ctx context.Context, image string) ([]string, error) {
 	ref, err := ref.New(image)
 	if err != nil {
-		return nil, errors.Wrap(err, "invalid image reference")
+		return nil, errors.Wrap(err, "parsing image reference")
 	}
 
 	const limit = 100
@@ -69,7 +69,7 @@ func (c *client) GetTags(ctx context.Context, image string) ([]string, error) {
 		}
 		tagList, err := c.regclient.TagList(ctx, ref, opts...)
 		if err != nil {
-			return nil, errors.Wrap(err, "list tags")
+			return nil, errors.Wrap(err, "listing tags")
 		}
 		tags = append(tags, tagList.Tags...)
 		if len(tagList.Tags) < limit {
@@ -83,19 +83,19 @@ func (c *client) GetTags(ctx context.Context, image string) ([]string, error) {
 func (c *client) GetImageSize(ctx context.Context, image, tag string) (int64, error) {
 	ref, err := ref.New(image + ":" + tag)
 	if err != nil {
-		return 0, errors.Wrap(err, "invalid image reference")
+		return 0, errors.Wrap(err, "parsing image reference")
 	}
 	m, err := c.regclient.ManifestGet(ctx, ref)
 	if err != nil {
-		return 0, errors.Wrap(err, "get manifest")
+		return 0, errors.Wrap(err, "getting manifest")
 	}
 	imager, ok := m.(manifest.Imager)
 	if !ok {
-		return 0, errors.New("interface conversion failed: manifest is not Imager")
+		return 0, errors.New("manifest is not an Imager")
 	}
 	layers, err := imager.GetLayers()
 	if err != nil {
-		return 0, errors.Wrap(err, "get image layers")
+		return 0, errors.Wrap(err, "getting image layers")
 	}
 
 	size := lo.SumBy(layers, func(l descriptor.Descriptor) int64 { return l.Size })

--- a/pkg/infrastructure/registry/registry.go
+++ b/pkg/infrastructure/registry/registry.go
@@ -91,7 +91,7 @@ func (c *client) GetImageSize(ctx context.Context, image, tag string) (int64, er
 	}
 	imager, ok := m.(manifest.Imager)
 	if !ok {
-		return 0, errors.New("manifest is not an Imager")
+		return 0, errors.Errorf("manifest %T is not an Imager", m)
 	}
 	layers, err := imager.GetLayers()
 	if err != nil {

--- a/pkg/infrastructure/repository/application.go
+++ b/pkg/infrastructure/repository/application.go
@@ -61,7 +61,7 @@ func (r *applicationRepository) GetApplications(ctx context.Context, cond domain
 
 	applications, err := models.Applications(mods...).All(ctx, r.db)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to get applications")
+		return nil, errors.Wrap(err, "getting applications")
 	}
 	return ds.Map(applications, repoconvert.ToDomainApplication), nil
 }
@@ -83,7 +83,7 @@ func (r *applicationRepository) getApplication(ctx context.Context, id string, f
 		if isNoRowsErr(err) {
 			return nil, ErrNotFound
 		}
-		return nil, errors.Wrap(err, "failed to get application")
+		return nil, errors.Wrap(err, "getting application")
 	}
 	return app, nil
 }
@@ -99,13 +99,13 @@ func (r *applicationRepository) GetApplication(ctx context.Context, id string) (
 func (r *applicationRepository) CreateApplication(ctx context.Context, app *domain.Application) error {
 	tx, err := r.db.BeginTx(ctx, nil)
 	if err != nil {
-		return errors.Wrap(err, "failed to start transaction")
+		return errors.Wrap(err, "starting transaction")
 	}
 	defer tx.Rollback()
 
 	ma := repoconvert.FromDomainApplication(app)
 	if err = ma.Insert(ctx, tx, boil.Blacklist()); err != nil {
-		return errors.Wrap(err, "failed to create application")
+		return errors.Wrap(err, "creating application")
 	}
 
 	mc := repoconvert.FromDomainApplicationConfig(app.ID, &app.Config)
@@ -130,7 +130,7 @@ func (r *applicationRepository) CreateApplication(ctx context.Context, app *doma
 	}
 
 	if err = tx.Commit(); err != nil {
-		return errors.Wrap(err, "failed to commit transaction")
+		return errors.Wrap(err, "committing transaction")
 	}
 
 	return nil
@@ -139,7 +139,7 @@ func (r *applicationRepository) CreateApplication(ctx context.Context, app *doma
 func (r *applicationRepository) UpdateApplication(ctx context.Context, id string, args *domain.UpdateApplicationArgs) error {
 	tx, err := r.db.BeginTx(ctx, nil)
 	if err != nil {
-		return errors.Wrap(err, "failed to start transaction")
+		return errors.Wrap(err, "starting transaction")
 	}
 	defer tx.Rollback()
 
@@ -199,7 +199,7 @@ func (r *applicationRepository) UpdateApplication(ctx context.Context, id string
 		mac := repoconvert.FromDomainApplicationConfig(app.ID, &args.Config.V)
 		err = mac.Upsert(ctx, tx, boil.Blacklist(), boil.Blacklist())
 		if err != nil {
-			return errors.Wrap(err, "failed to update config")
+			return errors.Wrap(err, "updating config")
 		}
 	}
 	if args.Websites.Valid {
@@ -223,7 +223,7 @@ func (r *applicationRepository) UpdateApplication(ctx context.Context, id string
 
 	err = tx.Commit()
 	if err != nil {
-		return errors.Wrap(err, "failed to commit transaction")
+		return errors.Wrap(err, "committing transaction")
 	}
 
 	return err
@@ -242,7 +242,7 @@ func (r *applicationRepository) BulkUpdateState(ctx context.Context, states []*d
 			models.ApplicationColumns.ContainerMessage,
 		))
 		if err != nil {
-			return errors.Wrap(err, "failed to update container state")
+			return errors.Wrap(err, "updating container state")
 		}
 	}
 	return nil
@@ -255,23 +255,23 @@ func (r *applicationRepository) DeleteApplication(ctx context.Context, id string
 	}
 	err = app.SetUsers(ctx, r.db, false)
 	if err != nil {
-		return errors.Wrap(err, "failed to delete application owners")
+		return errors.Wrap(err, "deleting application owners")
 	}
 	_, err = app.R.PortPublications.DeleteAll(ctx, r.db)
 	if err != nil {
-		return errors.Wrap(err, "failed to delete port publications")
+		return errors.Wrap(err, "deleting port publications")
 	}
 	_, err = app.R.Websites.DeleteAll(ctx, r.db)
 	if err != nil {
-		return errors.Wrap(err, "failed to delete websites")
+		return errors.Wrap(err, "deleting websites")
 	}
 	_, err = app.R.ApplicationConfig.Delete(ctx, r.db)
 	if err != nil {
-		return errors.Wrap(err, "failed to delete application config")
+		return errors.Wrap(err, "deleting application config")
 	}
 	_, err = app.Delete(ctx, r.db)
 	if err != nil {
-		return errors.Wrap(err, "failed to delete application")
+		return errors.Wrap(err, "deleting application")
 	}
 	return nil
 }
@@ -280,14 +280,14 @@ func (r *applicationRepository) setWebsites(ctx context.Context, ex boil.Context
 	if app.R != nil && app.R.Websites != nil {
 		_, err := app.R.Websites.DeleteAll(ctx, ex)
 		if err != nil {
-			return errors.Wrap(err, "failed to delete existing app websites")
+			return errors.Wrap(err, "deleting existing app websites")
 		}
 	}
 	for _, w := range websites {
 		mw := repoconvert.FromDomainWebsite(app.ID, w)
 		err := mw.Insert(ctx, ex, boil.Blacklist())
 		if err != nil {
-			return errors.Wrap(err, "failed to insert website")
+			return errors.Wrap(err, "inserting website")
 		}
 	}
 	return nil
@@ -314,14 +314,14 @@ func (r *applicationRepository) setOwners(ctx context.Context, ex boil.ContextEx
 	ownerIDs = lo.Uniq(ownerIDs)
 	users, err := models.Users(models.UserWhere.ID.IN(ownerIDs)).All(ctx, ex)
 	if err != nil {
-		return errors.Wrap(err, "failed to get owners")
+		return errors.Wrap(err, "getting owners")
 	}
 	if len(users) < len(ownerIDs) {
 		return ErrNotFound
 	}
 	err = app.SetUsers(ctx, ex, false, users...)
 	if err != nil {
-		return errors.Wrap(err, "failed to add owners")
+		return errors.Wrap(err, "adding owners")
 	}
 	return nil
 }

--- a/pkg/infrastructure/repository/application.go
+++ b/pkg/infrastructure/repository/application.go
@@ -111,7 +111,7 @@ func (r *applicationRepository) CreateApplication(ctx context.Context, app *doma
 	mc := repoconvert.FromDomainApplicationConfig(app.ID, &app.Config)
 	err = mc.Insert(ctx, tx, boil.Blacklist())
 	if err != nil {
-		return fmt.Errorf("failed to create application config")
+		return errors.Wrap(err, "creating application config")
 	}
 
 	err = r.setWebsites(ctx, tx, ma, app.Websites)

--- a/pkg/infrastructure/repository/artifact.go
+++ b/pkg/infrastructure/repository/artifact.go
@@ -60,7 +60,7 @@ func (r *artifactRepository) GetArtifact(ctx context.Context, id string) (*domai
 func (r *artifactRepository) GetArtifacts(ctx context.Context, cond domain.GetArtifactCondition) ([]*domain.Artifact, error) {
 	artifacts, err := models.Artifacts(r.buildMods(cond)...).All(ctx, r.db)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to get artifacts")
+		return nil, errors.Wrap(err, "getting artifacts")
 	}
 	return ds.Map(artifacts, repoconvert.ToDomainArtifact), nil
 }
@@ -68,7 +68,7 @@ func (r *artifactRepository) GetArtifacts(ctx context.Context, cond domain.GetAr
 func (r *artifactRepository) CreateArtifact(ctx context.Context, artifact *domain.Artifact) error {
 	ma := repoconvert.FromDomainArtifact(artifact)
 	if err := ma.Insert(ctx, r.db, boil.Blacklist()); err != nil {
-		return errors.Wrap(err, "failed to insert artifact")
+		return errors.Wrap(err, "inserting artifact")
 	}
 	return nil
 }
@@ -76,7 +76,7 @@ func (r *artifactRepository) CreateArtifact(ctx context.Context, artifact *domai
 func (r *artifactRepository) UpdateArtifact(ctx context.Context, id string, args domain.UpdateArtifactArgs) error {
 	artifact, err := models.Artifacts(models.ArtifactWhere.ID.EQ(id)).One(ctx, r.db)
 	if err != nil {
-		return errors.Wrap(err, "failed to get artifact")
+		return errors.Wrap(err, "getting artifact")
 	}
 
 	var cols []string
@@ -88,7 +88,7 @@ func (r *artifactRepository) UpdateArtifact(ctx context.Context, id string, args
 	if len(cols) > 0 {
 		_, err = artifact.Update(ctx, r.db, boil.Whitelist(cols...))
 		if err != nil {
-			return errors.Wrap(err, "failed to update artifact")
+			return errors.Wrap(err, "updating artifact")
 		}
 	}
 
@@ -98,11 +98,11 @@ func (r *artifactRepository) UpdateArtifact(ctx context.Context, id string, args
 func (r *artifactRepository) HardDeleteArtifacts(ctx context.Context, cond domain.GetArtifactCondition) error {
 	artifacts, err := models.Artifacts(r.buildMods(cond)...).All(ctx, r.db)
 	if err != nil {
-		return errors.Wrap(err, "failed to get artifacts")
+		return errors.Wrap(err, "getting artifacts")
 	}
 	_, err = artifacts.DeleteAll(ctx, r.db)
 	if err != nil {
-		return errors.Wrap(err, "failed to delete artifacts")
+		return errors.Wrap(err, "deleting artifacts")
 	}
 	return nil
 }

--- a/pkg/infrastructure/repository/build.go
+++ b/pkg/infrastructure/repository/build.go
@@ -73,7 +73,7 @@ func (r *buildRepository) GetBuilds(ctx context.Context, cond domain.GetBuildCon
 	mods = append(mods, r.buildMods(cond)...)
 	builds, err := models.Builds(mods...).All(ctx, r.db)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to get builds")
+		return nil, errors.Wrap(err, "getting builds")
 	}
 	return ds.Map(builds, repoconvert.ToDomainBuild), nil
 }
@@ -95,7 +95,7 @@ FROM builds b1
 WHERE b2.application_id IS NULL AND b1.application_id IN (`+inClause+`)`),
 	).All(ctx, r.db)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to list latest builds")
+		return nil, errors.Wrap(err, "listing latest builds")
 	}
 	return ds.Map(builds, repoconvert.ToDomainBuild), nil
 }
@@ -110,7 +110,7 @@ func (r *buildRepository) GetBuild(ctx context.Context, buildID string) (*domain
 		if isNoRowsErr(err) {
 			return nil, ErrNotFound
 		}
-		return nil, errors.Wrap(err, "failed to find build")
+		return nil, errors.Wrap(err, "finding build")
 	}
 	return repoconvert.ToDomainBuild(build), nil
 }
@@ -119,7 +119,7 @@ func (r *buildRepository) CreateBuild(ctx context.Context, build *domain.Build) 
 	mb := repoconvert.FromDomainBuild(build)
 	err := mb.Insert(ctx, r.db, boil.Blacklist())
 	if err != nil {
-		return errors.Wrap(err, "failed to insert build")
+		return errors.Wrap(err, "inserting build")
 	}
 	return nil
 }
@@ -144,7 +144,7 @@ func (r *buildRepository) UpdateBuild(ctx context.Context, cond domain.GetBuildC
 
 	n, err := models.Builds(r.buildMods(cond)...).UpdateAll(ctx, r.db, cols)
 	if err != nil {
-		return 0, errors.Wrap(err, "failed to update build")
+		return 0, errors.Wrap(err, "updating build")
 	}
 	return n, nil
 }
@@ -157,7 +157,7 @@ func (r *buildRepository) MarkCommitAsRetriable(ctx context.Context, application
 		models.BuildColumns.Retriable: true,
 	})
 	if err != nil {
-		return errors.Wrap(err, "failed to mark commit as retriable")
+		return errors.Wrap(err, "marking commit as retriable")
 	}
 	return nil
 }
@@ -165,11 +165,11 @@ func (r *buildRepository) MarkCommitAsRetriable(ctx context.Context, application
 func (r *buildRepository) DeleteBuilds(ctx context.Context, cond domain.GetBuildCondition) error {
 	builds, err := models.Builds(r.buildMods(cond)...).All(ctx, r.db)
 	if err != nil {
-		return errors.Wrap(err, "failed to get builds")
+		return errors.Wrap(err, "getting builds")
 	}
 	_, err = builds.DeleteAll(ctx, r.db)
 	if err != nil {
-		return errors.Wrap(err, "failed to delete builds")
+		return errors.Wrap(err, "deleting builds")
 	}
 	return nil
 }

--- a/pkg/infrastructure/repository/environment.go
+++ b/pkg/infrastructure/repository/environment.go
@@ -48,7 +48,7 @@ func (r *environmentRepository) SetEnv(ctx context.Context, env *domain.Environm
 	// NOTE: sqlboiler does not recognize multiple column unique keys: https://github.com/aarondl/sqlboiler/issues/328
 	tx, err := r.db.BeginTx(ctx, nil)
 	if err != nil {
-		return errors.Wrap(err, "failed to start transaction")
+		return errors.Wrap(err, "starting transaction")
 	}
 	defer tx.Rollback()
 
@@ -58,7 +58,7 @@ func (r *environmentRepository) SetEnv(ctx context.Context, env *domain.Environm
 		qm.For("UPDATE"),
 	).One(ctx, tx)
 	if err != nil {
-		return errors.Wrap(err, "failed to get application")
+		return errors.Wrap(err, "getting application")
 	}
 
 	exists, err := models.Environments(
@@ -66,7 +66,7 @@ func (r *environmentRepository) SetEnv(ctx context.Context, env *domain.Environm
 		models.EnvironmentWhere.Key.EQ(env.Key),
 	).Exists(ctx, tx)
 	if err != nil && !isNoRowsErr(err) {
-		return errors.Wrap(err, "failed to get environment")
+		return errors.Wrap(err, "getting environment")
 	}
 
 	me := repoconvert.FromDomainEnvironment(env)
@@ -77,12 +77,12 @@ func (r *environmentRepository) SetEnv(ctx context.Context, env *domain.Environm
 		err = me.Insert(ctx, tx, boil.Blacklist())
 	}
 	if err != nil {
-		return errors.Wrap(err, "failed to upsert environment")
+		return errors.Wrap(err, "upserting environment")
 	}
 
 	err = tx.Commit()
 	if err != nil {
-		return errors.Wrap(err, "failed to commit")
+		return errors.Wrap(err, "committing")
 	}
 
 	return nil
@@ -91,11 +91,11 @@ func (r *environmentRepository) SetEnv(ctx context.Context, env *domain.Environm
 func (r *environmentRepository) DeleteEnv(ctx context.Context, cond domain.GetEnvCondition) error {
 	envs, err := models.Environments(r.buildMods(cond)...).All(ctx, r.db)
 	if err != nil {
-		return errors.Wrap(err, "failed to get env")
+		return errors.Wrap(err, "getting env")
 	}
 	_, err = envs.DeleteAll(ctx, r.db)
 	if err != nil {
-		return errors.Wrap(err, "failed to delete env")
+		return errors.Wrap(err, "deleting env")
 	}
 	return nil
 }

--- a/pkg/infrastructure/repository/git_repository.go
+++ b/pkg/infrastructure/repository/git_repository.go
@@ -55,7 +55,7 @@ func (r *gitRepositoryRepository) GetRepositories(ctx context.Context, cond doma
 
 	modelRepos, err := models.Repositories(mods...).All(ctx, r.db)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to get repositories")
+		return nil, errors.Wrap(err, "getting repositories")
 	}
 
 	repos := ds.Map(modelRepos, repoconvert.ToDomainRepository)
@@ -97,7 +97,7 @@ func (r *gitRepositoryRepository) GetRepository(ctx context.Context, id string) 
 		if isNoRowsErr(err) {
 			return nil, ErrNotFound
 		}
-		return nil, errors.Wrap(err, "failed to get repository")
+		return nil, errors.Wrap(err, "getting repository")
 	}
 	return repoconvert.ToDomainRepository(repo), nil
 }
@@ -105,21 +105,21 @@ func (r *gitRepositoryRepository) GetRepository(ctx context.Context, id string) 
 func (r *gitRepositoryRepository) CreateRepository(ctx context.Context, repo *domain.Repository) error {
 	tx, err := r.db.BeginTx(ctx, nil)
 	if err != nil {
-		return errors.Wrap(err, "failed to start transaction")
+		return errors.Wrap(err, "starting transaction")
 	}
 	defer tx.Rollback()
 
 	mr := repoconvert.FromDomainRepository(repo)
 	err = mr.Insert(ctx, tx, boil.Blacklist())
 	if err != nil {
-		return errors.Wrap(err, "failed to insert repository")
+		return errors.Wrap(err, "inserting repository")
 	}
 
 	if repo.Auth.Valid {
 		mra := repoconvert.FromDomainRepositoryAuth(repo.ID, &repo.Auth.V)
 		err = mra.Insert(ctx, tx, boil.Blacklist())
 		if err != nil {
-			return errors.Wrap(err, "failed to insert repository auth")
+			return errors.Wrap(err, "inserting repository auth")
 		}
 	}
 
@@ -130,7 +130,7 @@ func (r *gitRepositoryRepository) CreateRepository(ctx context.Context, repo *do
 
 	err = tx.Commit()
 	if err != nil {
-		return errors.Wrap(err, "failed to commit transaction")
+		return errors.Wrap(err, "committing transaction")
 	}
 
 	return nil
@@ -139,13 +139,13 @@ func (r *gitRepositoryRepository) CreateRepository(ctx context.Context, repo *do
 func (r *gitRepositoryRepository) UpdateRepository(ctx context.Context, id string, args *domain.UpdateRepositoryArgs) error {
 	tx, err := r.db.BeginTx(ctx, nil)
 	if err != nil {
-		return errors.Wrap(err, "failed to begin transaction")
+		return errors.Wrap(err, "beginning transaction")
 	}
 	defer tx.Rollback()
 
 	repo, err := r.getRepository(ctx, tx, id)
 	if err != nil {
-		return errors.Wrap(err, "failed to get repository")
+		return errors.Wrap(err, "getting repository")
 	}
 	var cols []string
 
@@ -161,7 +161,7 @@ func (r *gitRepositoryRepository) UpdateRepository(ctx context.Context, id strin
 	if len(cols) > 0 {
 		_, err = repo.Update(ctx, tx, boil.Whitelist(cols...))
 		if err != nil {
-			return errors.Wrap(err, "failed to update repository")
+			return errors.Wrap(err, "updating repository")
 		}
 	}
 
@@ -169,14 +169,14 @@ func (r *gitRepositoryRepository) UpdateRepository(ctx context.Context, id strin
 		if repo.R != nil && repo.R.RepositoryAuth != nil {
 			_, err = repo.R.RepositoryAuth.Delete(ctx, tx)
 			if err != nil {
-				return errors.Wrap(err, "failed to delete existing repository auth")
+				return errors.Wrap(err, "deleting existing repository auth")
 			}
 		}
 		if args.Auth.V.Valid {
 			mra := repoconvert.FromDomainRepositoryAuth(repo.ID, &args.Auth.V.V)
 			err = repo.SetRepositoryAuth(ctx, tx, true, mra)
 			if err != nil {
-				return errors.Wrap(err, "failed to set repository auth")
+				return errors.Wrap(err, "setting repository auth")
 			}
 		}
 	}
@@ -190,7 +190,7 @@ func (r *gitRepositoryRepository) UpdateRepository(ctx context.Context, id strin
 
 	err = tx.Commit()
 	if err != nil {
-		return errors.Wrap(err, "failed to commit transaction")
+		return errors.Wrap(err, "committing transaction")
 	}
 	return nil
 }
@@ -199,14 +199,14 @@ func (r *gitRepositoryRepository) setOwners(ctx context.Context, ex boil.Context
 	ownerIDs = lo.Uniq(ownerIDs)
 	users, err := models.Users(models.UserWhere.ID.IN(ownerIDs)).All(ctx, ex)
 	if err != nil {
-		return errors.Wrap(err, "failed to get users")
+		return errors.Wrap(err, "getting users")
 	}
 	if len(users) < len(ownerIDs) {
 		return ErrNotFound
 	}
 	err = repo.SetUsers(ctx, ex, false, users...)
 	if err != nil {
-		return errors.Wrap(err, "failed to")
+		return errors.Wrap(err, "setting repository owners")
 	}
 	return nil
 }
@@ -218,17 +218,17 @@ func (r *gitRepositoryRepository) DeleteRepository(ctx context.Context, id strin
 	}
 	err = repo.SetUsers(ctx, r.db, false)
 	if err != nil {
-		return errors.Wrap(err, "failed to delete repository owners")
+		return errors.Wrap(err, "deleting repository owners")
 	}
 	if repo.R.RepositoryAuth != nil {
 		_, err = repo.R.RepositoryAuth.Delete(ctx, r.db)
 		if err != nil {
-			return errors.Wrap(err, "failed to delete repository auth")
+			return errors.Wrap(err, "deleting repository auth")
 		}
 	}
 	_, err = repo.Delete(ctx, r.db)
 	if err != nil {
-		return errors.Wrap(err, "failed to delete repository")
+		return errors.Wrap(err, "deleting repository")
 	}
 	return nil
 }

--- a/pkg/infrastructure/repository/repository_commit.go
+++ b/pkg/infrastructure/repository/repository_commit.go
@@ -30,7 +30,7 @@ func (r *repositoryCommitRepository) GetCommits(ctx context.Context, hashes []st
 		models.RepositoryCommitWhere.Hash.IN(hashes),
 	).All(ctx, r.db)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to query repository commits")
+		return nil, errors.Wrap(err, "querying repository commits")
 	}
 
 	return ds.Map(commits, repoconvert.ToDomainRepositoryCommit), nil
@@ -40,7 +40,7 @@ func (r *repositoryCommitRepository) RecordCommit(ctx context.Context, commit *d
 	m := repoconvert.FromDomainRepositoryCommit(commit)
 	err := m.Insert(ctx, r.db, boil.Blacklist())
 	if err != nil {
-		return errors.Wrap(err, "failed to insert repository commit")
+		return errors.Wrap(err, "inserting repository commit")
 	}
 	return nil
 }

--- a/pkg/infrastructure/repository/runtime_image.go
+++ b/pkg/infrastructure/repository/runtime_image.go
@@ -28,7 +28,7 @@ func (r *runtimeImageRepository) CreateRuntimeImage(ctx context.Context, image *
 	ri := repoconvert.FromDomainRuntimeImage(image)
 	err := ri.Insert(ctx, r.db, boil.Infer())
 	if err != nil {
-		return errors.Wrap(err, "failed to insert runtime image")
+		return errors.Wrap(err, "inserting runtime image")
 	}
 	return nil
 }
@@ -44,11 +44,11 @@ func (r *runtimeImageRepository) DeleteRuntimeImagesByAppID(ctx context.Context,
 		models.BuildWhere.ApplicationID.EQ(appID),
 	).All(ctx, r.db)
 	if err != nil {
-		return errors.Wrap(err, "failed to get runtime images")
+		return errors.Wrap(err, "getting runtime images")
 	}
 	_, err = images.DeleteAll(ctx, r.db)
 	if err != nil {
-		return errors.Wrap(err, "failed to delete runtime images")
+		return errors.Wrap(err, "deleting runtime images")
 	}
 	return nil
 }

--- a/pkg/infrastructure/repository/user.go
+++ b/pkg/infrastructure/repository/user.go
@@ -42,7 +42,7 @@ func (r *userRepository) GetUsers(ctx context.Context, cond domain.GetUserCondit
 func (r *userRepository) EnsureUser(ctx context.Context, name string) (*domain.User, error) {
 	tx, err := r.db.BeginTx(ctx, nil)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to begin transaction")
+		return nil, errors.Wrap(err, "beginning transaction")
 	}
 	defer tx.Rollback()
 
@@ -51,7 +51,7 @@ func (r *userRepository) EnsureUser(ctx context.Context, name string) (*domain.U
 		qm.For("UPDATE"),
 	).One(ctx, tx)
 	if err != nil && !isNoRowsErr(err) {
-		return nil, errors.Wrap(err, "failed to get user")
+		return nil, errors.Wrap(err, "getting user")
 	}
 
 	if isNoRowsErr(err) {
@@ -59,13 +59,13 @@ func (r *userRepository) EnsureUser(ctx context.Context, name string) (*domain.U
 		mu = repoconvert.FromDomainUser(user)
 		err = mu.Insert(ctx, tx, boil.Blacklist())
 		if err != nil {
-			return nil, errors.Wrap(err, "failed to insert user")
+			return nil, errors.Wrap(err, "inserting user")
 		}
 	}
 
 	err = tx.Commit()
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to commit")
+		return nil, errors.Wrap(err, "committing")
 	}
 
 	return repoconvert.ToDomainUser(mu), nil
@@ -102,7 +102,7 @@ func (r *userRepository) EnsureUsers(ctx context.Context, names []string) ([]*do
 
 	err = tx.Commit()
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to commit")
+		return nil, errors.Wrap(err, "committing")
 	}
 
 	return lo.MapToSlice(modelUsers, func(name string, mu *models.User) *domain.User {

--- a/pkg/infrastructure/repository/website.go
+++ b/pkg/infrastructure/repository/website.go
@@ -25,7 +25,7 @@ func NewWebsiteRepository(db *sql.DB) domain.WebsiteRepository {
 func (w *websiteRepository) GetWebsites(ctx context.Context) ([]*domain.Website, error) {
 	websites, err := models.Websites().All(ctx, w.db)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to get websites")
+		return nil, errors.Wrap(err, "getting websites")
 	}
 	return ds.Map(websites, repoconvert.ToDomainWebsite), nil
 }

--- a/pkg/infrastructure/storage/local.go
+++ b/pkg/infrastructure/storage/local.go
@@ -1,10 +1,11 @@
 package storage
 
 import (
-	"fmt"
 	"io"
 	"os"
 	"path/filepath"
+
+	"github.com/friendsofgo/errors"
 
 	"github.com/traPtitech/neoshowcase/pkg/domain"
 )
@@ -18,10 +19,10 @@ type LocalStorage struct {
 func NewLocalStorage(dir string) (*LocalStorage, error) {
 	fi, err := os.Stat(dir)
 	if err != nil {
-		return &LocalStorage{}, fmt.Errorf("dir %s doesn't exist", dir)
+		return &LocalStorage{}, errors.Wrapf(err, "checking dir %s", dir)
 	}
 	if !fi.IsDir() {
-		return &LocalStorage{}, fmt.Errorf("dir %s is not a directory", dir)
+		return &LocalStorage{}, errors.Errorf("dir %s is not a directory", dir)
 	}
 
 	return &LocalStorage{localDir: dir}, nil

--- a/pkg/infrastructure/storage/s3.go
+++ b/pkg/infrastructure/storage/s3.go
@@ -28,7 +28,7 @@ func NewS3Storage(bucket, accessKey, accessSecret, region, endpoint string) (*S3
 		config.WithRegion(region),
 	)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to load AWS config")
+		return nil, errors.Wrap(err, "loading AWS config")
 	}
 
 	client := s3.NewFromConfig(cfg, func(o *s3.Options) {

--- a/pkg/infrastructure/webhook/gitea.go
+++ b/pkg/infrastructure/webhook/gitea.go
@@ -30,7 +30,7 @@ func (r *Receiver) giteaHandler(c *echo.Context) error {
 	case gitea.RepositoryPayload:
 		slog.Info("Repository event received", "action", p.Action)
 		if err := r.giteaIntegration.Sync(context.Background()); err != nil {
-			slog.Error("Failed to sync gitea repositories", "error", err)
+			slog.Warn("failed to sync gitea repositories", "error", err)
 		}
 	default:
 		return echo.NewHTTPError(http.StatusInternalServerError, "unsupported payload type")

--- a/pkg/infrastructure/webhook/receiver.go
+++ b/pkg/infrastructure/webhook/receiver.go
@@ -82,7 +82,7 @@ func (r *Receiver) updateURLs(urls []string) {
 	ctx := context.Background()
 	repos, err := r.gitRepo.GetRepositories(ctx, domain.GetRepositoryCondition{URLs: optional.From(urls)})
 	if err != nil {
-		slog.ErrorContext(ctx, "failed to get repositories by url", "error", err)
+		slog.WarnContext(ctx, "failed to get repositories by url", "error", err)
 		return
 	}
 	for _, repo := range repos {

--- a/pkg/usecase/apiserver/app_build_service.go
+++ b/pkg/usecase/apiserver/app_build_service.go
@@ -41,7 +41,7 @@ func (s *Service) RetryCommitBuild(ctx context.Context, applicationID string, co
 	// NOTE: requires the app to be running for builds to register
 	err = s.controller.RegisterBuild(ctx, applicationID)
 	if err != nil {
-		return errors.Wrap(err, "failed to request new build registration")
+		return errors.Wrap(err, "requesting new build registration")
 	}
 	return nil
 }
@@ -54,7 +54,7 @@ func (s *Service) CancelBuild(ctx context.Context, buildID string) error {
 
 	err = s.controller.CancelBuild(ctx, buildID)
 	if err != nil {
-		return errors.Wrap(err, "failed to request cancel build")
+		return errors.Wrap(err, "requesting cancel build")
 	}
 	return nil
 }
@@ -83,14 +83,14 @@ func (s *Service) GetBuildLogStream(ctx context.Context, buildID string) (<-chan
 
 	addr, err := s.controller.DiscoverBuildLogInstance(ctx, buildID)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to discover build log instance")
+		return nil, errors.Wrap(err, "discovering build log instance")
 	}
 	if addr.Address == nil {
 		return nil, newError(ErrorTypeBadRequest, "build log instance not found", nil)
 	}
 	ch, err := s.controller.StreamBuildLog(ctx, *addr.Address, buildID)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to connect to build log stream")
+		return nil, errors.Wrap(err, "connecting to build log stream")
 	}
 	return ch, nil
 }

--- a/pkg/usecase/apiserver/app_config_service.go
+++ b/pkg/usecase/apiserver/app_config_service.go
@@ -58,7 +58,7 @@ func (s *Service) StartApplication(ctx context.Context, id string) error {
 		UpdatedAt: optional.From(time.Now()),
 	})
 	if err != nil {
-		return errors.Wrap(err, "failed to mark application as running")
+		return errors.Wrap(err, "marking application as running")
 	}
 
 	app, err := s.appRepo.GetApplication(ctx, id)
@@ -67,11 +67,11 @@ func (s *Service) StartApplication(ctx context.Context, id string) error {
 	}
 	err = s.controller.FetchRepository(ctx, app.RepositoryID)
 	if err != nil {
-		return errors.Wrap(err, "failed to request repository fetch")
+		return errors.Wrap(err, "requesting repository fetch")
 	}
 	err = s.controller.SyncDeployments(ctx)
 	if err != nil {
-		return errors.Wrap(err, "failed to request sync deployment")
+		return errors.Wrap(err, "requesting sync deployment")
 	}
 	return nil
 }
@@ -87,12 +87,12 @@ func (s *Service) StopApplication(ctx context.Context, id string) error {
 		UpdatedAt: optional.From(time.Now()),
 	})
 	if err != nil {
-		return errors.Wrap(err, "failed to mark application as not running")
+		return errors.Wrap(err, "marking application as not running")
 	}
 
 	err = s.controller.SyncDeployments(ctx)
 	if err != nil {
-		return errors.Wrap(err, "failed to request sync deployment")
+		return errors.Wrap(err, "requesting sync deployment")
 	}
 	return nil
 }

--- a/pkg/usecase/apiserver/app_info_service.go
+++ b/pkg/usecase/apiserver/app_info_service.go
@@ -59,7 +59,7 @@ func (s *Service) GetOutputStream(ctx context.Context, id string, begin time.Tim
 
 	ch, err := s.containerLogger.Stream(ctx, app, begin)
 	if err != nil {
-		return errors.Wrap(err, "failed to connect to stream")
+		return errors.Wrap(err, "connecting to stream")
 	}
 
 	for {
@@ -70,7 +70,7 @@ func (s *Service) GetOutputStream(ctx context.Context, id string, begin time.Tim
 			}
 			err = send(d)
 			if err != nil {
-				return errors.Wrap(err, "failed to send log")
+				return errors.Wrap(err, "sending log")
 			}
 		case <-ctx.Done():
 			return nil

--- a/pkg/usecase/apiserver/app_service.go
+++ b/pkg/usecase/apiserver/app_service.go
@@ -49,7 +49,7 @@ func (s *Service) validateApp(ctx context.Context, app *domain.Application) erro
 func (s *Service) CreateApplication(ctx context.Context, app *domain.Application) (*domain.Application, error) {
 	repo, err := s.gitRepo.GetRepository(ctx, app.RepositoryID)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to get repository metadata")
+		return nil, errors.Wrap(err, "getting repository metadata")
 	}
 
 	for _, website := range app.Websites {
@@ -80,7 +80,7 @@ func (s *Service) CreateApplication(ctx context.Context, app *domain.Application
 	s.systemInfo.Purge()
 	err = s.controller.FetchRepository(ctx, app.RepositoryID)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to request to fetch repository")
+		return nil, errors.Wrap(err, "requesting repository fetch")
 	}
 
 	return handleRepoError(s.appRepo.GetApplication(ctx, app.ID))
@@ -282,7 +282,7 @@ func (s *Service) deleteApplicationDatabase(ctx context.Context, app *domain.App
 	if app.Config.BuildConfig.MariaDB() {
 		dbKey, ok := lo.Find(envs, func(e *domain.Environment) bool { return e.Key == domain.EnvMariaDBDatabaseKey })
 		if !ok {
-			return errors.New("failed to find mariadb name from env key")
+			return errors.New("mariadb name not found in env key")
 		}
 		err := s.mariaDBManager.Delete(ctx, domain.DeleteArgs{Database: dbKey.Value})
 		if err != nil {
@@ -293,7 +293,7 @@ func (s *Service) deleteApplicationDatabase(ctx context.Context, app *domain.App
 	if app.Config.BuildConfig.MongoDB() {
 		dbKey, ok := lo.Find(envs, func(e *domain.Environment) bool { return e.Key == domain.EnvMongoDBDatabaseKey })
 		if !ok {
-			return errors.New("failed to find mongodb name from env key")
+			return errors.New("mongodb name not found in env key")
 		}
 		err := s.mongoDBManager.Delete(ctx, domain.DeleteArgs{Database: dbKey.Value})
 		if err != nil {

--- a/pkg/usecase/apiserver/repository_service.go
+++ b/pkg/usecase/apiserver/repository_service.go
@@ -181,7 +181,7 @@ func (s *Service) DeleteRepository(ctx context.Context, id string) error {
 
 	apps, err := s.appRepo.GetApplications(ctx, domain.GetApplicationCondition{RepositoryID: optional.From(id)})
 	if err != nil {
-		return errors.Wrap(err, "failed to get related applications")
+		return errors.Wrap(err, "getting related applications")
 	}
 	if len(apps) > 0 {
 		return newError(ErrorTypeBadRequest, "all related applications must be deleted first", nil)

--- a/pkg/usecase/apiserver/service.go
+++ b/pkg/usecase/apiserver/service.go
@@ -94,7 +94,7 @@ func (s *Service) isRepositoryOwner(ctx context.Context, repoID string) error {
 	user := web.GetUser(ctx)
 	repo, err := s.gitRepo.GetRepository(ctx, repoID)
 	if err != nil {
-		return errors.Wrap(err, "failed to get repository")
+		return errors.Wrap(err, "getting repository")
 	}
 	if !repo.IsOwner(user) {
 		return newError(ErrorTypeForbidden, "you do not have permission for this repository", nil)
@@ -106,7 +106,7 @@ func (s *Service) isApplicationOwner(ctx context.Context, appID string) error {
 	user := web.GetUser(ctx)
 	app, err := s.appRepo.GetApplication(ctx, appID)
 	if err != nil {
-		return errors.Wrap(err, "failed to get application")
+		return errors.Wrap(err, "getting application")
 	}
 	if !app.IsOwner(user) {
 		return newError(ErrorTypeForbidden, "you do not have permission for this application", nil)
@@ -118,11 +118,11 @@ func (s *Service) isBuildOwner(ctx context.Context, buildID string) error {
 	user := web.GetUser(ctx)
 	build, err := s.buildRepo.GetBuild(ctx, buildID)
 	if err != nil {
-		return errors.Wrap(err, "failed to get build")
+		return errors.Wrap(err, "getting build")
 	}
 	app, err := s.appRepo.GetApplication(ctx, build.ApplicationID)
 	if err != nil {
-		return errors.Wrap(err, "failed to get application")
+		return errors.Wrap(err, "getting application")
 	}
 	if !app.IsOwner(user) {
 		return newError(ErrorTypeForbidden, "you do not have permission for this application", nil)

--- a/pkg/usecase/builder/build.go
+++ b/pkg/usecase/builder/build.go
@@ -20,11 +20,11 @@ func (s *ServiceImpl) startBuild(req *domain.StartBuildRequest) error {
 	defer s.statusLock.Unlock()
 
 	if s.state != nil {
-		slog.Warn("Skipping build request, builder busy - builder scheduling may be malfunctioning?", "build_id", req.Build.ID)
+		slog.WarnContext(context.Background(), "Skipping build request, builder busy - builder scheduling may be malfunctioning?", "build_id", req.Build.ID)
 		return nil // Builder busy - skip
 	}
 
-	slog.Info("Starting build", "build_id", req.Build.ID)
+	slog.InfoContext(context.Background(), "Starting build", "build_id", req.Build.ID)
 
 	st, err := newState(req.App, req.Envs, req.Build, req.Repo, s.client)
 	if err != nil {
@@ -47,7 +47,7 @@ func (s *ServiceImpl) startBuild(req *domain.StartBuildRequest) error {
 		s.state = nil
 		s.stateCancel = nil
 		s.statusLock.Unlock()
-		slog.Info("Build settled", "build_id", st.build.ID)
+		slog.InfoContext(ctx, "Build settled", "build_id", st.build.ID)
 		// Send settled response *after* unlocking internal state for next build
 		s.response <- &pb.BuilderResponse{Type: pb.BuilderResponse_BUILD_SETTLED, Body: &pb.BuilderResponse_Settled{Settled: &pb.BuildSettled{
 			BuildId: st.build.ID,
@@ -230,7 +230,7 @@ func (s *ServiceImpl) finalize(ctx context.Context, st *state, status domain.Bui
 func (s *ServiceImpl) fetchImageSize(ctx context.Context, st *state) (int64, error) {
 	size, err := s.regclient.GetImageSize(ctx, s.imageConfig.ImageName(st.app.ID), s.imageTag(st.build))
 	if err != nil {
-		return 0, errors.Wrap(err, "failed to get image size")
+		return 0, errors.Wrap(err, "getting image size")
 	}
 
 	return size, nil

--- a/pkg/usecase/builder/build_buildkit.go
+++ b/pkg/usecase/builder/build_buildkit.go
@@ -60,7 +60,7 @@ func createTempFile(pattern string, content string) (name string, cleanup func()
 	cleanup = func() {
 		err := os.Remove(f.Name())
 		if err != nil {
-			slog.Error("removing temp file", "file", f.Name(), "error", err)
+			slog.WarnContext(context.Background(), "removing temp file", "file", f.Name(), "error", err)
 		}
 	}
 	_, err = f.WriteString(content)

--- a/pkg/usecase/builder/build_static.go
+++ b/pkg/usecase/builder/build_static.go
@@ -26,7 +26,7 @@ func (s *ServiceImpl) buildStaticExtract(
 		})).
 		Marshal(ctx)
 	if err != nil {
-		return errors.Wrap(err, "failed to marshal llb")
+		return errors.Wrap(err, "marshaling llb")
 	}
 	mount, err := fsutil.NewFS(st.repositoryTempDir)
 	if err != nil {

--- a/pkg/usecase/builder/service.go
+++ b/pkg/usecase/builder/service.go
@@ -54,14 +54,14 @@ func NewService(
 ) (*ServiceImpl, error) {
 	systemInfo, err := client.GetBuilderSystemInfo(context.Background())
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to get builder system info")
+		return nil, errors.Wrap(err, "getting builder system info")
 	}
 	// FIXME: git service should be injected via DI,
 	// but it's currently created here because it requires a public key
 	// derived from a runtime value (SSHKey from systemInfo).
 	pubKey, err := domain.IntoPublicKey(systemInfo.SSHKey)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to convert into public key")
+		return nil, errors.Wrap(err, "converting into public key")
 	}
 	gitsvc := git.NewService(pubKey)
 	return &ServiceImpl{
@@ -127,7 +127,7 @@ func (s *ServiceImpl) cancelBuild(buildID string) {
 	if s.state != nil && s.stateCancel != nil && s.state.build.ID == buildID {
 		s.stateCancel()
 	} else {
-		slog.Warn("Skipping cancel build request - a race condition or builder scheduling malfunction?", "build_id", buildID)
+		slog.WarnContext(context.Background(), "Skipping cancel build request - a race condition or builder scheduling malfunction?", "build_id", buildID)
 	}
 }
 
@@ -137,12 +137,12 @@ func (s *ServiceImpl) onRequest(req *pb.BuilderRequest) {
 		b := req.Body.(*pb.BuilderRequest_StartBuild).StartBuild
 		err := s.startBuild(pbconvert.FromPBStartBuildRequest(b))
 		if err != nil {
-			slog.Error("failed to start build", "error", err)
+			slog.ErrorContext(context.Background(), "failed to start build", "error", err)
 		}
 	case pb.BuilderRequest_CANCEL_BUILD:
 		b := req.Body.(*pb.BuilderRequest_CancelBuild).CancelBuild
 		s.cancelBuild(b.BuildId)
 	default:
-		slog.Error("unknown builder request type", "value", req.Type)
+		slog.ErrorContext(context.Background(), "unknown builder request type", "value", req.Type)
 	}
 }

--- a/pkg/usecase/builder/state.go
+++ b/pkg/usecase/builder/state.go
@@ -24,9 +24,10 @@ type logWriter struct {
 func newLogWriter(buildID string, client domain.ControllerBuilderServiceClient) *logWriter {
 	send := make(chan []byte, 50)
 	go func() {
-		err := client.StreamBuildLog(context.Background(), buildID, send)
+		ctx := context.Background()
+		err := client.StreamBuildLog(ctx, buildID, send)
 		if err != nil {
-			slog.Error("failed to send build log", "error", err)
+			slog.WarnContext(ctx, "failed to send build log", "build_id", buildID, "error", err)
 		}
 	}()
 	return &logWriter{
@@ -84,11 +85,11 @@ func newState(app *domain.Application, envs []*domain.Environment, build *domain
 	var err error
 	st.repositoryTempDir, err = os.MkdirTemp("", "repository-")
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to create tmp repository dir")
+		return nil, errors.Wrap(err, "creating tmp repository dir")
 	}
 	st.artifactTempFile, err = os.CreateTemp("", "artifacts-")
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to create tmp artifact file")
+		return nil, errors.Wrap(err, "creating tmp artifact file")
 	}
 	return st, nil
 }

--- a/pkg/usecase/cdservice/container_state_mutator.go
+++ b/pkg/usecase/cdservice/container_state_mutator.go
@@ -42,9 +42,10 @@ func (m *ContainerStateMutator) _subscribe(backend domain.Backend) {
 	for e := range sub {
 		// coalesce events
 		go func(appID string) {
-			_, err := updateOne.Get(context.Background(), appID)
+			ctx := context.Background()
+			_, err := updateOne.Get(ctx, appID)
 			if err != nil {
-				slog.Error("failed to update app container state", "error", err)
+				slog.WarnContext(ctx, "failed to update app container state", "app_id", appID, "error", err)
 			}
 		}(e.ApplicationID)
 	}
@@ -56,14 +57,14 @@ func (m *ContainerStateMutator) _updateOne(ctx context.Context, appID string) (s
 
 	container, err := m.backend.GetContainer(ctx, appID)
 	if err != nil {
-		return struct{}{}, errors.Wrap(err, "failed to get container state")
+		return struct{}{}, errors.Wrapf(err, "getting container state (app_id=%s)", appID)
 	}
 	err = m.appRepo.UpdateApplication(ctx, appID, &domain.UpdateApplicationArgs{
 		Container:        optional.From(container.State),
 		ContainerMessage: optional.From(container.Message),
 	})
 	if err != nil {
-		return struct{}{}, errors.Wrap(err, "failed to update application")
+		return struct{}{}, errors.Wrapf(err, "updating application (app_id=%s)", appID)
 	}
 
 	return struct{}{}, nil
@@ -76,7 +77,7 @@ func (m *ContainerStateMutator) updateAll(ctx context.Context) error {
 	// Fetch all runtime apps
 	allRuntimeApps, err := m.appRepo.GetApplications(ctx, domain.GetApplicationCondition{DeployType: optional.From(domain.DeployTypeRuntime)})
 	if err != nil {
-		return errors.Wrap(err, "failed to get all runtime applications")
+		return errors.Wrap(err, "getting all runtime applications")
 	}
 	// Shard by app ID
 	allRuntimeApps = lo.Filter(allRuntimeApps, func(app *domain.Application, _ int) bool {
@@ -86,7 +87,7 @@ func (m *ContainerStateMutator) updateAll(ctx context.Context) error {
 	// Fetch actual states
 	containers, err := m.backend.ListContainers(ctx)
 	if err != nil {
-		return errors.Wrap(err, "failed to list containers")
+		return errors.Wrap(err, "listing containers")
 	}
 
 	// If actual state is not found, update state as "missing"
@@ -105,7 +106,7 @@ func (m *ContainerStateMutator) updateAll(ctx context.Context) error {
 	// Update
 	err = m.appRepo.BulkUpdateState(ctx, containers)
 	if err != nil {
-		return errors.Wrap(err, "failed to bulk update state")
+		return errors.Wrap(err, "bulk-updating container state")
 	}
 	return nil
 }

--- a/pkg/usecase/cdservice/service.go
+++ b/pkg/usecase/cdservice/service.go
@@ -81,7 +81,7 @@ func NewService(
 	doLocalStartBuild := scutil.NewCoalescer(func(ctx context.Context) error {
 		start := time.Now()
 		if err := cd.startBuildsLocal(ctx); err != nil {
-			slog.ErrorContext(ctx, "failed to start builds", "error", err)
+			slog.WarnContext(ctx, "failed to start builds", "error", err)
 			return nil
 		}
 		slog.InfoContext(ctx, "Started builds", "duration", time.Since(start))
@@ -92,16 +92,17 @@ func NewService(
 		_ = doLocalStartBuild.Do(context.Background())
 	}
 	cd.doClusterStartBuild = func() {
-		err := cd.localClient.StartBuild(context.Background())
+		ctx := context.Background()
+		err := cd.localClient.StartBuild(ctx)
 		if err != nil {
-			slog.Error("failed to broadcast StartBuild", "error", err)
+			slog.WarnContext(ctx, "failed to broadcast StartBuild", "error", err)
 		}
 	}
 
 	doLocalSyncDeploy := scutil.NewCoalescer(func(ctx context.Context) error {
 		start := time.Now()
 		if err := cd.syncDeployments(ctx); err != nil {
-			slog.ErrorContext(ctx, "failed to sync deployments", "error", err)
+			slog.WarnContext(ctx, "failed to sync deployments", "error", err)
 			return nil
 		}
 		elapsed := time.Since(start)
@@ -113,16 +114,17 @@ func NewService(
 		_ = doLocalSyncDeploy.Do(context.Background())
 	}
 	cd.doClusterSyncDeploy = func() {
-		err := cd.localClient.SyncDeployments(context.Background())
+		ctx := context.Background()
+		err := cd.localClient.SyncDeployments(ctx)
 		if err != nil {
-			slog.Error("failed to broadcast SyncDeployments", "error", err)
+			slog.WarnContext(ctx, "failed to broadcast SyncDeployments", "error", err)
 		}
 	}
 
 	doDetectBuildCrash := func(ctx context.Context) {
 		start := time.Now()
 		if err := cd.detectBuildCrash(ctx); err != nil {
-			slog.ErrorContext(ctx, "failed to detect build crash", "error", err)
+			slog.WarnContext(ctx, "failed to detect build crash", "error", err)
 		}
 		slog.DebugContext(ctx, "Build crash detection complete", "duration", time.Since(start))
 	}
@@ -156,8 +158,9 @@ func (cd *service) Run() {
 
 func (cd *service) RegisterBuild(appID string) {
 	go func() {
-		if err := cd.registerBuild(context.Background(), appID); err != nil {
-			slog.Error("failed to kickoff build for app", "app_id", appID, "error", err)
+		ctx := context.Background()
+		if err := cd.registerBuild(ctx, appID); err != nil {
+			slog.WarnContext(ctx, "failed to kickoff build for app", "app_id", appID, "error", err)
 			return
 		}
 		go cd.doClusterStartBuild()
@@ -245,7 +248,7 @@ func (cd *service) detectBuildCrash(ctx context.Context) error {
 
 	builds, err := cd.buildRepo.GetBuilds(ctx, domain.GetBuildCondition{Status: optional.From(domain.BuildStatusBuilding)})
 	if err != nil {
-		return errors.Wrap(err, "failed to get running builds")
+		return errors.Wrap(err, "getting running builds")
 	}
 	crashed := lo.Filter(builds, func(build *domain.Build, _ int) bool {
 		return now.Sub(build.UpdatedAt.ValueOrZero()) > crashDetectThreshold
@@ -258,7 +261,7 @@ func (cd *service) detectBuildCrash(ctx context.Context) error {
 			Status: optional.From(domain.BuildStatusFailed),
 		})
 		if err != nil {
-			slog.ErrorContext(ctx, "failed to mark crashed build as errored", "error", err)
+			slog.WarnContext(ctx, "failed to mark crashed build as errored", "build_id", build.ID, "error", err)
 		}
 	}
 
@@ -314,7 +317,7 @@ func (cd *service) _syncAppFields(ctx context.Context) error {
 				UpdatedAt:    optional.From(nextBuild.FinishedAt.V),
 			})
 			if err != nil {
-				return errors.Wrap(err, "failed to sync application commit")
+				return errors.Wrapf(err, "syncing application commit (app_id=%s)", app.ID)
 			}
 		}
 	}
@@ -331,7 +334,7 @@ func (cd *service) syncDeployments(ctx context.Context) error {
 	// Synchronize
 	err = cd.deployer.synchronize(ctx)
 	if err != nil {
-		return errors.Wrap(err, "failed to synchronize deployments")
+		return errors.Wrap(err, "synchronizing deployments")
 	}
 
 	// Update container states

--- a/pkg/usecase/cleaner/service.go
+++ b/pkg/usecase/cleaner/service.go
@@ -2,7 +2,6 @@ package cleaner
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
 	"sync"
 	"time"
@@ -64,7 +63,7 @@ func NewService(
 			start := time.Now()
 			err := c.pruneImages(ctx, c.regclient)
 			if err != nil {
-				slog.ErrorContext(ctx, "failed to prune images", "error", err)
+				slog.WarnContext(ctx, "failed to prune images", "error", err)
 				return
 			}
 			slog.InfoContext(ctx, "Pruned images", "duration", time.Since(start))
@@ -73,7 +72,7 @@ func NewService(
 			start := time.Now()
 			err := c.pruneArtifacts(ctx)
 			if err != nil {
-				slog.ErrorContext(ctx, "failed to prune artifacts", "error", err)
+				slog.WarnContext(ctx, "failed to prune artifacts", "error", err)
 				return
 			}
 			slog.InfoContext(ctx, "Pruned artifacts", "duration", time.Since(start))
@@ -108,7 +107,7 @@ func (c *cleanerService) pruneImages(ctx context.Context, r builder.RegistryClie
 
 		err = c.pruneImage(ctx, r, app)
 		if err != nil {
-			slog.ErrorContext(ctx, "failed to prune image", "image", c.image.NamePrefix+app.ID, "error", err)
+			slog.WarnContext(ctx, "failed to prune image", "image", c.image.NamePrefix+app.ID, "error", err)
 		}
 	}
 
@@ -140,7 +139,7 @@ func (c *cleanerService) pruneImage(ctx context.Context, r builder.RegistryClien
 		// https://docs.docker.com/registry/garbage-collection/
 		err = r.DeleteImage(ctx, imageName, tag)
 		if err != nil {
-			slog.ErrorContext(ctx, "failed to delete tag", "image_name", imageName, "tag", tag, "error", err)
+			slog.WarnContext(ctx, "failed to delete tag", "image_name", imageName, "tag", tag, "error", err)
 			// fail-safe and continue
 		}
 	}
@@ -157,7 +156,7 @@ func (c *cleanerService) getOlderBuilds(ctx context.Context, appID string, targe
 	}
 	current, ok := lo.Find(builds, func(b *domain.Build) bool { return b.ID == targetBuildID })
 	if !ok {
-		return nil, errors.Errorf("failed to find build %v in retrieved builds", targetBuildID)
+		return nil, errors.Errorf("build %v not found in retrieved builds", targetBuildID)
 	}
 	return lo.Filter(builds, func(b *domain.Build, _ int) bool { return b.QueuedAt.Before(current.QueuedAt) }), nil
 }
@@ -165,17 +164,17 @@ func (c *cleanerService) getOlderBuilds(ctx context.Context, appID string, targe
 func (c *cleanerService) pruneArtifacts(ctx context.Context) error {
 	notInUse, err := c.getArtifactsNoLongerInUse(ctx)
 	if err != nil {
-		return errors.Wrap(err, "failed to get artifacts in use")
+		return errors.Wrap(err, "getting artifacts in use")
 	}
 
 	for _, artifact := range notInUse {
 		err = domain.DeleteArtifact(c.storage, artifact.ID)
 		if err != nil {
-			return errors.Wrap(err, fmt.Sprintf("deleting artifact %v", artifact.ID))
+			return errors.Wrapf(err, "deleting artifact %v", artifact.ID)
 		}
 		err = c.artifactRepo.UpdateArtifact(ctx, artifact.ID, domain.UpdateArtifactArgs{DeletedAt: optional.From(time.Now())})
 		if err != nil {
-			return errors.Wrap(err, "failed to mark artifact as deleted")
+			return errors.Wrapf(err, "marking artifact as deleted (artifact_id=%s)", artifact.ID)
 		}
 	}
 	return nil

--- a/pkg/usecase/commit-fetcher/service.go
+++ b/pkg/usecase/commit-fetcher/service.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/pkg/errors"
+	"github.com/friendsofgo/errors"
 	"github.com/samber/lo"
 
 	"github.com/traPtitech/neoshowcase/pkg/domain"
@@ -82,7 +82,7 @@ func (s *service) Run() {
 func (s *service) resolveCommits(ctx context.Context) {
 	apps, err := s.appRepo.GetApplications(ctx, domain.GetApplicationCondition{})
 	if err != nil {
-		slog.ErrorContext(ctx, "failed to get applications", "error", err)
+		slog.WarnContext(ctx, "failed to get applications", "error", err)
 		return
 	}
 
@@ -94,7 +94,7 @@ func (s *service) resolveCommits(ctx context.Context) {
 
 		builds, err := s.buildRepo.GetBuilds(ctx, domain.GetBuildCondition{ApplicationID: optional.From(app.ID)})
 		if err != nil {
-			slog.ErrorContext(ctx, "failed to get builds", "error", err)
+			slog.WarnContext(ctx, "failed to get builds", "app_id", app.ID, "error", err)
 			return
 		}
 
@@ -113,7 +113,7 @@ func (s *service) Fetch(repositoryID string, hashes []string) {
 	select {
 	case s.queue <- queueItem{repositoryID, hashes}:
 	default:
-		slog.Warn("commit fetcher: queue is full, skipping request for repository and hashes", "repository_id", repositoryID, "hash_count", len(hashes))
+		slog.WarnContext(context.Background(), "commit fetcher: queue is full, skipping request for repository and hashes", "repository_id", repositoryID, "hash_count", len(hashes))
 	}
 }
 
@@ -141,7 +141,7 @@ func (s *service) fetchOne(ctx context.Context, repositoryID string, hashes []st
 	// Check if we have already tried
 	recordedCommits, err := s.commitsRepo.GetCommits(ctx, hashes)
 	if err != nil {
-		return errors.Wrap(err, "failed to get recorded commits")
+		return errors.Wrap(err, "getting recorded commits")
 	}
 	recordedCommitMap := lo.SliceToMap(recordedCommits, func(c *domain.RepositoryCommit) (string, bool) {
 		return c.Hash, true
@@ -155,24 +155,24 @@ func (s *service) fetchOne(ctx context.Context, repositoryID string, hashes []st
 
 	repo, err := s.gitRepo.GetRepository(ctx, repositoryID)
 	if err != nil {
-		return errors.Wrap(err, "failed to get repository")
+		return errors.Wrapf(err, "getting repository (repository_id=%s)", repositoryID)
 	}
 
 	// Init local git directory
 	tmpDir, err := os.MkdirTemp("", "commit-fetcher-")
 	if err != nil {
-		return errors.Wrap(err, "failed to create temp dir")
+		return errors.Wrap(err, "creating temp dir")
 	}
 	defer os.RemoveAll(tmpDir)
 
 	localRepo, err := s.gitsvc.CreateBareRepository(tmpDir, repo)
 	if err != nil {
-		return errors.Wrap(err, "failed to initialize git repo")
+		return errors.Wrap(err, "initializing git repo")
 	}
 
 	err = localRepo.Fetch(ctx, hashes)
 	if err != nil {
-		return errors.Wrap(err, "failed to fetch")
+		return errors.Wrap(err, "fetching commits")
 	}
 
 	// Get commit objects and record, in a *fail-safe* manner -
@@ -180,13 +180,13 @@ func (s *service) fetchOne(ctx context.Context, repositoryID string, hashes []st
 	for _, hash := range hashes {
 		commit, err := localRepo.GetCommit(hash)
 		if err != nil {
-			slog.ErrorContext(ctx, "failed to fetch commit for repository", "hash", hash, "repository_id", repositoryID, "error", err)
+			slog.WarnContext(ctx, "failed to fetch commit for repository", "hash", hash, "repository_id", repositoryID, "error", err)
 			commit = domain.ToErroredRepositoryCommit(hash)
 		}
 
 		err = s.commitsRepo.RecordCommit(ctx, commit)
 		if err != nil {
-			return errors.Wrap(err, "failed to record commit")
+			return errors.Wrap(err, "recording commit")
 		}
 	}
 

--- a/pkg/usecase/gitea-integration/integration.go
+++ b/pkg/usecase/gitea-integration/integration.go
@@ -2,11 +2,11 @@ package giteaintegration
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
 	"time"
 
 	"code.gitea.io/sdk/gitea"
+	"github.com/friendsofgo/errors"
 
 	"github.com/traPtitech/neoshowcase/pkg/domain"
 	"github.com/traPtitech/neoshowcase/pkg/util/loop"
@@ -22,13 +22,13 @@ type Config struct {
 
 func (c *Config) Validate() error {
 	if c.Token == "" {
-		return fmt.Errorf("provide admin gitea token (got empty string)")
+		return errors.New("provide admin gitea token (got empty string)")
 	}
 	if c.IntervalSeconds <= 0 {
-		return fmt.Errorf("provide positive interval seconds (got %v)", c.IntervalSeconds)
+		return errors.Errorf("provide positive interval seconds (got %v)", c.IntervalSeconds)
 	}
 	if c.Concurrency <= 0 {
-		return fmt.Errorf("provide positive concurrency (got %v)", c.Concurrency)
+		return errors.Errorf("provide positive concurrency (got %v)", c.Concurrency)
 	}
 	return nil
 }
@@ -65,7 +65,7 @@ func NewIntegration(
 		gitea.SetGiteaVersion(""),
 	)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "creating gitea client")
 	}
 
 	i := &Integration{
@@ -99,7 +99,8 @@ func (i *Integration) Sync(ctx context.Context) error {
 func (i *Integration) syncAndLog(ctx context.Context) error {
 	err := i.sync(ctx)
 	if err != nil {
-		slog.ErrorContext(ctx, "failed to sync", "error", err)
+		// Reconcile loop: the next tick retries, so a failure is expected/transient (Warn, not Error).
+		slog.WarnContext(ctx, "failed to sync gitea", "error", err)
 	}
 	return nil
 }

--- a/pkg/usecase/gitea-integration/integration.go
+++ b/pkg/usecase/gitea-integration/integration.go
@@ -99,7 +99,6 @@ func (i *Integration) Sync(ctx context.Context) error {
 func (i *Integration) syncAndLog(ctx context.Context) error {
 	err := i.sync(ctx)
 	if err != nil {
-		// Reconcile loop: the next tick retries, so a failure is expected/transient (Warn, not Error).
 		slog.WarnContext(ctx, "failed to sync gitea", "error", err)
 	}
 	return nil

--- a/pkg/usecase/gitea-integration/sync.go
+++ b/pkg/usecase/gitea-integration/sync.go
@@ -88,7 +88,7 @@ func (i *Integration) sync(ctx context.Context) error {
 			// Get users with write access
 			members, _, err := i.c.GetAssignees(repo.Owner.UserName, repo.Name)
 			if err != nil {
-				return errors.Wrap(err, fmt.Sprintf("syncing repository %v/%v: getting users", repo.Owner.UserName, repo.Name))
+				return errors.Wrapf(err, "getting assignees (repo=%v/%v)", repo.Owner.UserName, repo.Name)
 			}
 			memberIDs := lo.Flatten(ds.Map(members, func(member *gitea.User) []string {
 				user, ok := usersMap[member.UserName]
@@ -110,7 +110,7 @@ func (i *Integration) syncRepository(ctx context.Context, username string, gitea
 	// NOTE: no transaction, creating repository is assumed rare
 	repos, err := i.gitRepo.GetRepositories(ctx, domain.GetRepositoryCondition{URLs: optional.From([]string{giteaRepo.SSHURL})})
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "getting repository (ssh_url=%s)", giteaRepo.SSHURL)
 	}
 
 	if len(repos) == 0 {
@@ -122,7 +122,10 @@ func (i *Integration) syncRepository(ctx context.Context, username string, gitea
 			giteaOwnerIDs,
 		)
 		slog.InfoContext(ctx, "New repository found", "name", repo.Name, "id", repo.ID)
-		return i.gitRepo.CreateRepository(ctx, repo)
+		if err := i.gitRepo.CreateRepository(ctx, repo); err != nil {
+			return errors.Wrapf(err, "creating repository (name=%s)", repo.Name)
+		}
+		return nil
 	}
 
 	// Already exists
@@ -136,14 +139,14 @@ func (i *Integration) syncRepository(ctx context.Context, username string, gitea
 		slog.InfoContext(ctx, "Syncing repository owners", "repo_name", repo.Name, "repo_id", repo.ID, "old_count", len(repo.OwnerIDs), "new_count", len(newOwners))
 		err = i.gitRepo.UpdateRepository(ctx, repo.ID, &domain.UpdateRepositoryArgs{OwnerIDs: optional.From(newOwners)})
 		if err != nil {
-			return err
+			return errors.Wrapf(err, "updating repository owners (repo_id=%s)", repo.ID)
 		}
 	}
 
 	// Sync owners of generated applications
 	apps, err := i.appRepo.GetApplications(ctx, domain.GetApplicationCondition{RepositoryID: optional.From(repo.ID)})
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "getting applications (repo_id=%s)", repo.ID)
 	}
 	for _, app := range apps {
 		err = i.syncApplication(ctx, app, giteaOwnerIDs)
@@ -163,7 +166,7 @@ func (i *Integration) syncApplication(ctx context.Context, app *domain.Applicati
 		slog.InfoContext(ctx, "Syncing application owners", "app_name", app.Name, "app_id", app.ID, "old_count", len(app.OwnerIDs), "new_count", len(newOwners))
 		err := i.appRepo.UpdateApplication(ctx, app.ID, &domain.UpdateApplicationArgs{OwnerIDs: optional.From(newOwners)})
 		if err != nil {
-			return err
+			return errors.Wrapf(err, "updating application owners (app_id=%s)", app.ID)
 		}
 	}
 	return nil

--- a/pkg/usecase/repofetcher/service.go
+++ b/pkg/usecase/repofetcher/service.go
@@ -105,7 +105,7 @@ func (r *service) fetchLoop(ctx context.Context, fetcher <-chan string) {
 		start := time.Now()
 		n, err := r.doFetchEpoch(ctx, epoch)
 		if err != nil {
-			slog.ErrorContext(ctx, "failed to fetch repositories", "error", err)
+			slog.WarnContext(ctx, "failed to fetch repositories", "error", err)
 		}
 		slog.InfoContext(ctx, "Fetched repositories", "count", n, "duration", time.Since(start))
 		epoch++
@@ -118,7 +118,7 @@ func (r *service) fetchLoop(ctx context.Context, fetcher <-chan string) {
 		case id := <-fetcher:
 			err := r.fetchOne(ctx, id)
 			if err != nil {
-				slog.ErrorContext(ctx, "failed to fetch repository", "repository_id", id, "error", err)
+				slog.WarnContext(ctx, "failed to fetch repository", "repository_id", id, "error", err)
 			}
 		case <-ticker.C:
 			runFetchEpoch()
@@ -169,7 +169,7 @@ func (r *service) doFetchEpoch(ctx context.Context, epoch int) (int, error) {
 				}
 				err := r.updateApps(ctx, repo, apps)
 				if err != nil {
-					slog.WarnContext(ctx, "failed to update repo", "error", err)
+					slog.WarnContext(ctx, "failed to update repo", "repository_id", repo.ID, "error", err)
 				}
 			})
 		}
@@ -210,7 +210,7 @@ func (r *service) updateApps(ctx context.Context, repo *domain.Repository, apps 
 
 		err = r.appRepo.UpdateApplication(ctx, app.ID, &domain.UpdateApplicationArgs{Commit: optional.From(commit)})
 		if err != nil {
-			return errors.Wrap(err, "failed to update application")
+			return errors.Wrapf(err, "updating application (app_id=%s)", app.ID)
 		}
 		// Notify builds
 		r.cd.RegisterBuild(app.ID)

--- a/pkg/usecase/ssgen/generator.go
+++ b/pkg/usecase/ssgen/generator.go
@@ -109,9 +109,10 @@ func (s *generatorService) onRequest(req *pb.SSGenRequest) {
 }
 
 func (s *generatorService) reload() {
-	err := s.reloader.Do(context.Background())
+	ctx := context.Background()
+	err := s.reloader.Do(ctx)
 	if err != nil {
-		slog.Error("failed to reload static server", "error", err)
+		slog.WarnContext(ctx, "failed to reload static server", "error", err)
 	}
 }
 
@@ -140,7 +141,7 @@ func (s *generatorService) _reload(ctx context.Context) error {
 func (s *generatorService) syncArtifacts(sites []*domain.StaticSite) error {
 	entries, err := os.ReadDir(s.docsRoot)
 	if err != nil {
-		return errors.Wrap(err, "failed to read docs root")
+		return errors.Wrap(err, "reading docs root")
 	}
 	artifactsOnDisk := make(map[string]struct{}, len(entries))
 	for _, e := range entries {
@@ -170,7 +171,7 @@ func (s *generatorService) syncArtifacts(sites []*domain.StaticSite) error {
 		artifactDir := filepath.Join(s.docsRoot, artifactID)
 		err = os.RemoveAll(artifactDir)
 		if err != nil {
-			return errors.Wrap(err, "failed to delete unused artifact directory")
+			return errors.Wrapf(err, "deleting unused artifact directory (artifact_id=%s)", artifactID)
 		}
 	}
 
@@ -191,7 +192,7 @@ func (s *generatorService) extractArtifact(artifactID string) error {
 	defer tarReader.Close()
 	err = tarfs.Extract(tarReader, destDir)
 	if err != nil {
-		return errors.Wrap(err, "failed to extract artifact tar")
+		return errors.Wrap(err, "extracting artifact tar")
 	}
 	return nil
 }

--- a/pkg/util/discovery/discoverer.go
+++ b/pkg/util/discovery/discoverer.go
@@ -2,7 +2,8 @@ package discovery
 
 import (
 	"context"
-	"fmt"
+
+	"github.com/friendsofgo/errors"
 )
 
 type Target struct {
@@ -27,11 +28,11 @@ func validateTargets(targets []Target) error {
 	}
 	// Note that it is possible there are no targets marked as "me".
 	if meCnt > 1 {
-		return fmt.Errorf("too many targets marked as \"me\": %d", meCnt)
+		return errors.Errorf("too many targets marked as \"me\": %d", meCnt)
 	}
 	for i := 0; i < len(targets)-1; i++ {
 		if targets[i].IP == targets[i+1].IP {
-			return fmt.Errorf("duplicate target: %s", targets[i].IP)
+			return errors.Errorf("duplicate target: %s", targets[i].IP)
 		}
 	}
 	return nil

--- a/pkg/util/discovery/discoverer_k8s.go
+++ b/pkg/util/discovery/discoverer_k8s.go
@@ -52,11 +52,11 @@ func NewK8sDiscoverer(svcName string) (Discoverer, error) {
 	// sanity check
 	_, err = d.findService()
 	if err != nil {
-		return nil, errors.Wrapf(err, "finding service %s, is configuration done right?", svcName)
+		return nil, errors.Wrapf(err, "finding service (service_name=%s)", svcName)
 	}
 	_, err = d.discover()
 	if err != nil {
-		return nil, errors.Wrapf(err, "discovering targets, is configuration done right?")
+		return nil, errors.Wrap(err, "discovering targets")
 	}
 
 	return d, nil

--- a/pkg/util/discovery/discoverer_k8s.go
+++ b/pkg/util/discovery/discoverer_k8s.go
@@ -134,7 +134,7 @@ func (k *k8sDiscoverer) watch(ctx context.Context, updates chan<- []Target) erro
 	// Send initial state
 	targets, err := k.discover()
 	if err != nil {
-		return fmt.Errorf("failed to discover targets: %w", err)
+		return errors.Wrap(err, "discovering targets")
 	}
 	if len(targets) > 0 {
 		updates <- targets
@@ -143,7 +143,7 @@ func (k *k8sDiscoverer) watch(ctx context.Context, updates chan<- []Target) erro
 	for range watcher.ResultChan() {
 		targets, err = k.discover()
 		if err != nil {
-			return fmt.Errorf("failed to discover targets: %w", err)
+			return errors.Wrap(err, "discovering targets")
 		}
 		if len(targets) > 0 {
 			updates <- targets

--- a/pkg/util/discovery/discoverer_k8s.go
+++ b/pkg/util/discovery/discoverer_k8s.go
@@ -52,11 +52,11 @@ func NewK8sDiscoverer(svcName string) (Discoverer, error) {
 	// sanity check
 	_, err = d.findService()
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to find service %s, is configuration done right?", svcName)
+		return nil, errors.Wrapf(err, "finding service %s, is configuration done right?", svcName)
 	}
 	_, err = d.discover()
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to discover targets, is configuration done right?")
+		return nil, errors.Wrapf(err, "discovering targets, is configuration done right?")
 	}
 
 	return d, nil

--- a/pkg/util/fig/color.go
+++ b/pkg/util/fig/color.go
@@ -4,8 +4,9 @@ package fig
 
 import (
 	"encoding/hex"
-	"errors"
 	"fmt"
+
+	"github.com/friendsofgo/errors"
 )
 
 // Escape char
@@ -68,7 +69,7 @@ func (tc TrueColor) GetSuffix() string {
 func NewTrueColorFromHexString(c string) (*TrueColor, error) {
 	rgb, err := hex.DecodeString(c)
 	if err != nil {
-		return nil, errors.New("Invalid color given (" + c + ")")
+		return nil, errors.Errorf("invalid color given (%s)", c)
 	}
 
 	return &TrueColor{

--- a/pkg/util/retry/retry.go
+++ b/pkg/util/retry/retry.go
@@ -28,7 +28,7 @@ func Do(ctx context.Context, fn func(ctx context.Context) error, msg string) {
 		if err == nil {
 			slog.InfoContext(ctx, "Retrier: retrying", "backoff", backoff, "message", msg)
 		} else {
-			slog.ErrorContext(ctx, "Retrier: retrying", "backoff", backoff, "message", msg, "error", err)
+			slog.WarnContext(ctx, "Retrier: retrying", "backoff", backoff, "message", msg, "error", err)
 		}
 		select {
 		case <-time.After(backoff):

--- a/pkg/util/tarfs/extract.go
+++ b/pkg/util/tarfs/extract.go
@@ -42,22 +42,22 @@ func Extract(tarStream io.Reader, destPath string) error {
 		switch header.Typeflag {
 		case tar.TypeDir:
 			if err = os.MkdirAll(path, header.FileInfo().Mode()); err != nil {
-				return errors.Wrap(err, "failed to create directory")
+				return errors.Wrap(err, "creating directory")
 			}
 
 		case tar.TypeReg:
 			if err = os.MkdirAll(filepath.Dir(path), header.FileInfo().Mode()|os.ModeDir|100); err != nil {
-				return errors.Wrap(err, "failed to create directory")
+				return errors.Wrap(err, "creating directory")
 			}
 
 			file, err := os.OpenFile(path, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, header.FileInfo().Mode())
 			if err != nil {
-				return errors.Wrap(err, "failed to create file")
+				return errors.Wrap(err, "creating file")
 			}
 			_, err = io.Copy(file, tr)
 			_ = file.Close()
 			if err != nil {
-				return errors.Wrap(err, "failed to write file")
+				return errors.Wrap(err, "writing file")
 			}
 
 		default:


### PR DESCRIPTION
## なぜやるか

エラーハンドリングがドリフトしていた（2 つのエラーライブラリが混在、error への context の付け方が不統一、同一の失敗が複数箇所でログされる）。本番障害時に「症状 → 根本原因」を素早く辿れるようにするため、唯一のルールを定義し、既存コードをそれに移行する。

## やったこと

- **ルールを明文化**: `docs/guidelines/error-handling.md` にエラーハンドリング規約を定義し、README の「Coding guidelines」節からリンク。
- **エラーライブラリを統一**: `github.com/friendsofgo/errors` に一本化（stack trace を保持）。`fmt.Errorf` / `github.com/pkg/errors` / stdlib での error 生成・wrap を排除。
- **メッセージ様式**: wrap/error メッセージを gerund 句に統一し `"failed to"` を除去（log メッセージ文字列の `"failed to"` は連結しないため温存）。
- **ログ配置とレベル（rule 3 / 4 / 7）**: 終端で 1 回だけログするよう log-and-return を解消。`Error` は「人が見るべき想定外」に限定し、reconcile ループ・per-item・best-effort・非クリティカルな transient 失敗を `Warn` に是正。制御 plane の接続断や DB 依存障害は `Error` のまま維持。
- 結果、非生成コード全体で `fmt.Errorf` = 0 / `pkg/errors` = 0 / wrap・error メッセージの `"failed to"` = 0。`pkg/...` `cmd/...` はビルド通過、`golangci-lint` 0 issues。

移行は「ライブラリ + メッセージ様式 + ログ配置をパッケージ単位でまとめて」進め、コミットも段階的に分割している。

## やらなかったこと

- **streaming interceptor の client/server level split**: `WrapStreamingHandler` は現状すべて `Error`。unary と同じ Connect code ベースの Error/Warn 振り分けは挙動変更のため別タスク。
- **logInterceptor の適用拡大（controller-builder / ssgen）**: 現状これらのサービスには logInterceptor が無い（そのため `StreamBuildLog` 等は明示ログを終端としている）。適用拡大は上記 level split とセットで別タスク。
- **起動 / CLI・sshserver 等での 非 Context `slog` の Context 化**: ctx 配線が非機械的なため対象外。

## 資料

- `docs/guidelines/error-handling.md`（本 PR で追加したルール本体）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * エラーハンドリングのガイドラインを追加し、エラー分類、ログ出力、リトライ、構造化ログの方針を明文化しました。
  * READMEから関連ガイドラインを参照できるようになりました。

* **Bug Fixes**
  * エラーメッセージを整理し、失敗した処理や対象をより明確に示すよう改善しました。
  * リトライや継続処理に伴うログレベルを見直し、警告として適切に記録するよう変更しました。
  * ログに関連する識別情報を追加し、問題の追跡性を向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->