### PR TITLE
refactor(errors): friendsofgo/errors から samber/oops へ移行

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -2,13 +2,13 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
 	"os"
 	"time"
 
-	"github.com/friendsofgo/errors"
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/spf13/cobra"
 

--- a/cmd/providers.go
+++ b/cmd/providers.go
@@ -9,8 +9,8 @@ import (
 
 	"connectrpc.com/connect"
 	"connectrpc.com/otelconnect"
-	"github.com/friendsofgo/errors"
 	buildkit "github.com/moby/buildkit/client"
+	"github.com/samber/oops"
 
 	authdev "github.com/traPtitech/neoshowcase/cmd/auth-dev"
 	buildpackhelper "github.com/traPtitech/neoshowcase/cmd/buildpack-helper"
@@ -38,7 +38,7 @@ import (
 func provideRepositoryPrivateKey(c Config) (domain.PrivateKey, error) {
 	bytes, err := os.ReadFile(c.PrivateKeyFile)
 	if err != nil {
-		return nil, errors.Wrap(err, "opening private key file")
+		return nil, oops.Wrapf(err, "opening private key file")
 	}
 	return bytes, nil
 }
@@ -52,7 +52,7 @@ func provideStorage(c domain.StorageConfig) (domain.Storage, error) {
 	case "swift":
 		return storage.NewSwiftStorage(c.Swift.Container, c.Swift.UserName, c.Swift.APIKey, c.Swift.TenantName, c.Swift.TenantID, c.Swift.AuthURL)
 	default:
-		return nil, errors.Errorf("unknown storage: %s", c.Type)
+		return nil, oops.Errorf("unknown storage: %s", c.Type)
 	}
 }
 
@@ -100,17 +100,17 @@ func provideDiscoverer(c Config) (discovery.Discoverer, error) {
 	case "k8s", "kubernetes":
 		return discovery.NewK8sDiscoverer(c.Components.Controller.K8s.ServiceName)
 	}
-	return nil, errors.New("unknown mode: " + c.Components.Controller.Mode)
+	return nil, oops.New("unknown mode: " + c.Components.Controller.Mode)
 }
 
 func provideBuilderConfig(c Config) (*ubuilder.Config, error) {
 	stepTimeoutStr := c.Components.Builder.StepTimeout
 	stepTimeout, err := time.ParseDuration(stepTimeoutStr)
 	if err != nil {
-		return nil, errors.Wrapf(err, "parsing components.builder.stepTimeout value: %s", stepTimeoutStr)
+		return nil, oops.Wrapf(err, "parsing components.builder.stepTimeout value: %s", stepTimeoutStr)
 	}
 	if stepTimeout <= 0 {
-		return nil, errors.Errorf("components.builder.stepTimeout must be positive: %s", stepTimeoutStr)
+		return nil, oops.Errorf("components.builder.stepTimeout must be positive: %s", stepTimeoutStr)
 	}
 	return &ubuilder.Config{
 		StepTimeout: stepTimeout,
@@ -123,7 +123,7 @@ func provideBuildkitClient(c Config) (*buildkit.Client, error) {
 	defer cancel()
 	client, err := buildkit.New(ctx, cc.Buildkit.Address)
 	if err != nil {
-		return nil, errors.Wrap(err, "initializing Buildkit Client")
+		return nil, oops.Wrapf(err, "initializing Buildkit Client")
 	}
 	return client, nil
 }
@@ -167,7 +167,7 @@ func provideContainerLogger(c Config) (domain.ContainerLogger, error) {
 	case "victorialogs":
 		return victorialogs.NewVictoriaLogsStreamer(cc.Log.VictoriaLogs)
 	default:
-		return nil, errors.Errorf("invalid log type: %v (supported values: loki, victorialogs)", cc.Log.Type)
+		return nil, oops.Errorf("invalid log type: %v (supported values: loki, victorialogs)", cc.Log.Type)
 	}
 }
 
@@ -177,7 +177,7 @@ func provideMetricsService(c Config) (domain.MetricsService, error) {
 	case "prometheus":
 		return prometheus.NewPromClient(cc.Metrics.Prometheus)
 	default:
-		return nil, errors.Errorf("invalid metrics type: %v (supported values: prometheus)", cc.Metrics.Type)
+		return nil, oops.Errorf("invalid metrics type: %v (supported values: prometheus)", cc.Metrics.Type)
 	}
 }
 
@@ -251,7 +251,7 @@ func provideStaticServer(c Config) (domain.StaticServer, error) {
 	case "caddy":
 		return caddy.NewServer(cc.Server.Caddy), nil
 	default:
-		return nil, errors.Errorf("invalid static server type: %v", cc.Server.Type)
+		return nil, oops.Errorf("invalid static server type: %v", cc.Server.Type)
 	}
 }
 

--- a/cmd/wire.go
+++ b/cmd/wire.go
@@ -4,8 +4,8 @@ package main
 
 import (
 	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/client/clientset/versioned"
-	"github.com/friendsofgo/errors"
 	"github.com/google/wire"
+	"github.com/samber/oops"
 	traefikv1alpha1 "github.com/traefik/traefik/v3/pkg/provider/kubernetes/crd/generated/clientset/versioned/typed/traefikio/v1alpha1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -176,7 +176,7 @@ func NewController(c Config) (component, error) {
 	case "k8s", "kubernetes":
 		return NewControllerK8s(c)
 	}
-	return nil, errors.New("unknown mode: " + c.Components.Controller.Mode)
+	return nil, oops.New("unknown mode: " + c.Components.Controller.Mode)
 }
 
 func NewControllerDocker(c Config) (component, error) {

--- a/cmd/wire_gen.go
+++ b/cmd/wire_gen.go
@@ -8,8 +8,8 @@ package main
 
 import (
 	"github.com/cert-manager/cert-manager/pkg/client/clientset/versioned"
-	"github.com/friendsofgo/errors"
 	"github.com/google/wire"
+	"github.com/samber/oops"
 	builder2 "github.com/traPtitech/neoshowcase/cmd/builder"
 	"github.com/traPtitech/neoshowcase/cmd/buildpack-helper"
 	"github.com/traPtitech/neoshowcase/cmd/controller"
@@ -506,5 +506,5 @@ func NewController(c Config) (component, error) {
 	case "k8s", "kubernetes":
 		return NewControllerK8s(c)
 	}
-	return nil, errors.New("unknown mode: " + c.Components.Controller.Mode)
+	return nil, oops.New("unknown mode: " + c.Components.Controller.Mode)
 }

--- a/docs/guidelines/error-handling.md
+++ b/docs/guidelines/error-handling.md
@@ -15,11 +15,12 @@ them.
 
 ## Rules at a glance
 
-1. **One library.** Use `github.com/friendsofgo/errors` everywhere. It preserves
-   stack traces. Do not create errors with the standard `errors.New` / `fmt.Errorf`.
-2. **Wrap with context, don't log while propagating.** As an error travels up,
-   add context (IDs, state) to the *message*. Never log an error you are also
-   returning.
+1. **One library.** Create and wrap errors with `github.com/samber/oops` everywhere.
+   It captures stack traces and carries structured context. Do not create errors
+   with the standard `errors.New` / `fmt.Errorf`.
+2. **Wrap with context, don't log while propagating.** As an error travels up, add
+   context: the operation as the wrap message, identifiers and state as `With()`
+   attributes. Never log an error you are also returning.
 3. **Log once, where the error stops.** The single place that handles an error
    terminally (an interceptor, a reconcile loop tick) logs it once — with the full
    wrap chain, stack trace, `trace_id`, and `user_id`.
@@ -37,43 +38,71 @@ The rest of this document explains each rule and shows the intended shape of the
 
 ## 1. Error library and stack traces
 
-Use `github.com/friendsofgo/errors` (a `pkg/errors` fork) as the **only** error
-constructor library. It attaches a stack trace at the point the error is created or
-wrapped, which is the single most valuable thing for locating where a failure
-originated.
+Use `github.com/samber/oops` as the **only** error constructor library. It attaches
+a stack trace at the point the error is created or wrapped — the single most valuable
+thing for locating where a failure originated — and lets identifiers ride along as
+structured attributes instead of being interpolated into a string.
 
-- **MUST** create and wrap errors with `errors.New`, `errors.Wrap`, and
-  `errors.Wrapf` from this package.
+- **MUST** create and wrap errors with `oops.New`, `oops.Errorf`, and `oops.Wrapf`.
+  Note that `oops.Wrap(err)` takes **no message**; use `oops.Wrapf` whenever you are
+  adding one.
 - **MUST NOT** use the standard library's `errors.New` or `fmt.Errorf` to create or
-  wrap errors — they discard the stack trace and are the reason the two libraries
-  currently mix.
-- Inspecting errors with the standard `errors.Is` / `errors.As` is fine;
-  `friendsofgo/errors` exposes the same functions and chains interoperate.
+  wrap errors — they discard the stack trace.
+- **Inspect** errors with the **standard library** `errors.Is` / `errors.As`. `oops`
+  does not re-export them, and its errors unwrap normally, so import `"errors"`
+  alongside it when a file needs both.
+
+> The SQLBoiler-generated models under `pkg/infrastructure/repository/models/` still
+> import `github.com/friendsofgo/errors`: that import is baked into SQLBoiler's
+> templates and comes back on every `mise run gen`. It is expected — leave it alone,
+> and do not use that package in hand-written code.
 
 **Capture the stack once, at the origin.** Wrap an external/library error the moment
 it enters our code so the stack points at the boundary where it happened. Higher up,
-keep adding *context* with `Wrap`, but do not re-wrap an error without adding new
-information — that only adds noise to the chain.
+keep adding *context*, but do not re-wrap an error without adding new information —
+that only adds noise to the chain.
 
 ```go
 // Good: the DB error is wrapped as it enters our code; the stack is captured here.
 row, err := models.Applications(...).One(ctx, db)
 if err != nil {
-    return errors.Wrap(err, "querying application")
+    return oops.Wrapf(err, "querying application")
 }
 ```
 
 ## 2. Creating and wrapping errors
 
 As an error propagates, attach the **local context** that will matter during an
-investigation — identifiers and relevant state — onto the wrap message, not into a
+investigation — identifiers and relevant state — onto the error itself, not into a
 separate log line. One log at the boundary then carries everything.
 
+**Prefer `With()` over interpolation.** Attributes attached with `With()` are emitted
+as their own log fields, so they can be queried (`error.context.app_id`) rather than
+grepped out of a message.
+
 ```go
-// Good: app_id and step are on the message; no local log needed.
+// Good: app_id and step become queryable fields; no local log needed.
 if err := b.updateApp(ctx, appID); err != nil {
-    return errors.Wrapf(err, "updating app (app_id=%s, step=%s)", appID, step)
+    return oops.With("app_id", appID, "step", step).Wrapf(err, "updating app")
 }
+
+// Acceptable, but the identifiers are only greppable prose.
+return oops.Wrapf(err, "updating app (app_id=%s, step=%s)", appID, step)
+```
+
+**Keep the value in the message when it *is* the message.** `With()` is for the
+identifiers and state surrounding a failed *operation*. A validation or
+configuration error describes a *condition*, and its value belongs in the sentence —
+splitting it out only makes the message vague, and these messages often reach the
+client through rule 5.
+
+```go
+// Good: the condition reads as one sentence.
+return oops.Errorf("domain %v must be lower case", domain)
+return oops.Errorf("unknown auth method: %v", a.Method)
+
+// Bad: the message no longer says what is wrong with what.
+return oops.With("domain", domain).New("domain must be lower case")
 ```
 
 ### Message style
@@ -95,12 +124,13 @@ operation, and are written as plain phrases — `"application not found"`,
 
 ```go
 // Good
-return errors.Wrap(err, "reading docs root")
-return errors.Wrapf(err, "resolving ref (ref=%s, app_id=%s)", ref, appID)
+return oops.Wrapf(err, "reading docs root")
+return oops.With("ref", ref, "app_id", appID).Wrapf(err, "resolving ref")
 
 // Bad
-return errors.Wrap(err, "Failed to read docs root.")   // "failed to", capitalized, punctuation
-return fmt.Errorf("read docs root: %w", err)            // stdlib, no stack trace
+return oops.Wrapf(err, "Failed to read docs root.")  // "failed to", capitalized, punctuation
+return fmt.Errorf("read docs root: %w", err)         // stdlib, no stack trace
+return oops.Wrapf(err, msg)                          // non-constant format string
 ```
 
 ## 3. Where to log: log once, at the point the error stops
@@ -130,7 +160,7 @@ if err != nil {
 
 // Good: attach context, return; the boundary logs it exactly once.
 if err != nil {
-    return errors.Wrapf(err, "updating app (app_id=%s)", appID)
+    return oops.With("app_id", appID).Wrapf(err, "updating app")
 }
 ```
 
@@ -158,12 +188,17 @@ intent, so **classification is the usecase layer's job**.
 - **Infrastructure and domain layers** return plain wrapped errors. They do not know
   or decide HTTP/Connect semantics.
 - **The usecase layer** tags an error with its business meaning using the helper in
-  `pkg/usecase/apiserver/errors.go` (`newError(ErrorType..., "message", cause)`).
-  Use `errors.Is` to detect a known low-level condition and translate it into a tag.
+  `pkg/usecase/apiserver/errors.go` (`newError(ErrorType..., "message", cause)`). The
+  helper records the tag as the `oops` error **code** and the message as the `oops`
+  **public** message. Use the standard `errors.Is` to detect a known low-level
+  condition and translate it into a tag.
 - **The transport boundary** (`handleUseCaseError` in
   `pkg/infrastructure/grpc/api_service.go`) decomposes the tag and maps it to a
   Connect code. **Anything untagged maps to `Internal`** — an untagged error is by
   definition something we did not anticipate.
+
+Because the code travels *with* the error, an outer layer may keep wrapping a
+classified error without losing its classification.
 
 ```go
 // usecase layer: detect a known condition and classify it.
@@ -172,7 +207,7 @@ if errors.Is(err, repository.ErrNotFound) {
     return nil, newError(ErrorTypeNotFound, "application not found", err)
 }
 if err != nil {
-    return nil, errors.Wrap(err, "getting application") // stays Internal at the boundary
+    return nil, oops.Wrapf(err, "getting application") // stays Internal at the boundary
 }
 ```
 
@@ -184,11 +219,17 @@ appears — keep the set small and meaningful.
 Split what the client receives from what we record:
 
 - **Classified errors** (bad request, not found, forbidden, already exists) **MUST**
-  return their message to the client — the user can act on it.
-- **`Internal` errors MUST return only a generic message** (e.g. "internal server
-  error"). The wrapped detail — DB errors, file paths, internal state — stays in the
-  logs only, never in the response. The full detail is already captured by the single
-  boundary log (rule 3), correlated by `user_id`, `procedure`, and timestamp.
+  return their message to the client — the user can act on it. That message is
+  exactly the one given to `newError`, i.e. the `oops` public message; the wrap chain
+  beneath it is *not* sent.
+- **`Internal` errors MUST return only a generic message** ("internal server error").
+  The wrapped detail — DB errors, file paths, internal state — stays in the logs only,
+  never in the response. The full detail is already captured by the single boundary
+  log (rule 3), correlated by `user_id`, `procedure`, and timestamp.
+
+This is enforced mechanically rather than by convention: `handleUseCaseError` returns
+a small `publicError` whose `Error()` is the client-facing message only, while it
+still unwraps to the internal chain so the interceptor can log the whole thing.
 
 ## 7. Reconcile loops
 
@@ -227,12 +268,17 @@ for _, app := range apps {
 - **MUST NOT** `panic` inside a goroutine for control flow — an unrecovered goroutine
   panic takes the whole process down.
 
-## 9. Structured logging
+### How the error attribute is rendered
 
-- **MUST** use `slog` with the `Context` variants (`slog.ErrorContext`,
-  `slog.WarnContext`, `slog.InfoContext`) so that `trace_id` and `user_id`, injected
-  by the interceptor, travel with every line.
-- **MUST** pass the error as a structured attribute: `slog.ErrorContext(ctx, "…",
-  "error", err)`. Do not format the error into the message string.
-- Prefer stable, queryable attribute keys (`app_id`, `build_id`, `procedure`) over
-  interpolated prose.
+`oops` errors implement `slog.LogValuer`, so **the log handler expands them by
+itself**, for any output format. Logging one produces a group of fields:
+
+| field | contents |
+|---|---|
+| `error.err` | the wrap chain (`getting application: querying application`) — greppable and aggregatable |
+| `error.message` | the outermost wrap message |
+| `error.code` | the classification from rule 5, when the usecase tagged it |
+| `error.public` | the message the client received |
+| `error.context.*` | everything attached with `With()` — queryable, one field per key |
+| `error.stacktrace` | the stack, captured where the error was created or wrapped |
+

--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ require (
 	github.com/prometheus/common v0.70.0
 	github.com/regclient/regclient v0.11.5
 	github.com/samber/lo v1.53.0
+	github.com/samber/oops v1.23.0
 	github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
@@ -183,6 +184,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/morikuni/aec v1.1.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/oklog/ulid/v2 v2.1.1 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/patrickmn/go-cache v2.1.0+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -388,6 +388,8 @@ github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f h1:KUppIJq7/+
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/ncw/swift/v2 v2.0.5 h1:9o5Gsd7bInAFEqsGPcaUdsboMbqf8lnNtxqWKFT9iz8=
 github.com/ncw/swift/v2 v2.0.5/go.mod h1:cbAO76/ZwcFrFlHdXPjaqWZ9R7Hdar7HpjRXBfbjigk=
+github.com/oklog/ulid/v2 v2.1.1 h1:suPZ4ARWLOJLegGFiZZ1dFAkqzhMjL3J1TzI+5wHz8s=
+github.com/oklog/ulid/v2 v2.1.1/go.mod h1:rcEKHmBBKfef9DhnvX7y1HZBYxjXb0cP5ExxNsTT1QQ=
 github.com/olareg/olareg v0.2.1 h1:RPHGIaqlVWPbKAsOYUj7e2WfEEW5M7F8I6hKMrwd4jU=
 github.com/olareg/olareg v0.2.1/go.mod h1:dhr8QetC7U7jJ2m93oxDhEEOKCRbPgOK1oGyKfB4QNo=
 github.com/onsi/gomega v1.34.1 h1:EUMJIKUjM8sKjYbtxQI9A4z2o+rruxnzNvpknOXie6k=
@@ -404,6 +406,7 @@ github.com/package-url/packageurl-go v0.1.1 h1:KTRE0bK3sKbFKAk3yy63DpeskU7Cvs/x/
 github.com/package-url/packageurl-go v0.1.1/go.mod h1:uQd4a7Rh3ZsVg5j0lNyAfyxIeGde9yrlhjF78GzeW0c=
 github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
 github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
+github.com/pborman/getopt v0.0.0-20170112200414-7148bc3a4c30/go.mod h1:85jBQOZwpVEaDAr341tbn15RS4fCAsIst0qp7i8ex1o=
 github.com/pelletier/go-toml/v2 v2.3.1 h1:MYEvvGnQjeNkRF1qUuGolNtNExTDwct51yp7olPtrEc=
 github.com/pelletier/go-toml/v2 v2.3.1/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/pjbgf/sha1cd v0.6.0 h1:3WJ8Wz8gvDz29quX1OcEmkAlUg9diU4GxJHqs0/XiwU=
@@ -437,6 +440,8 @@ github.com/sagikazarmark/locafero v0.11.0 h1:1iurJgmM9G3PA/I+wWYIOw/5SyBtxapeHDc
 github.com/sagikazarmark/locafero v0.11.0/go.mod h1:nVIGvgyzw595SUSUE6tvCp3YYTeHs15MvlmU87WwIik=
 github.com/samber/lo v1.53.0 h1:t975lj2py4kJPQ6haz1QMgtId2gtmfktACxIXArw3HM=
 github.com/samber/lo v1.53.0/go.mod h1:4+MXEGsJzbKGaUEQFKBq2xtfuznW9oz/WrgyzMzRoM0=
+github.com/samber/oops v1.23.0 h1:27aIZSRreSy4yveT0ZV4s3gLZp7/ra9Zbb84gwWbA9I=
+github.com/samber/oops v1.23.0/go.mod h1:8ZDRxwQdphVhmLtEX9I6134LHJe5yeCV8cTfHz3m91Y=
 github.com/secure-systems-lab/go-securesystemslib v0.11.0 h1:iuCR9kcMFD4QurdKrGvPLoKZLv9YvwPYVr0473BdtFs=
 github.com/secure-systems-lab/go-securesystemslib v0.11.0/go.mod h1:+PMOTjUGwHj2vcZ+TFKlb1tXRbrdWE1LYDT5i9JC80Q=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN3Uc8sB6B/s6Z4t2xvBgU1htSHuq8=

--- a/pkg/domain/app.go
+++ b/pkg/domain/app.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/friendsofgo/errors"
 	"github.com/samber/lo"
+	"github.com/samber/oops"
 
 	"github.com/traPtitech/neoshowcase/pkg/util/hash"
 )
@@ -18,10 +18,10 @@ type ApplicationConfig struct {
 
 func (c *ApplicationConfig) Validate(deployType DeployType) error {
 	if c.BuildConfig.BuildType().DeployType() != deployType {
-		return errors.New("deploy type doesn't match build type")
+		return oops.New("deploy type doesn't match build type")
 	}
 	if err := c.BuildConfig.Validate(); err != nil {
-		return errors.Wrap(err, "invalid build_config")
+		return oops.Wrapf(err, "invalid build_config")
 	}
 	return nil
 }
@@ -65,29 +65,29 @@ type Application struct {
 
 func (a *Application) SelfValidate() error {
 	if a.Name == "" {
-		return errors.New("name is required")
+		return oops.New("name is required")
 	}
 	if a.RepositoryID == "" {
-		return errors.New("repository_id is required")
+		return oops.New("repository_id is required")
 	}
 	if a.RefName == "" {
-		return errors.New("ref_name is required")
+		return oops.New("ref_name is required")
 	}
 	if err := a.Config.Validate(a.DeployType); err != nil {
-		return errors.Wrap(err, "invalid config")
+		return oops.Wrapf(err, "invalid config")
 	}
 	for _, website := range a.Websites {
 		if err := website.Validate(); err != nil {
-			return errors.Wrap(err, "invalid website")
+			return oops.Wrapf(err, "invalid website")
 		}
 	}
 	for _, p := range a.PortPublications {
 		if err := p.Validate(); err != nil {
-			return errors.Wrap(err, "invalid port publication")
+			return oops.Wrapf(err, "invalid port publication")
 		}
 	}
 	if len(a.OwnerIDs) == 0 {
-		return errors.New("owner_ids cannot be empty")
+		return oops.New("owner_ids cannot be empty")
 	}
 	return nil
 }
@@ -105,15 +105,15 @@ func (a *Application) Validate(
 	// resource availability check
 	for _, website := range a.Websites {
 		if website.Authentication != AuthenticationTypeOff && !domains.IsAuthAvailable(website.FQDN) {
-			return errors.Errorf("auth not available for domain %s", website.FQDN)
+			return oops.Errorf("auth not available for domain %s", website.FQDN)
 		}
 		if !domains.IsAvailable(website.FQDN) {
-			return errors.Errorf("domain %s not available", website.FQDN)
+			return oops.Errorf("domain %s not available", website.FQDN)
 		}
 	}
 	for _, p := range a.PortPublications {
 		if !ports.IsAvailable(p.InternetPort, p.Protocol) {
-			return errors.Errorf("port %d/%s not available", p.InternetPort, p.Protocol)
+			return oops.Errorf("port %d/%s not available", p.InternetPort, p.Protocol)
 		}
 	}
 
@@ -121,11 +121,11 @@ func (a *Application) Validate(
 	// exclude self if contained
 	existingApps = lo.Filter(existingApps, func(app *Application, _ int) bool { return app.ID != a.ID })
 	if a.WebsiteConflicts(existingApps, actor) {
-		return errors.New("website conflict")
+		return oops.New("website conflict")
 	}
 	for _, p := range a.PortPublications {
 		if p.ConflictsWith(existingApps) {
-			return errors.Errorf("port %d/%s conflicts with existing port publication", p.InternetPort, p.Protocol)
+			return oops.Errorf("port %d/%s conflicts with existing port publication", p.InternetPort, p.Protocol)
 		}
 	}
 

--- a/pkg/domain/app_build_config.go
+++ b/pkg/domain/app_build_config.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/friendsofgo/errors"
 	"github.com/google/shlex"
 	"github.com/samber/lo"
+	"github.com/samber/oops"
 )
 
 type BuildType int
@@ -86,7 +86,7 @@ func ParseArgs(s string) ([]string, error) {
 	}
 	args, err := shlex.Split(s)
 	if err != nil {
-		return nil, errors.Wrap(err, "cannot parse command")
+		return nil, oops.Wrapf(err, "cannot parse command")
 	}
 	shellSyntax := lo.ContainsBy(args, func(arg string) bool {
 		return strings.ContainsAny(arg, shellSpecialCharacters)
@@ -99,13 +99,13 @@ func ParseArgs(s string) ([]string, error) {
 
 func (rc *RuntimeConfig) Validate() error {
 	if _, err := ParseArgs(rc.Entrypoint); err != nil {
-		return errors.Wrap(err, "entrypoint")
+		return oops.Wrapf(err, "entrypoint")
 	}
 	if _, err := ParseArgs(rc.Command); err != nil {
-		return errors.Wrap(err, "command")
+		return oops.Wrapf(err, "command")
 	}
 	if rc.AutoShutdown.Enabled && rc.AutoShutdown.Startup == StartupBehaviorUndefined {
-		return errors.New("startup is required if auto shutdown is enabled")
+		return oops.New("startup is required if auto shutdown is enabled")
 	}
 	return nil
 }
@@ -133,7 +133,7 @@ type StaticConfig struct {
 
 func (sc *StaticConfig) Validate() error {
 	if sc.ArtifactPath == "" {
-		return errors.New("artifact_path is required for static builds")
+		return oops.New("artifact_path is required for static builds")
 	}
 	return nil
 }
@@ -205,7 +205,7 @@ func (bc *BuildConfigRuntimeCmd) Validate() error {
 	}
 	// NOTE: Base image could have no entrypoint/command but is impossible to catch only from config
 	if bc.BaseImage == "" && bc.Entrypoint == "" && bc.Command == "" {
-		return errors.New("entrypoint or command is required")
+		return oops.New("entrypoint or command is required")
 	}
 	// NOTE: base image is not necessary (default: scratch)
 	// NOTE: build cmd is not necessary
@@ -228,7 +228,7 @@ func (bc *BuildConfigRuntimeDockerfile) Validate() error {
 		return err
 	}
 	if bc.DockerfileName == "" {
-		return errors.New("dockerfile_name is required")
+		return oops.New("dockerfile_name is required")
 	}
 	// NOTE: Runtime Dockerfile build could have no entrypoint/command but is impossible to catch only from config
 	// (can only catch at runtime)
@@ -271,7 +271,7 @@ func (bc *BuildConfigStaticCmd) Validate() error {
 	// NOTE: base image is not necessary (default: scratch)
 	// NOTE: build cmd is not necessary
 	if bc.ArtifactPath == "" {
-		return errors.New("artifact_path is required")
+		return oops.New("artifact_path is required")
 	}
 	return nil
 }
@@ -292,7 +292,7 @@ func (bc *BuildConfigStaticDockerfile) Validate() error {
 		return err
 	}
 	if bc.DockerfileName == "" {
-		return errors.New("dockerfile_name is required")
+		return oops.New("dockerfile_name is required")
 	}
 	return nil
 }

--- a/pkg/domain/app_environment.go
+++ b/pkg/domain/app_environment.go
@@ -3,7 +3,7 @@ package domain
 import (
 	"regexp"
 
-	"github.com/friendsofgo/errors"
+	"github.com/samber/oops"
 )
 
 type Environment struct {
@@ -21,7 +21,7 @@ var environmentVariableKeyFormat = regexp.MustCompile(`^[A-Z_][A-Z0-9_]*$`)
 
 func (e *Environment) Validate() error {
 	if !environmentVariableKeyFormat.MatchString(e.Key) {
-		return errors.Errorf("bad key format: %s", e.Key)
+		return oops.Errorf("bad key format: %s", e.Key)
 	}
 	return nil
 }

--- a/pkg/domain/app_ports.go
+++ b/pkg/domain/app_ports.go
@@ -3,8 +3,8 @@ package domain
 import (
 	"strings"
 
-	"github.com/friendsofgo/errors"
 	"github.com/samber/lo"
+	"github.com/samber/oops"
 )
 
 type PortPublicationProtocol string
@@ -24,20 +24,20 @@ type AvailablePortSlice []*AvailablePort
 
 func isValidPort(port int) error {
 	if port < 0 || 65535 < port {
-		return errors.New("invalid port (needs to be within 0 to 65535)")
+		return oops.New("invalid port (needs to be within 0 to 65535)")
 	}
 	return nil
 }
 
 func (ap *AvailablePort) Validate() error {
 	if err := isValidPort(ap.StartPort); err != nil {
-		return errors.Wrap(err, "invalid start port")
+		return oops.Wrapf(err, "invalid start port")
 	}
 	if err := isValidPort(ap.EndPort); err != nil {
-		return errors.Wrap(err, "invalid end port")
+		return oops.Wrapf(err, "invalid end port")
 	}
 	if ap.EndPort < ap.StartPort {
-		return errors.New("end port comes before start port")
+		return oops.New("end port comes before start port")
 	}
 	return nil
 }
@@ -56,10 +56,10 @@ type PortPublication struct {
 
 func (p *PortPublication) Validate() error {
 	if err := isValidPort(p.InternetPort); err != nil {
-		return errors.Wrap(err, "invalid internet port")
+		return oops.Wrapf(err, "invalid internet port")
 	}
 	if err := isValidPort(p.ApplicationPort); err != nil {
-		return errors.Wrap(err, "invalid application port")
+		return oops.Wrapf(err, "invalid application port")
 	}
 	return nil
 }

--- a/pkg/domain/app_repository.go
+++ b/pkg/domain/app_repository.go
@@ -1,10 +1,10 @@
 package domain
 
 import (
-	"github.com/friendsofgo/errors"
 	"github.com/go-git/go-git/v5/plumbing/transport"
 	"github.com/go-git/go-git/v5/plumbing/transport/ssh"
 	"github.com/samber/lo"
+	"github.com/samber/oops"
 
 	"github.com/traPtitech/neoshowcase/pkg/util/optional"
 )
@@ -29,30 +29,30 @@ func NewRepository(name, url string, auth optional.Of[RepositoryAuth], ownerIDs 
 
 func (r *Repository) Validate() error {
 	if r.Name == "" {
-		return errors.New("name is required")
+		return oops.New("name is required")
 	}
 	ep, err := transport.NewEndpoint(r.URL)
 	if err != nil {
-		return errors.Wrap(err, "invalid url")
+		return oops.Wrapf(err, "invalid url")
 	}
 	if !r.Auth.Valid {
 		// URL is in http(s) format
 		if ep.Protocol != "http" && ep.Protocol != "https" {
-			return errors.New("url has to be http(s) protocol when auth is none")
+			return oops.New("url has to be http(s) protocol when auth is none")
 		}
 	} else if r.Auth.V.Method == RepositoryAuthMethodBasic {
 		// URL is in https format
 		if ep.Protocol != "https" {
-			return errors.New("url has to be https protocol when auth is basic")
+			return oops.New("url has to be https protocol when auth is basic")
 		}
 	} else if r.Auth.V.Method == RepositoryAuthMethodSSH {
 		// URL is in ssh format
 		if ep.Protocol != "ssh" {
-			return errors.New("url has to be ssh protocol when auth is ssh")
+			return oops.New("url has to be ssh protocol when auth is ssh")
 		}
 	}
 	if len(r.OwnerIDs) == 0 {
-		return errors.New("owner_ids cannot be empty")
+		return oops.New("owner_ids cannot be empty")
 	}
 	return nil
 }
@@ -109,16 +109,16 @@ func (r *RepositoryAuth) Validate() error {
 	switch r.Method {
 	case RepositoryAuthMethodBasic:
 		if r.Username == "" {
-			return errors.New("username cannot be empty")
+			return oops.New("username cannot be empty")
 		}
 		if r.Password == "" {
-			return errors.New("password cannot be empty")
+			return oops.New("password cannot be empty")
 		}
 	case RepositoryAuthMethodSSH:
 		if r.SSHKey != "" {
 			_, err := ssh.NewPublicKeys("", []byte(r.SSHKey), "")
 			if err != nil {
-				return errors.Wrap(err, "invalid ssh private key")
+				return oops.Wrapf(err, "invalid ssh private key")
 			}
 		}
 	}

--- a/pkg/domain/app_user.go
+++ b/pkg/domain/app_user.go
@@ -3,7 +3,7 @@ package domain
 import (
 	"time"
 
-	"github.com/friendsofgo/errors"
+	"github.com/samber/oops"
 	"golang.org/x/crypto/ssh"
 )
 
@@ -57,7 +57,7 @@ func (u *UserKey) MarshalKey() []byte {
 func (u *UserKey) Validate() error {
 	_, _, _, _, err := ssh.ParseAuthorizedKey([]byte(u.PublicKey))
 	if err != nil {
-		return errors.Wrap(err, "invalid public key format")
+		return oops.Wrapf(err, "invalid public key format")
 	}
 	return nil
 }

--- a/pkg/domain/app_website.go
+++ b/pkg/domain/app_website.go
@@ -1,13 +1,12 @@
 package domain
 
 import (
-	"fmt"
 	"net/url"
 	"regexp"
 	"strings"
 
-	"github.com/friendsofgo/errors"
 	"github.com/samber/lo"
+	"github.com/samber/oops"
 	"golang.org/x/net/idna"
 
 	"github.com/traPtitech/neoshowcase/pkg/util/ds"
@@ -18,33 +17,33 @@ var domainRegexp = regexp.MustCompile(`^[a-z0-9-_]+(\.[a-z0-9-_]+)*$`)
 func ValidateDomain(domain string) error {
 	// ドメインが大文字を含むときはエラー
 	if domain != strings.ToLower(domain) {
-		return errors.Errorf("domain %v must be lower case", domain)
+		return oops.Errorf("domain %v must be lower case", domain)
 	}
 
 	// 半角数字と英小文字以外を含むときはエラー
 	if !domainRegexp.MatchString(domain) {
-		return errors.Errorf("domain %v must consist of lower alpha-numeric letters, hyphen (-), or underscore (_)", domain)
+		return oops.Errorf("domain %v must consist of lower alpha-numeric letters, hyphen (-), or underscore (_)", domain)
 	}
 
 	// 面倒なのでtrailing dotは無しで統一
 	if strings.HasSuffix(domain, ".") {
-		return errors.Errorf("trailing dot not allowed in domain %v", domain)
+		return oops.Errorf("trailing dot not allowed in domain %v", domain)
 	}
 	if strings.HasPrefix(domain, ".") {
-		return errors.Errorf("leading dot not allowed in domain %v", domain)
+		return oops.Errorf("leading dot not allowed in domain %v", domain)
 	}
 	// allow underscore; Showcaseとのcompatibilityのため 本来はホスト名にunderscoreが入るのはダメ
 	// https://stackoverflow.com/questions/2180465/can-domain-name-subdomains-have-an-underscore-in-it
 	_, err := idna.Lookup.ToUnicode(strings.ReplaceAll(domain, "_", "-"))
 	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("invalid domain %v", domain))
+		return oops.Wrapf(err, "invalid domain %v", domain)
 	}
 	return nil
 }
 
 func ValidateWildcardDomain(domain string) error {
 	if !strings.HasPrefix(domain, "*.") {
-		return errors.Errorf("wildcard domain needs to begin with *. (got %v)", domain)
+		return oops.Errorf("wildcard domain needs to begin with *. (got %v)", domain)
 	}
 	baseDomain := strings.TrimPrefix(domain, "*.")
 	return ValidateDomain(baseDomain)
@@ -89,7 +88,7 @@ func (a *AvailableDomain) Validate() error {
 			return err
 		}
 		if !ContainsDomain(a.Domain, excludeDomain) {
-			return errors.Errorf("exclude domain %v is not contained within %v", excludeDomain, a.Domain)
+			return oops.Errorf("exclude domain %v is not contained within %v", excludeDomain, a.Domain)
 		}
 	}
 	return nil
@@ -154,26 +153,26 @@ func (w *Website) Compare(other *Website) bool {
 
 func (w *Website) Validate() error {
 	if err := ValidateDomain(w.FQDN); err != nil {
-		return errors.Wrap(err, "invalid domain")
+		return oops.Wrapf(err, "invalid domain")
 	}
 	if !strings.HasPrefix(w.PathPrefix, "/") {
-		return errors.New("path_prefix has to start with /")
+		return oops.New("path_prefix has to start with /")
 	}
 	if w.PathPrefix != "/" && strings.HasSuffix(w.PathPrefix, "/") {
-		return errors.New("path_prefix requires no trailing slash")
+		return oops.New("path_prefix requires no trailing slash")
 	}
 	if w.StripPrefix && w.PathPrefix == "/" {
-		return errors.New("strip_prefix has to be false when path_prefix is /")
+		return oops.New("strip_prefix has to be false when path_prefix is /")
 	}
 	u, err := url.ParseRequestURI(w.PathPrefix)
 	if err != nil {
-		return errors.Wrap(err, "invalid path")
+		return oops.Wrapf(err, "invalid path")
 	}
 	if u.EscapedPath() != w.PathPrefix {
-		return errors.New("invalid path: either not escaped or contains non-path elements")
+		return oops.New("invalid path: either not escaped or contains non-path elements")
 	}
 	if err = isValidPort(w.HTTPPort); err != nil {
-		return errors.Wrap(err, "invalid http port")
+		return oops.Wrapf(err, "invalid http port")
 	}
 	return nil
 }

--- a/pkg/domain/auth.go
+++ b/pkg/domain/auth.go
@@ -7,7 +7,7 @@ import (
 	"encoding/base64"
 	"encoding/pem"
 
-	"github.com/friendsofgo/errors"
+	"github.com/samber/oops"
 	ssh2 "golang.org/x/crypto/ssh"
 
 	"github.com/go-git/go-git/v5/plumbing/transport/ssh"
@@ -26,13 +26,13 @@ func Base64EncodedPublicKey(pubKey ssh2.PublicKey) string {
 func EncodePrivateKeyPem(privKey ed25519.PrivateKey) (string, error) {
 	privBytes, err := x509.MarshalPKCS8PrivateKey(privKey)
 	if err != nil {
-		return "", errors.Wrap(err, "encoding private key")
+		return "", oops.Wrapf(err, "encoding private key")
 	}
 	var res bytes.Buffer
 	privateKeyPEM := &pem.Block{Type: "PRIVATE KEY", Bytes: privBytes}
 	err = pem.Encode(&res, privateKeyPEM)
 	if err != nil {
-		return "", errors.Wrap(err, "encoding pem")
+		return "", oops.Wrapf(err, "encoding pem")
 	}
 	return res.String(), nil
 }

--- a/pkg/domain/storage.go
+++ b/pkg/domain/storage.go
@@ -4,12 +4,12 @@ import (
 	"io"
 	"path/filepath"
 
-	"github.com/friendsofgo/errors"
+	"github.com/samber/oops"
 )
 
 var (
 	// ErrFileNotFound ファイルが存在しない
-	ErrFileNotFound = errors.New("not found")
+	ErrFileNotFound = oops.New("not found")
 )
 
 // Storage ストレージインターフェース
@@ -27,7 +27,7 @@ func buildLogPath(buildID string) string {
 func SaveBuildLog(s Storage, buildID string, src io.Reader) error {
 	err := s.Save(buildLogPath(buildID), src)
 	if err != nil {
-		return errors.Wrap(err, "saving build log")
+		return oops.Wrapf(err, "saving build log")
 	}
 	return nil
 }
@@ -35,7 +35,7 @@ func SaveBuildLog(s Storage, buildID string, src io.Reader) error {
 func GetBuildLog(s Storage, buildID string) ([]byte, error) {
 	r, err := s.Open(buildLogPath(buildID))
 	if err != nil {
-		return nil, errors.Wrap(err, "opening build log")
+		return nil, oops.Wrapf(err, "opening build log")
 	}
 	defer r.Close()
 	return io.ReadAll(r)
@@ -44,7 +44,7 @@ func GetBuildLog(s Storage, buildID string) ([]byte, error) {
 func DeleteBuildLog(s Storage, buildID string) error {
 	err := s.Delete(buildLogPath(buildID))
 	if err != nil {
-		return errors.Wrap(err, "deleting build log")
+		return oops.Wrapf(err, "deleting build log")
 	}
 	return nil
 }
@@ -60,7 +60,7 @@ func artifactFilename(artifactID string) string {
 // SaveArtifact Artifactをtar形式で保存する
 func SaveArtifact(s Storage, artifactID string, src io.Reader) error {
 	if err := s.Save(artifactPath(artifactID), src); err != nil {
-		return errors.Wrap(err, "saving artifact")
+		return oops.Wrapf(err, "saving artifact")
 	}
 	return nil
 }
@@ -68,7 +68,7 @@ func SaveArtifact(s Storage, artifactID string, src io.Reader) error {
 func GetArtifact(s Storage, artifactID string) (r io.ReadCloser, err error) {
 	r, err = s.Open(artifactPath(artifactID))
 	if err != nil {
-		return nil, errors.Wrap(err, "opening artifact")
+		return nil, oops.Wrapf(err, "opening artifact")
 	}
 	return r, nil
 }
@@ -76,7 +76,7 @@ func GetArtifact(s Storage, artifactID string) (r io.ReadCloser, err error) {
 func DeleteArtifact(s Storage, artifactID string) error {
 	err := s.Delete(artifactPath(artifactID))
 	if err != nil {
-		return errors.Wrap(err, "deleting artifact")
+		return oops.Wrapf(err, "deleting artifact")
 	}
 	return nil
 }

--- a/pkg/domain/storage.go
+++ b/pkg/domain/storage.go
@@ -1,6 +1,7 @@
 package domain
 
 import (
+	"errors"
 	"io"
 	"path/filepath"
 
@@ -9,7 +10,7 @@ import (
 
 var (
 	// ErrFileNotFound ファイルが存在しない
-	ErrFileNotFound = oops.New("not found")
+	ErrFileNotFound = errors.New("not found")
 )
 
 // Storage ストレージインターフェース

--- a/pkg/infrastructure/backend/dockerimpl/backend.go
+++ b/pkg/infrastructure/backend/dockerimpl/backend.go
@@ -12,9 +12,9 @@ import (
 	"github.com/traPtitech/neoshowcase/pkg/util/retry"
 
 	clitypes "github.com/docker/cli/cli/config/types"
-	"github.com/friendsofgo/errors"
 	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/client"
+	"github.com/samber/oops"
 
 	"github.com/traPtitech/neoshowcase/pkg/domain"
 	"github.com/traPtitech/neoshowcase/pkg/domain/builder"
@@ -70,7 +70,7 @@ func NewDockerBackend(
 func (b *Backend) Start(ctx context.Context) error {
 	// showcase用のネットワークを用意
 	if err := b.initNetworks(ctx); err != nil {
-		return errors.Wrap(err, "initializing networks")
+		return oops.Wrapf(err, "initializing networks")
 	}
 
 	eventCtx, eventCancel := context.WithCancel(context.Background())
@@ -135,7 +135,7 @@ func (b *Backend) ListenContainerEvents() (sub <-chan *domain.ContainerEvent, un
 func (b *Backend) initNetworks(ctx context.Context) error {
 	networks, err := b.c.NetworkList(ctx, client.NetworkListOptions{})
 	if err != nil {
-		return errors.Wrap(err, "listing networks")
+		return oops.Wrapf(err, "listing networks")
 	}
 	for _, network := range networks.Items {
 		if network.Name == b.config.Network {

--- a/pkg/infrastructure/backend/dockerimpl/config.go
+++ b/pkg/infrastructure/backend/dockerimpl/config.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"math"
 
-	"github.com/friendsofgo/errors"
 	"github.com/samber/lo"
+	"github.com/samber/oops"
 
 	"github.com/traPtitech/neoshowcase/pkg/domain"
 	"github.com/traPtitech/neoshowcase/pkg/util/mapper"
@@ -134,12 +134,12 @@ func (c *Config) labels() map[string]string {
 func (c *Config) Validate() error {
 	for _, dc := range c.Domains {
 		if err := dc.toDomainAD().Validate(); err != nil {
-			return errors.Wrap(err, "invalid domain config")
+			return oops.Wrapf(err, "invalid domain config")
 		}
 	}
 	for _, pc := range c.Ports {
 		if err := pc.toDomainAP().Validate(); err != nil {
-			return errors.Wrap(err, "invalid port config")
+			return oops.Wrapf(err, "invalid port config")
 		}
 	}
 
@@ -147,23 +147,23 @@ func (c *Config) Validate() error {
 	case routingTypeTraefik:
 		// Nothing to validate as of now
 	default:
-		return errors.New(fmt.Sprintf("docker.routing.type is invalid: %s", c.Routing.Type))
+		return oops.New(fmt.Sprintf("docker.routing.type is invalid: %s", c.Routing.Type))
 	}
 	if err := c.TLS.Wildcard.Domains.Validate(); err != nil {
-		return errors.Wrap(err, "docker.tls.wildcard.domains is invalid")
+		return oops.Wrapf(err, "docker.tls.wildcard.domains is invalid")
 	}
 
 	if c.Resources.CPUs < 0 || math.IsNaN(c.Resources.CPUs) || math.IsInf(c.Resources.CPUs, 0) {
-		return errors.New("docker.resources.cpus needs to be a positive number")
+		return oops.New("docker.resources.cpus needs to be a positive number")
 	}
 	if c.Resources.Memory < 0 {
-		return errors.New("docker.resources.memory needs to be a positive number")
+		return oops.New("docker.resources.memory needs to be a positive number")
 	}
 	if c.Resources.MemorySwap < -1 {
-		return errors.New("docker.resources.memorySwap needs to be a positive number, or -1 for unlimited swap")
+		return oops.New("docker.resources.memorySwap needs to be a positive number, or -1 for unlimited swap")
 	}
 	if c.Resources.MemoryReservation < 0 {
-		return errors.New("docker.resources.memoryReservation needs to be a positive number")
+		return oops.New("docker.resources.memoryReservation needs to be a positive number")
 	}
 
 	return nil

--- a/pkg/infrastructure/backend/dockerimpl/exec.go
+++ b/pkg/infrastructure/backend/dockerimpl/exec.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"io"
 
-	"github.com/friendsofgo/errors"
 	"github.com/moby/moby/api/pkg/stdcopy"
 	"github.com/moby/moby/client"
+	"github.com/samber/oops"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -17,7 +17,7 @@ func streamHijackedResp(ctx context.Context, res client.HijackedResponse, stdin 
 		defer cancel()
 		_, err := io.Copy(res.Conn, stdin)
 		if err != nil {
-			return errors.Wrap(err, "writing into exec conn")
+			return oops.Wrapf(err, "writing into exec conn")
 		}
 		return nil
 	})
@@ -25,7 +25,7 @@ func streamHijackedResp(ctx context.Context, res client.HijackedResponse, stdin 
 		defer cancel()
 		_, err := stdcopy.StdCopy(stdout, stderr, res.Reader)
 		if err != nil {
-			return errors.Wrap(err, "reading exec response")
+			return oops.Wrapf(err, "reading exec response")
 		}
 		return nil
 	})
@@ -47,7 +47,7 @@ func (b *Backend) AttachContainer(ctx context.Context, appID string, stdin io.Re
 		Logs:       true,
 	})
 	if err != nil {
-		return errors.Wrap(err, "attaching to container")
+		return oops.Wrapf(err, "attaching to container")
 	}
 	return streamHijackedResp(ctx, res.HijackedResponse, stdin, stdout, stderr)
 }
@@ -63,12 +63,12 @@ func (b *Backend) ExecContainer(ctx context.Context, appID string, cmd []string,
 	}
 	execID, err := b.c.ExecCreate(ctx, containerName(appID), execConf)
 	if err != nil {
-		return errors.Wrap(err, "creating exec")
+		return oops.Wrapf(err, "creating exec")
 	}
 
 	res, err := b.c.ExecAttach(ctx, execID.ID, client.ExecAttachOptions{})
 	if err != nil {
-		return errors.Wrap(err, "attaching exec process")
+		return oops.Wrapf(err, "attaching exec process")
 	}
 
 	return streamHijackedResp(ctx, res.HijackedResponse, stdin, stdout, stderr)

--- a/pkg/infrastructure/backend/dockerimpl/ingress.go
+++ b/pkg/infrastructure/backend/dockerimpl/ingress.go
@@ -8,8 +8,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/friendsofgo/errors"
 	"github.com/samber/lo"
+	"github.com/samber/oops"
 	"gopkg.in/yaml.v3"
 
 	"github.com/traPtitech/neoshowcase/pkg/domain"
@@ -152,7 +152,7 @@ func (b *runtimeConfigBuilder) build() m {
 func (b *Backend) writeConfig(filename string, config any) error {
 	file, err := os.OpenFile(filepath.Join(b.config.ConfDir, filename), os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644)
 	if err != nil {
-		return errors.Wrap(err, "opening config file")
+		return oops.Wrapf(err, "opening config file")
 	}
 	defer file.Close()
 	enc := yaml.NewEncoder(file)

--- a/pkg/infrastructure/backend/dockerimpl/list_containers.go
+++ b/pkg/infrastructure/backend/dockerimpl/list_containers.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/friendsofgo/errors"
 	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/client"
+	"github.com/samber/oops"
 
 	"github.com/traPtitech/neoshowcase/pkg/domain"
 	"github.com/traPtitech/neoshowcase/pkg/util/ds"
@@ -20,7 +20,7 @@ func (b *Backend) GetContainer(ctx context.Context, appID string) (*domain.Conta
 			Add("label", fmt.Sprintf("%s=true", appLabel), fmt.Sprintf("%s=%s", appIDLabel, appID)),
 	})
 	if err != nil {
-		return nil, errors.Wrap(err, "fetching containers")
+		return nil, oops.Wrapf(err, "fetching containers")
 	}
 
 	if len(containers.Items) == 0 {
@@ -43,7 +43,7 @@ func (b *Backend) ListContainers(ctx context.Context) ([]*domain.Container, erro
 		Filters: make(client.Filters).Add("label", fmt.Sprintf("%s=true", appLabel)),
 	})
 	if err != nil {
-		return nil, errors.Wrap(err, "fetching containers")
+		return nil, oops.Wrapf(err, "fetching containers")
 	}
 
 	result := ds.Map(containers.Items, func(c container.Summary) *domain.Container {

--- a/pkg/infrastructure/backend/dockerimpl/synchronize_runtime.go
+++ b/pkg/infrastructure/backend/dockerimpl/synchronize_runtime.go
@@ -8,11 +8,11 @@ import (
 	"net/netip"
 	"strconv"
 
-	"github.com/friendsofgo/errors"
 	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/network"
 	"github.com/moby/moby/client"
 	"github.com/samber/lo"
+	"github.com/samber/oops"
 
 	"github.com/traPtitech/neoshowcase/pkg/domain"
 )
@@ -31,27 +31,27 @@ func (b *Backend) syncAppContainer(ctx context.Context, app *domain.RuntimeDesir
 			Force:         true,
 		})
 		if err != nil {
-			return errors.Wrap(err, "removing old container")
+			return oops.Wrapf(err, "removing old container")
 		}
 	}
 
 	registryAuth, err := b.authConfig()
 	if err != nil {
-		return errors.Wrap(err, "getting auth config")
+		return oops.Wrapf(err, "getting auth config")
 	}
 	res, err := b.c.ImagePull(ctx, app.ImageName+":"+app.ImageTag, client.ImagePullOptions{
 		RegistryAuth: registryAuth,
 	})
 	if err != nil {
-		return errors.Wrap(err, "pulling image")
+		return oops.Wrapf(err, "pulling image")
 	}
 	_, err = io.ReadAll(res)
 	if err != nil {
-		return errors.Wrap(err, "pulling image")
+		return oops.Wrapf(err, "pulling image")
 	}
 	err = res.Close()
 	if err != nil {
-		return errors.Wrap(err, "pulling image")
+		return oops.Wrapf(err, "pulling image")
 	}
 
 	envs := lo.MapToSlice(app.Envs, func(key string, value string) string {
@@ -120,12 +120,12 @@ func (b *Backend) syncAppContainer(ctx context.Context, app *domain.RuntimeDesir
 		Name:             containerName(app.App.ID),
 	})
 	if err != nil {
-		return errors.Wrap(err, "creating container")
+		return oops.Wrapf(err, "creating container")
 	}
 
 	_, err = b.c.ContainerStart(ctx, cont.ID, client.ContainerStartOptions{})
 	if err != nil {
-		return errors.Wrap(err, "starting container")
+		return oops.Wrapf(err, "starting container")
 	}
 	return nil
 }
@@ -137,7 +137,7 @@ func (b *Backend) synchronizeRuntime(ctx context.Context, apps []*domain.Runtime
 		Filters: make(client.Filters).Add("label", fmt.Sprintf("%s=true", appLabel)),
 	})
 	if err != nil {
-		return errors.Wrap(err, "listing containers")
+		return oops.Wrapf(err, "listing containers")
 	}
 	oldContainersMap := lo.SliceToMap(oldContainers.Items, func(c container.Summary) (string, *container.Summary) {
 		return c.Labels[appIDLabel], &c
@@ -161,7 +161,7 @@ func (b *Backend) synchronizeRuntime(ctx context.Context, apps []*domain.Runtime
 	}
 	err = b.writeConfig(traefikRuntimeFilename, cb.build())
 	if err != nil {
-		return errors.Wrap(err, "writing runtime ingress config")
+		return oops.Wrapf(err, "writing runtime ingress config")
 	}
 
 	// Prune old resources

--- a/pkg/infrastructure/backend/k8simpl/backend.go
+++ b/pkg/infrastructure/backend/k8simpl/backend.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 
 	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/client/clientset/versioned"
-	"github.com/friendsofgo/errors"
+	"github.com/samber/oops"
 	traefikv1alpha1 "github.com/traefik/traefik/v3/pkg/provider/kubernetes/crd/generated/clientset/versioned/typed/traefikio/v1alpha1"
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -91,7 +91,7 @@ func (b *Backend) eventListener(ctx context.Context) error {
 		}}),
 	})
 	if err != nil {
-		return errors.Wrap(err, "watching pods")
+		return oops.Wrapf(err, "watching pods")
 	}
 	defer podWatcher.Stop()
 

--- a/pkg/infrastructure/backend/k8simpl/config.go
+++ b/pkg/infrastructure/backend/k8simpl/config.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/friendsofgo/errors"
 	"github.com/samber/lo"
+	"github.com/samber/oops"
 	traefikv1alpha1 "github.com/traefik/traefik/v3/pkg/provider/kubernetes/crd/traefikio/v1alpha1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -376,12 +376,12 @@ func validateResourceQuantity(s string) error {
 func (c *Config) Validate() error {
 	for _, dc := range c.Domains {
 		if err := dc.toDomainAD().Validate(); err != nil {
-			return errors.Wrap(err, "invalid domain config")
+			return oops.Wrapf(err, "invalid domain config")
 		}
 	}
 	for _, pc := range c.Ports {
 		if err := pc.toDomainAP().Validate(); err != nil {
-			return errors.Wrap(err, "invalid port config")
+			return oops.Wrapf(err, "invalid port config")
 		}
 	}
 
@@ -389,12 +389,12 @@ func (c *Config) Validate() error {
 	case routingTypeTraefik:
 		// Nothing to validate as of now
 	default:
-		return errors.New(fmt.Sprintf("k8s.routing.type is invalid: %s", c.Routing.Type))
+		return oops.New(fmt.Sprintf("k8s.routing.type is invalid: %s", c.Routing.Type))
 	}
 
 	for _, family := range c.Service.IPFamilies {
 		if !lo.Contains([]v1.IPFamily{v1.IPv4Protocol, v1.IPv6Protocol}, family) {
-			return errors.New(fmt.Sprintf("invalid IPFamily %s", family))
+			return oops.New(fmt.Sprintf("invalid IPFamily %s", family))
 		}
 	}
 	if !lo.Contains([]v1.IPFamilyPolicy{
@@ -404,49 +404,49 @@ func (c *Config) Validate() error {
 		v1.IPFamilyPolicyPreferDualStack,
 		v1.IPFamilyPolicyRequireDualStack,
 	}, c.Service.IPFamilyPolicy) {
-		return errors.New(fmt.Sprintf("invalid IPFamily policy: %s", c.Service.IPFamilyPolicy))
+		return oops.New(fmt.Sprintf("invalid IPFamily policy: %s", c.Service.IPFamilyPolicy))
 	}
 
 	switch c.TLS.Type {
 	case tlsTypeTraefik:
 		if err := c.TLS.Traefik.Wildcard.Domains.Validate(); err != nil {
-			return errors.Wrap(err, "k8s.tls.traefik.wildcard.domains is invalid")
+			return oops.Wrapf(err, "k8s.tls.traefik.wildcard.domains is invalid")
 		}
 	case tlsTypeCertManager:
 		if err := c.TLS.CertManager.Wildcard.Domains.Validate(); err != nil {
-			return errors.Wrap(err, "k8s.tls.certManager.wildcard.domains is invalid")
+			return oops.Wrapf(err, "k8s.tls.certManager.wildcard.domains is invalid")
 		}
 	default:
-		return errors.New("k8s.tls.type needs to be one of 'traefik' or 'cert-manager'")
+		return oops.New("k8s.tls.type needs to be one of 'traefik' or 'cert-manager'")
 	}
 
 	for _, t := range c.Scheduling.Tolerations {
 		if _, ok := tolerationOperatorMapper.Into(t.Operator); !ok {
-			return errors.Errorf("k8s.scheduling.tolerations: unknown toleration operator: %v", t.Operator)
+			return oops.Errorf("k8s.scheduling.tolerations: unknown toleration operator: %v", t.Operator)
 		}
 		if _, ok := taintEffectMapper.Into(t.Effect); !ok {
-			return errors.Errorf("k8s.scheduling.tolerations: unknown taint effect: %v", t.Effect)
+			return oops.Errorf("k8s.scheduling.tolerations: unknown taint effect: %v", t.Effect)
 		}
 	}
 
 	if c.Resources.Requests.CPU != "" {
 		if err := validateResourceQuantity(c.Resources.Requests.CPU); err != nil {
-			return errors.Wrap(err, "k8s.resources.requests.cpu: invalid quantity")
+			return oops.Wrapf(err, "k8s.resources.requests.cpu: invalid quantity")
 		}
 	}
 	if c.Resources.Requests.Memory != "" {
 		if err := validateResourceQuantity(c.Resources.Requests.Memory); err != nil {
-			return errors.Wrap(err, "k8s.resources.requests.memory: invalid quantity")
+			return oops.Wrapf(err, "k8s.resources.requests.memory: invalid quantity")
 		}
 	}
 	if c.Resources.Limits.CPU != "" {
 		if err := validateResourceQuantity(c.Resources.Limits.CPU); err != nil {
-			return errors.Wrap(err, "k8s.resources.limits.cpu: invalid quantity")
+			return oops.Wrapf(err, "k8s.resources.limits.cpu: invalid quantity")
 		}
 	}
 	if c.Resources.Limits.Memory != "" {
 		if err := validateResourceQuantity(c.Resources.Limits.Memory); err != nil {
-			return errors.Wrap(err, "k8s.resources.limits.memory: invalid quantity")
+			return oops.Wrapf(err, "k8s.resources.limits.memory: invalid quantity")
 		}
 	}
 

--- a/pkg/infrastructure/backend/k8simpl/exec.go
+++ b/pkg/infrastructure/backend/k8simpl/exec.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/friendsofgo/errors"
+	"github.com/samber/oops"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/remotecommand"
@@ -24,7 +24,7 @@ func (b *Backend) AttachContainer(ctx context.Context, appID string, stdin io.Re
 	req.VersionedParams(option, scheme.ParameterCodec)
 	ex, err := remotecommand.NewSPDYExecutor(b.restConfig, "POST", req.URL())
 	if err != nil {
-		return errors.Wrap(err, "creating SPDY executor")
+		return oops.Wrapf(err, "creating SPDY executor")
 	}
 	err = ex.StreamWithContext(ctx, remotecommand.StreamOptions{
 		Stdin:  stdin,
@@ -33,7 +33,7 @@ func (b *Backend) AttachContainer(ctx context.Context, appID string, stdin io.Re
 		Tty:    true,
 	})
 	if err != nil {
-		return errors.Wrap(err, "streaming")
+		return oops.Wrapf(err, "streaming")
 	}
 	return nil
 }
@@ -53,7 +53,7 @@ func (b *Backend) ExecContainer(ctx context.Context, appID string, cmd []string,
 	req.VersionedParams(option, scheme.ParameterCodec)
 	ex, err := remotecommand.NewSPDYExecutor(b.restConfig, "POST", req.URL())
 	if err != nil {
-		return errors.Wrap(err, "creating SPDY executor")
+		return oops.Wrapf(err, "creating SPDY executor")
 	}
 	err = ex.StreamWithContext(ctx, remotecommand.StreamOptions{
 		Stdin:  stdin,
@@ -62,7 +62,7 @@ func (b *Backend) ExecContainer(ctx context.Context, appID string, cmd []string,
 		Tty:    true,
 	})
 	if err != nil {
-		return errors.Wrap(err, "streaming")
+		return oops.Wrapf(err, "streaming")
 	}
 	return nil
 }

--- a/pkg/infrastructure/backend/k8simpl/helper.go
+++ b/pkg/infrastructure/backend/k8simpl/helper.go
@@ -8,8 +8,8 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/friendsofgo/errors"
 	"github.com/samber/lo"
+	"github.com/samber/oops"
 	"github.com/sourcegraph/conc/pool"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -258,7 +258,7 @@ func replaceResource[T apiResource](
 	// This timeout provides sufficient buffer for most deletion scenarios while
 	// preventing indefinite waits for stuck resources.
 	case <-time.After(2 * time.Minute):
-		return errors.New("timeout while waiting for resource to be deleted")
+		return oops.New("timeout while waiting for resource to be deleted")
 	case <-ctx.Done():
 		return ctx.Err()
 	}

--- a/pkg/infrastructure/backend/k8simpl/helper.go
+++ b/pkg/infrastructure/backend/k8simpl/helper.go
@@ -258,7 +258,7 @@ func replaceResource[T apiResource](
 	// This timeout provides sufficient buffer for most deletion scenarios while
 	// preventing indefinite waits for stuck resources.
 	case <-time.After(2 * time.Minute):
-		return oops.New("timeout while waiting for resource to be deleted")
+		return oops.With("resource_name", rc.GetName()).New("timeout while waiting for resource to be deleted")
 	case <-ctx.Done():
 		return ctx.Err()
 	}

--- a/pkg/infrastructure/backend/k8simpl/list_containers.go
+++ b/pkg/infrastructure/backend/k8simpl/list_containers.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/friendsofgo/errors"
 	"github.com/samber/lo"
+	"github.com/samber/oops"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -20,7 +20,7 @@ func (b *Backend) GetContainer(ctx context.Context, appID string) (*domain.Conta
 		LabelSelector: toSelectorString(appSelector(appID)),
 	})
 	if err != nil {
-		return nil, errors.Wrap(err, "fetching pods")
+		return nil, oops.Wrapf(err, "fetching pods")
 	}
 
 	if len(list.Items) == 0 {
@@ -42,7 +42,7 @@ func (b *Backend) ListContainers(ctx context.Context) ([]*domain.Container, erro
 		LabelSelector: toSelectorString(b.shardedAllSelector()),
 	})
 	if err != nil {
-		return nil, errors.Wrap(err, "fetching pods")
+		return nil, oops.Wrapf(err, "fetching pods")
 	}
 
 	result := ds.Map(list.Items, func(pod v1.Pod) *domain.Container {

--- a/pkg/infrastructure/backend/k8simpl/synchronize.go
+++ b/pkg/infrastructure/backend/k8simpl/synchronize.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
-	"github.com/friendsofgo/errors"
+	"github.com/samber/oops"
 	traefikv1alpha1 "github.com/traefik/traefik/v3/pkg/provider/kubernetes/crd/traefikio/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
@@ -32,31 +32,31 @@ func (b *Backend) listCurrentResources(ctx context.Context) (*resources, error) 
 
 	ss, err := b.client.AppsV1().StatefulSets(b.config.Namespace).List(ctx, listOpt)
 	if err != nil {
-		return nil, errors.Wrap(err, "getting stateful sets")
+		return nil, oops.Wrapf(err, "getting stateful sets")
 	}
 	rsc.statefulSets = ds.SliceOfPtr(ss.Items)
 
 	secrets, err := b.client.CoreV1().Secrets(b.config.Namespace).List(ctx, listOpt)
 	if err != nil {
-		return nil, errors.Wrap(err, "getting secrets")
+		return nil, oops.Wrapf(err, "getting secrets")
 	}
 	rsc.secrets = ds.SliceOfPtr(secrets.Items)
 
 	svc, err := b.client.CoreV1().Services(b.config.Namespace).List(ctx, listOpt)
 	if err != nil {
-		return nil, errors.Wrap(err, "getting services")
+		return nil, oops.Wrapf(err, "getting services")
 	}
 	rsc.services = ds.SliceOfPtr(svc.Items)
 
 	mw, err := b.traefikClient.Middlewares(b.config.Namespace).List(ctx, listOpt)
 	if err != nil {
-		return nil, errors.Wrap(err, "getting middlewares")
+		return nil, oops.Wrapf(err, "getting middlewares")
 	}
 	rsc.middlewares = ds.SliceOfPtr(mw.Items)
 
 	ir, err := b.traefikClient.IngressRoutes(b.config.Namespace).List(ctx, listOpt)
 	if err != nil {
-		return nil, errors.Wrap(err, "getting ingress routes")
+		return nil, oops.Wrapf(err, "getting ingress routes")
 	}
 	rsc.ingressRoutes = ds.SliceOfPtr(ir.Items)
 
@@ -70,7 +70,7 @@ func (b *Backend) listCurrentSharedResources(ctx context.Context) (*sharedResour
 	if b.config.TLS.Type == tlsTypeCertManager {
 		certs, err := b.certManagerClient.CertmanagerV1().Certificates(b.config.Namespace).List(ctx, listOpt)
 		if err != nil {
-			return nil, errors.Wrap(err, "getting certificates")
+			return nil, oops.Wrapf(err, "getting certificates")
 		}
 		rsc.certificates = ds.SliceOfPtr(certs.Items)
 	}
@@ -96,23 +96,23 @@ func (b *Backend) Synchronize(ctx context.Context, s *domain.DesiredState) error
 	// Synchronize resources
 	err = syncResourcesWithReplace[*appsv1.StatefulSet](ctx, b.cluster, "statefulsets", old.statefulSets, next.statefulSets, b.client.AppsV1().StatefulSets(b.config.Namespace))
 	if err != nil {
-		return errors.Wrap(err, "syncing stateful sets")
+		return oops.Wrapf(err, "syncing stateful sets")
 	}
 	err = syncResources[*v1.Secret](ctx, b.cluster, "secrets", old.secrets, next.secrets, b.client.CoreV1().Secrets(b.config.Namespace))
 	if err != nil {
-		return errors.Wrap(err, "syncing secrets")
+		return oops.Wrapf(err, "syncing secrets")
 	}
 	err = syncResources[*v1.Service](ctx, b.cluster, "services", old.services, next.services, b.client.CoreV1().Services(b.config.Namespace))
 	if err != nil {
-		return errors.Wrap(err, "syncing services")
+		return oops.Wrapf(err, "syncing services")
 	}
 	err = syncResources[*traefikv1alpha1.Middleware](ctx, b.cluster, "middlewares", old.middlewares, next.middlewares, b.traefikClient.Middlewares(b.config.Namespace))
 	if err != nil {
-		return errors.Wrap(err, "syncing middlewares")
+		return oops.Wrapf(err, "syncing middlewares")
 	}
 	err = syncResources[*traefikv1alpha1.IngressRoute](ctx, b.cluster, "ingressroutes", old.ingressRoutes, next.ingressRoutes, b.traefikClient.IngressRoutes(b.config.Namespace))
 	if err != nil {
-		return errors.Wrap(err, "syncing ingressroutes")
+		return oops.Wrapf(err, "syncing ingressroutes")
 	}
 
 	return nil
@@ -132,7 +132,7 @@ func (b *Backend) SynchronizeShared(ctx context.Context, s *domain.DesiredStateL
 	// Synchronize resources
 	err = syncResources[*certmanagerv1.Certificate](ctx, b.cluster, "certificates", old.certificates, next.certificates, b.certManagerClient.CertmanagerV1().Certificates(b.config.Namespace))
 	if err != nil {
-		return errors.Wrap(err, "syncing certificates")
+		return oops.Wrapf(err, "syncing certificates")
 	}
 
 	return nil

--- a/pkg/infrastructure/buildpack/backend.go
+++ b/pkg/infrastructure/buildpack/backend.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/docker/cli/cli/config/configfile"
 	types2 "github.com/docker/cli/cli/config/types"
-	"github.com/friendsofgo/errors"
+	"github.com/samber/oops"
 
 	"github.com/traPtitech/neoshowcase/pkg/domain"
 	"github.com/traPtitech/neoshowcase/pkg/domain/builder"
@@ -60,7 +60,7 @@ func (b *backend) exec(ctx context.Context, workDir string, cmd []string, env ma
 		return err
 	}
 	if code != 0 {
-		return errors.Errorf("command exited with code %d", code)
+		return oops.Errorf("command exited with code %d", code)
 	}
 	return nil
 }
@@ -70,11 +70,11 @@ func (b *backend) prepareAuth(imageConfig builder.ImageConfig) error {
 	if ok {
 		err := b.exec(context.Background(), "/", []string{"sh", "-c", "mkdir -p ~/.docker"}, nil, io.Discard)
 		if err != nil {
-			return errors.Wrap(err, "making ~/.docker directory")
+			return oops.Wrapf(err, "making ~/.docker directory")
 		}
 		err = b.exec(context.Background(), "/", []string{"sh", "-c", fmt.Sprintf(`echo '%s' > ~/.docker/config.json`, escapeSingleQuote(auth))}, nil, io.Discard)
 		if err != nil {
-			return errors.Wrap(err, "writing ~/.docker/config.json to builder")
+			return oops.Wrapf(err, "writing ~/.docker/config.json to builder")
 		}
 	}
 	return nil
@@ -84,7 +84,7 @@ func (b *backend) prepareDir(ctx context.Context, localName, remoteName string) 
 	remotePath = filepath.Join(b.config.RemoteDir, remoteName)
 	err = b.exec(ctx, b.config.RemoteDir, []string{"mkdir", remotePath}, nil, io.Discard)
 	if err != nil {
-		return "", nil, errors.Wrap(err, "making remote tmp dir")
+		return "", nil, oops.Wrapf(err, "making remote tmp dir")
 	}
 	cleanup = func() {
 		err := b.exec(context.Background(), b.config.RemoteDir, []string{"rm", "-r", remotePath}, nil, io.Discard)
@@ -96,7 +96,7 @@ func (b *backend) prepareDir(ctx context.Context, localName, remoteName string) 
 	err = b.client.CopyFileTree(ctx, remotePath, tarfs.Compress(localName))
 	if err != nil {
 		cleanup()
-		return "", nil, errors.Wrap(err, "copying files to container")
+		return "", nil, oops.Wrapf(err, "copying files to container")
 	}
 	return remotePath, cleanup, nil
 }
@@ -122,17 +122,17 @@ func (b *backend) Pack(
 
 	localEnvTmp, err := os.MkdirTemp("", "env-")
 	if err != nil {
-		return "", errors.Wrap(err, "creating env temp dir")
+		return "", oops.Wrapf(err, "creating env temp dir")
 	}
 	defer os.RemoveAll(localEnvTmp)
 	err = os.Mkdir(filepath.Join(localEnvTmp, "env"), 0700)
 	if err != nil {
-		return "", errors.Wrap(err, "creating platform env dir")
+		return "", oops.Wrapf(err, "creating platform env dir")
 	}
 	for k, v := range env {
 		err = os.WriteFile(filepath.Join(localEnvTmp, "env", k), []byte(v), 0600)
 		if err != nil {
-			return "", errors.Wrap(err, "creating env file")
+			return "", oops.Wrapf(err, "creating env file")
 		}
 	}
 	remoteEnvPath, cleanupEnvDir, err := b.prepareDir(ctx, localEnvTmp, "ns-env")

--- a/pkg/infrastructure/dbmanager/mariadb.go
+++ b/pkg/infrastructure/dbmanager/mariadb.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/friendsofgo/errors"
 	"github.com/go-sql-driver/mysql"
+	"github.com/samber/oops"
 
 	"github.com/traPtitech/neoshowcase/pkg/domain"
 )
@@ -38,11 +38,11 @@ func NewMariaDBManager(c MariaDBConfig) (domain.MariaDBManager, error) {
 	// DB接続
 	connector, err := mysql.NewConnector(conf)
 	if err != nil {
-		return nil, errors.Wrap(err, "creating new connector")
+		return nil, oops.Wrapf(err, "creating new connector")
 	}
 	db := sql.OpenDB(connector)
 	if err := db.Ping(); err != nil {
-		return nil, errors.Wrap(err, "pinging db")
+		return nil, oops.Wrapf(err, "pinging db")
 	}
 	db.SetMaxOpenConns(1024)
 	db.SetMaxIdleConns(1024)
@@ -58,7 +58,7 @@ func (m *mariaDBManagerImpl) GetHost() (host string, port int) {
 
 func (m *mariaDBManagerImpl) Create(ctx context.Context, args domain.CreateArgs) error {
 	if strings.ContainsRune(args.Database, '`') {
-		return errors.New("backtick(`) in database name are not permitted")
+		return oops.New("backtick(`) in database name are not permitted")
 	}
 	if _, err := m.db.ExecContext(ctx, fmt.Sprintf("CREATE DATABASE IF NOT EXISTS `%s`", args.Database)); err != nil {
 		return err
@@ -74,7 +74,7 @@ func (m *mariaDBManagerImpl) Create(ctx context.Context, args domain.CreateArgs)
 
 func (m *mariaDBManagerImpl) Delete(ctx context.Context, args domain.DeleteArgs) error {
 	if strings.ContainsRune(args.Database, '`') {
-		return errors.New("backtick(`) in database name are not permitted")
+		return oops.New("backtick(`) in database name are not permitted")
 	}
 	if _, err := m.db.ExecContext(ctx, fmt.Sprintf("DROP DATABASE IF EXISTS `%s`", args.Database)); err != nil {
 		return err

--- a/pkg/infrastructure/dbmanager/mongodb.go
+++ b/pkg/infrastructure/dbmanager/mongodb.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/friendsofgo/errors"
+	"github.com/samber/oops"
 	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/mongo"
 	"go.mongodb.org/mongo-driver/v2/mongo/options"
@@ -31,7 +31,7 @@ func NewMongoDBManager(config MongoDBConfig) (domain.MongoDBManager, error) {
 		options.Client().ApplyURI(fmt.Sprintf("mongodb://%s:%s@%s:%d", config.AdminUser, config.AdminPassword, config.Host, config.Port)),
 	)
 	if err != nil {
-		return nil, errors.Wrap(err, "creating new client")
+		return nil, oops.Wrapf(err, "creating new client")
 	}
 
 	return &mongoDBManagerImpl{client: client, c: config}, nil

--- a/pkg/infrastructure/git/service.go
+++ b/pkg/infrastructure/git/service.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/friendsofgo/errors"
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing"
@@ -15,6 +14,7 @@ import (
 	"github.com/go-git/go-git/v5/plumbing/transport/http"
 	"github.com/go-git/go-git/v5/plumbing/transport/ssh"
 	"github.com/samber/lo"
+	"github.com/samber/oops"
 	"github.com/traPtitech/neoshowcase/pkg/domain"
 )
 
@@ -66,7 +66,7 @@ func (s *service) ResolveRefs(ctx context.Context, repo *domain.Repository) (map
 		Auth: auth,
 	})
 	if err != nil {
-		return nil, errors.Wrap(err, fmt.Sprintf("list remote refs at %v", repo.URL))
+		return nil, oops.With("repo_url", repo.URL).Wrapf(err, "listing remote refs")
 	}
 
 	refToCommit := make(map[string]string, 2*len(refs))
@@ -106,16 +106,16 @@ func (s *service) CloneRepository(ctx context.Context, dir string, repo *domain.
 		Auth:       auth,
 	})
 	if err != nil {
-		return errors.Wrap(err, "fetch commit")
+		return oops.Wrapf(err, "fetch commit")
 	}
 
 	wt, err := localRepo.Worktree()
 	if err != nil {
-		return errors.Wrap(err, "get worktree")
+		return oops.Wrapf(err, "get worktree")
 	}
 	err = wt.Checkout(&git.CheckoutOptions{Branch: targetRef})
 	if err != nil {
-		return errors.Wrap(err, "checkout")
+		return oops.Wrapf(err, "checkout")
 	}
 
 	err = updateSubModules(wt, auth)
@@ -134,7 +134,7 @@ func (s *service) CloneRepository(ctx context.Context, dir string, repo *domain.
 func updateSubModules(wt *git.Worktree, auth transport.AuthMethod) error {
 	sm, err := wt.Submodules()
 	if err != nil {
-		return errors.Wrap(err, "get submodules")
+		return oops.Wrapf(err, "get submodules")
 	}
 	// Try with auth first, then try without auth
 	err = sm.Update(&git.SubmoduleUpdateOptions{
@@ -150,7 +150,7 @@ func updateSubModules(wt *git.Worktree, auth transport.AuthMethod) error {
 			Depth:             1,
 		})
 		if err != nil {
-			return errors.Wrap(err, "update submodules")
+			return oops.Wrapf(err, "update submodules")
 		}
 	}
 	return nil
@@ -171,14 +171,14 @@ func (s *service) CreateBareRepository(dir string, repo *domain.Repository) (dom
 func initializeGitRepo(dir, remoteURL string, isBare bool) (*git.Repository, *git.Remote, error) {
 	localRepo, err := git.PlainInit(dir, isBare)
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "init repository")
+		return nil, nil, oops.Wrapf(err, "init repository")
 	}
 	remote, err := localRepo.CreateRemote(&config.RemoteConfig{
 		Name: "origin",
 		URLs: []string{remoteURL},
 	})
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "create remote")
+		return nil, nil, oops.Wrapf(err, "create remote")
 	}
 	return localRepo, remote, nil
 }
@@ -203,7 +203,7 @@ func (r *repository) Fetch(ctx context.Context, hashes []string) error {
 		Auth:       r.auth,
 	})
 	if err != nil {
-		return errors.Wrap(err, "fetch commits")
+		return oops.Wrapf(err, "fetch commits")
 	}
 
 	return nil
@@ -212,7 +212,7 @@ func (r *repository) Fetch(ctx context.Context, hashes []string) error {
 func (r *repository) GetCommit(hash string) (*domain.RepositoryCommit, error) {
 	commit, err := r.repo.CommitObject(plumbing.NewHash(hash))
 	if err != nil {
-		return nil, errors.Wrap(err, "get commit")
+		return nil, oops.Wrapf(err, "get commit")
 	}
 	return toRepositoryCommit(commit), nil
 }

--- a/pkg/infrastructure/grpc/api_app_build_service.go
+++ b/pkg/infrastructure/grpc/api_app_build_service.go
@@ -5,7 +5,7 @@ import (
 	"io"
 
 	"connectrpc.com/connect"
-	"github.com/friendsofgo/errors"
+	"github.com/samber/oops"
 	"google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/traPtitech/neoshowcase/pkg/infrastructure/grpc/pb"
@@ -83,7 +83,7 @@ func (s *APIService) GetBuildLogStream(ctx context.Context, req *connect.Request
 	for l := range ch {
 		err = st.Send(l)
 		if err != nil {
-			return errors.Wrap(err, "sending event")
+			return oops.Wrapf(err, "sending event")
 		}
 	}
 	return nil

--- a/pkg/infrastructure/grpc/api_app_info_service.go
+++ b/pkg/infrastructure/grpc/api_app_info_service.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"connectrpc.com/connect"
-	"github.com/friendsofgo/errors"
+	"github.com/samber/oops"
 	"google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/traPtitech/neoshowcase/pkg/domain"
@@ -25,7 +25,7 @@ func (s *APIService) GetAvailableMetrics(ctx context.Context, c *connect.Request
 func (s *APIService) GetApplicationMetrics(ctx context.Context, req *connect.Request[pb.GetApplicationMetricsRequest]) (*connect.Response[pb.ApplicationMetrics], error) {
 	msg := req.Msg
 	if msg.Before == nil {
-		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("before cannot be null"))
+		return nil, connect.NewError(connect.CodeInvalidArgument, oops.New("before cannot be null"))
 	}
 	metrics, err := s.svc.GetApplicationMetrics(ctx,
 		msg.MetricsName,
@@ -45,7 +45,7 @@ func (s *APIService) GetApplicationMetrics(ctx context.Context, req *connect.Req
 func (s *APIService) GetOutput(ctx context.Context, req *connect.Request[pb.GetOutputRequest]) (*connect.Response[pb.ApplicationOutputs], error) {
 	msg := req.Msg
 	if msg.Before == nil {
-		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("before cannot be null"))
+		return nil, connect.NewError(connect.CodeInvalidArgument, oops.New("before cannot be null"))
 	}
 	before := msg.Before.AsTime()
 	logs, err := s.svc.GetOutput(ctx, msg.ApplicationId, before, int(msg.Limit))
@@ -60,7 +60,7 @@ func (s *APIService) GetOutput(ctx context.Context, req *connect.Request[pb.GetO
 
 func (s *APIService) GetOutputStream(ctx context.Context, req *connect.Request[pb.GetOutputStreamRequest], st *connect.ServerStream[pb.ApplicationOutput]) error {
 	if req.Msg.Begin == nil {
-		return connect.NewError(connect.CodeInvalidArgument, errors.New("begin cannot be null"))
+		return connect.NewError(connect.CodeInvalidArgument, oops.New("begin cannot be null"))
 	}
 	begin := req.Msg.Begin.AsTime()
 	err := s.svc.GetOutputStream(ctx, req.Msg.ApplicationId, begin, func(l *domain.ContainerLog) error {

--- a/pkg/infrastructure/grpc/api_service.go
+++ b/pkg/infrastructure/grpc/api_service.go
@@ -8,21 +8,37 @@ import (
 	"github.com/traPtitech/neoshowcase/pkg/usecase/apiserver"
 )
 
+// publicError reports only the client-facing message from Error(), which is what
+// Connect puts on the wire, while still unwrapping to the internal chain so the
+// boundary log keeps the full detail.
+type publicError struct {
+	public string
+	cause  error
+}
+
+func (e publicError) Error() string { return e.public }
+func (e publicError) Unwrap() error { return e.cause }
+
+var connectCodes = map[apiserver.ErrorType]connect.Code{
+	apiserver.ErrorTypeBadRequest:    connect.CodeInvalidArgument,
+	apiserver.ErrorTypeNotFound:      connect.CodeNotFound,
+	apiserver.ErrorTypeAlreadyExists: connect.CodeAlreadyExists,
+	apiserver.ErrorTypeForbidden:     connect.CodePermissionDenied,
+}
+
 func handleUseCaseError(err error) error {
-	underlying, typ, ok := apiserver.DecomposeError(err)
+	publicMessage, typ, ok := apiserver.DecomposeError(err)
 	if ok {
-		switch typ {
-		case apiserver.ErrorTypeBadRequest:
-			return connect.NewError(connect.CodeInvalidArgument, underlying)
-		case apiserver.ErrorTypeNotFound:
-			return connect.NewError(connect.CodeNotFound, underlying)
-		case apiserver.ErrorTypeAlreadyExists:
-			return connect.NewError(connect.CodeAlreadyExists, underlying)
-		case apiserver.ErrorTypeForbidden:
-			return connect.NewError(connect.CodePermissionDenied, underlying)
+		if code, known := connectCodes[typ]; known {
+			return connect.NewError(code, publicError{public: publicMessage, cause: err})
 		}
 	}
-	return connect.NewError(connect.CodeInternal, err)
+	// Untagged errors are unanticipated: the client gets a generic message, the
+	// detail stays in the log.
+	return connect.NewError(connect.CodeInternal, publicError{
+		public: "internal server error",
+		cause:  err,
+	})
 }
 
 type APIService struct {

--- a/pkg/infrastructure/grpc/buildpack_helper_service.go
+++ b/pkg/infrastructure/grpc/buildpack_helper_service.go
@@ -3,12 +3,13 @@ package grpc
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"os"
 	"os/exec"
 
 	"connectrpc.com/connect"
-	"github.com/friendsofgo/errors"
+	"github.com/samber/oops"
 	"github.com/traPtitech/neoshowcase/pkg/infrastructure/grpc/pb"
 	"github.com/traPtitech/neoshowcase/pkg/infrastructure/grpc/pb/pbconnect"
 	"github.com/traPtitech/neoshowcase/pkg/util/ds"
@@ -51,7 +52,7 @@ func (b *buildpackHelperExec) Write(p []byte) (n int, err error) {
 
 func (b *BuildpackHelperService) Exec(ctx context.Context, req *connect.Request[pb.HelperExecRequest], st *connect.ServerStream[pb.HelperExecResponse]) error {
 	if len(req.Msg.Cmd) == 0 {
-		return connect.NewError(connect.CodeInvalidArgument, errors.New("cmd cannot have length of 0"))
+		return connect.NewError(connect.CodeInvalidArgument, oops.New("cmd cannot have length of 0"))
 	}
 
 	// Prepare command

--- a/pkg/infrastructure/grpc/buildpack_helper_service_client.go
+++ b/pkg/infrastructure/grpc/buildpack_helper_service_client.go
@@ -5,8 +5,8 @@ import (
 	"io"
 
 	"connectrpc.com/connect"
-	"github.com/friendsofgo/errors"
 	"github.com/samber/lo"
+	"github.com/samber/oops"
 
 	"github.com/traPtitech/neoshowcase/pkg/domain"
 	"github.com/traPtitech/neoshowcase/pkg/domain/web"
@@ -53,7 +53,7 @@ func (b *BuildpackHelperServiceClient) Exec(ctx context.Context, workDir string,
 	})
 	st, err := b.client.Exec(ctx, req)
 	if err != nil {
-		return 0, errors.Wrap(err, "requesting exec")
+		return 0, oops.Wrapf(err, "requesting exec")
 	}
 	var exitCode *int
 	for st.Receive() {
@@ -71,10 +71,10 @@ func (b *BuildpackHelperServiceClient) Exec(ctx context.Context, workDir string,
 		}
 	}
 	if err := st.Err(); err != nil {
-		return 0, errors.Wrap(err, "receiving logs")
+		return 0, oops.Wrapf(err, "receiving logs")
 	}
 	if exitCode == nil {
-		return 0, errors.New("exit code not received")
+		return 0, oops.New("exit code not received")
 	}
 	return *exitCode, nil
 }

--- a/pkg/infrastructure/grpc/controller_builder_service.go
+++ b/pkg/infrastructure/grpc/controller_builder_service.go
@@ -273,7 +273,7 @@ func (s *ControllerBuilderService) startBuildPayload(ctx context.Context, buildI
 	}, nil
 }
 
-var errBuildLockConflict = oops.New("build lock conflict")
+var errBuildLockConflict = errors.New("build lock conflict")
 
 func (s *ControllerBuilderService) startBuild(ctx context.Context, conn *builderConnection, buildID string) error {
 	// Change build status in order to acquire lock

--- a/pkg/infrastructure/grpc/controller_builder_service.go
+++ b/pkg/infrastructure/grpc/controller_builder_service.go
@@ -3,6 +3,7 @@ package grpc
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"log/slog"
 	"slices"
@@ -10,8 +11,8 @@ import (
 	"time"
 
 	"connectrpc.com/connect"
-	"github.com/friendsofgo/errors"
 	"github.com/samber/lo"
+	"github.com/samber/oops"
 	"google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/traPtitech/neoshowcase/pkg/domain"
@@ -127,7 +128,7 @@ func (s *ControllerBuilderService) StreamBuildLog(ctx context.Context, st *conne
 	if err := st.Err(); err != nil {
 		// This service has no log interceptor, so this is the terminal log for the error.
 		slog.WarnContext(ctx, "receiving build log", "error", err)
-		return nil, errors.Wrap(err, "receiving build log")
+		return nil, oops.Wrapf(err, "receiving build log")
 	}
 	res := connect.NewResponse(&emptypb.Empty{})
 	return res, nil
@@ -272,7 +273,7 @@ func (s *ControllerBuilderService) startBuildPayload(ctx context.Context, buildI
 	}, nil
 }
 
-var errBuildLockConflict = errors.New("build lock conflict")
+var errBuildLockConflict = oops.New("build lock conflict")
 
 func (s *ControllerBuilderService) startBuild(ctx context.Context, conn *builderConnection, buildID string) error {
 	// Change build status in order to acquire lock
@@ -297,7 +298,7 @@ func (s *ControllerBuilderService) startBuild(ctx context.Context, conn *builder
 	// Construct payload to send to builder
 	req, err := s.startBuildPayload(ctx, buildID)
 	if err != nil {
-		return errors.Wrapf(err, "constructing start build payload (build_id=%v)", buildID)
+		return oops.With("build_id", buildID).Wrapf(err, "constructing start build payload")
 	}
 	// Send payload to builder
 	conn.Send(&pb.BuilderRequest{
@@ -329,7 +330,7 @@ func (s *ControllerBuilderService) finishBuild(ctx context.Context, buildID stri
 		return err
 	}
 	if n == 0 {
-		return errors.Errorf("changing build status from building to finished (build_id=%v): no row updated, builder scheduling may be malfunctioning", buildID)
+		return oops.With("build_id", buildID).New("changing build status from building to finished: no row updated, builder scheduling may be malfunctioning")
 	}
 
 	// metrics

--- a/pkg/infrastructure/grpc/controller_builder_service_client.go
+++ b/pkg/infrastructure/grpc/controller_builder_service_client.go
@@ -2,13 +2,12 @@ package grpc
 
 import (
 	"context"
+	"errors"
 	"io"
 	"log/slog"
 
 	"connectrpc.com/connect"
 	"google.golang.org/protobuf/types/known/emptypb"
-
-	"github.com/friendsofgo/errors"
 
 	"github.com/traPtitech/neoshowcase/pkg/domain"
 	"github.com/traPtitech/neoshowcase/pkg/domain/web"

--- a/pkg/infrastructure/grpc/controller_service.go
+++ b/pkg/infrastructure/grpc/controller_service.go
@@ -5,9 +5,9 @@ import (
 	"time"
 
 	"connectrpc.com/connect"
-	"github.com/friendsofgo/errors"
 	"github.com/motoki317/sc"
 	"github.com/samber/lo"
+	"github.com/samber/oops"
 	"github.com/sourcegraph/conc/pool"
 	"google.golang.org/protobuf/types/known/emptypb"
 
@@ -126,7 +126,7 @@ func (s *ControllerService) DiscoverBuildLogInstance(ctx context.Context, c *con
 		return r.Address != nil
 	})
 	if !ok {
-		return nil, errors.New("build log not available")
+		return nil, oops.New("build log not available")
 	}
 	return connect.NewResponse(neighborResult), nil
 }
@@ -135,7 +135,7 @@ func (s *ControllerService) StreamBuildLog(ctx context.Context, c *connect.Reque
 	sub := make(chan []byte, 100)
 	ok, unsubscribe := s.logStream.SubscribeBuildLog(c.Msg.BuildId, sub)
 	if !ok {
-		return errors.New("build log stream unavailable")
+		return oops.New("build log stream unavailable")
 	}
 	defer unsubscribe()
 
@@ -148,7 +148,7 @@ loop:
 			}
 			err := c2.Send(&pb.BuildLog{Log: l})
 			if err != nil {
-				return errors.Wrap(err, "sending message")
+				return oops.Wrapf(err, "sending message")
 			}
 		case <-ctx.Done():
 			break loop
@@ -204,7 +204,7 @@ func (s *ControllerService) DiscoverBuildLogLocal(_ context.Context, c *connect.
 	}
 	addr, ok := s.cluster.MyAddress(s.Port)
 	if !ok {
-		return nil, errors.New("self address not available")
+		return nil, oops.New("self address not available")
 	}
 	return connect.NewResponse(&pb.AddressInfo{Address: &addr}), nil
 }

--- a/pkg/infrastructure/grpc/controller_service_client.go
+++ b/pkg/infrastructure/grpc/controller_service_client.go
@@ -2,12 +2,12 @@ package grpc
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"time"
 
 	"connectrpc.com/connect"
 	"connectrpc.com/otelconnect"
-	"github.com/friendsofgo/errors"
 	"github.com/motoki317/sc"
 	"google.golang.org/protobuf/types/known/emptypb"
 

--- a/pkg/infrastructure/grpc/log_interceptor.go
+++ b/pkg/infrastructure/grpc/log_interceptor.go
@@ -2,12 +2,13 @@ package grpc
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"time"
 
 	"connectrpc.com/connect"
-	"github.com/friendsofgo/errors"
+	"github.com/samber/oops"
 	"github.com/traPtitech/neoshowcase/pkg/domain"
 	"github.com/traPtitech/neoshowcase/pkg/domain/web"
 	"github.com/traPtitech/neoshowcase/pkg/util/slogutil"
@@ -19,6 +20,19 @@ type LogInterceptor struct {
 
 func NewLogInterceptor() *LogInterceptor {
 	return &LogInterceptor{}
+}
+
+// logError picks the value to log for err.
+//
+// oops.OopsError implements slog.LogValuer, so logging it expands into structured
+// fields (the wrap chain, the code, With() attributes and the stack trace). The
+// *connect.Error the boundary returns implements neither, so logging it directly
+// would flatten everything to its message — hence the unwrap.
+func logError(err error) any {
+	if oopsErr, ok := oops.AsOops(err); ok {
+		return oopsErr
+	}
+	return err
 }
 
 func (l *LogInterceptor) WrapUnary(next connect.UnaryFunc) connect.UnaryFunc {
@@ -54,7 +68,7 @@ func (l *LogInterceptor) WrapUnary(next connect.UnaryFunc) connect.UnaryFunc {
 				slog.ErrorContext(ctx, "unary request failed with server error",
 					"procedure", request.Spec().Procedure,
 					"duration_sec", elapsed,
-					"error", err,
+					"error", logError(err),
 					"status", connect.CodeOf(err).String(),
 				)
 
@@ -62,7 +76,7 @@ func (l *LogInterceptor) WrapUnary(next connect.UnaryFunc) connect.UnaryFunc {
 				slog.WarnContext(ctx, "unary request failed with client error",
 					"procedure", request.Spec().Procedure,
 					"duration_sec", elapsed,
-					"error", err,
+					"error", logError(err),
 					"status", connect.CodeOf(err).String(),
 				)
 			}
@@ -111,7 +125,7 @@ func (l *LogInterceptor) WrapStreamingHandler(next connect.StreamingHandlerFunc)
 				"stream_id", streamID,
 				"procedure", shc.Spec().Procedure,
 				"duration_sec", elapsed,
-				"error", err,
+				"error", logError(err),
 				"status", connect.CodeOf(err).String(),
 			)
 		}

--- a/pkg/infrastructure/grpc/token_auth_interceptor.go
+++ b/pkg/infrastructure/grpc/token_auth_interceptor.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 
 	"connectrpc.com/connect"
-	"github.com/friendsofgo/errors"
+	"github.com/samber/oops"
 )
 
 type TokenAuthInterceptor struct {
@@ -20,10 +20,10 @@ func NewTokenAuthInterceptor(
 	token string,
 ) (*TokenAuthInterceptor, error) {
 	if header == "" {
-		return nil, errors.New("header name cannot be empty")
+		return nil, oops.New("header name cannot be empty")
 	}
 	if token == "" {
-		return nil, errors.New("token cannot be empty")
+		return nil, oops.New("token cannot be empty")
 	}
 	return &TokenAuthInterceptor{
 		header: header,

--- a/pkg/infrastructure/log/loki/streamer.go
+++ b/pkg/infrastructure/log/loki/streamer.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"iter"
 	"log/slog"
@@ -13,7 +14,7 @@ import (
 	"time"
 
 	"github.com/coder/websocket"
-	"github.com/friendsofgo/errors"
+	"github.com/samber/oops"
 
 	"github.com/traPtitech/neoshowcase/pkg/domain"
 )
@@ -39,7 +40,7 @@ func NewLokiStreamer(
 ) (domain.ContainerLogger, error) {
 	tmpl, err := template.New("logQL templater").Parse(config.QueryTemplate)
 	if err != nil {
-		return nil, errors.Wrap(err, "invalid logQL template")
+		return nil, oops.Wrapf(err, "invalid logQL template")
 	}
 
 	l := &lokiStreamer{
@@ -57,7 +58,7 @@ func NewLokiStreamer(
 	var dummy domain.Application
 	_, err = l.logQL(&dummy)
 	if err != nil {
-		return nil, errors.Wrap(err, "executing logQL template")
+		return nil, oops.Wrapf(err, "executing logQL template")
 	}
 
 	return l, nil
@@ -85,11 +86,11 @@ func (l *lokiStreamer) LogLimit() int {
 func (l *lokiStreamer) Get(ctx context.Context, app *domain.Application, before time.Time, limit int) ([]*domain.ContainerLog, error) {
 	req, err := http.NewRequestWithContext(ctx, "GET", l.queryRangeEndpoint(), nil)
 	if err != nil {
-		return nil, errors.Wrap(err, "creating http request")
+		return nil, oops.Wrapf(err, "creating http request")
 	}
 	logQL, err := l.logQL(app)
 	if err != nil {
-		return nil, errors.Wrap(err, "templating logQL")
+		return nil, oops.Wrapf(err, "templating logQL")
 	}
 	q := req.URL.Query()
 	q.Set("query", logQL)
@@ -101,19 +102,19 @@ func (l *lokiStreamer) Get(ctx context.Context, app *domain.Application, before 
 
 	hres, err := l.client.Do(req)
 	if err != nil {
-		return nil, errors.Wrap(err, "performing http request")
+		return nil, oops.Wrapf(err, "performing http request")
 	}
 	var res queryRangeResponse
 	err = json.NewDecoder(hres.Body).Decode(&res)
 	if err != nil {
-		return nil, errors.Wrap(err, "decoding response")
+		return nil, oops.Wrapf(err, "decoding response")
 	}
 
 	if res.Status != "success" {
-		return nil, errors.Errorf("expected response status to be success, got %s", res.Status)
+		return nil, oops.Errorf("expected response status to be success, got %s", res.Status)
 	}
 	if res.Data.ResultType != "streams" {
-		return nil, errors.Errorf("expected result type to be streams, got %s", res.Data.ResultType)
+		return nil, oops.Errorf("expected result type to be streams, got %s", res.Data.ResultType)
 	}
 	return res.Data.Result.toSortedResponse(true)
 }
@@ -121,7 +122,7 @@ func (l *lokiStreamer) Get(ctx context.Context, app *domain.Application, before 
 func (l *lokiStreamer) Stream(ctx context.Context, app *domain.Application, begin time.Time) (<-chan *domain.ContainerLog, error) {
 	logQL, err := l.logQL(app)
 	if err != nil {
-		return nil, errors.Wrap(err, "templating logQL")
+		return nil, oops.Wrapf(err, "templating logQL")
 	}
 
 	ch := make(chan *domain.ContainerLog, 100)

--- a/pkg/infrastructure/log/loki/types.go
+++ b/pkg/infrastructure/log/loki/types.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/friendsofgo/errors"
+	"github.com/samber/oops"
 
 	"github.com/traPtitech/neoshowcase/pkg/domain"
 	"github.com/traPtitech/neoshowcase/pkg/util/ds"
@@ -69,7 +69,7 @@ func (values streamValues) toSortedResponse(asc bool) ([]*domain.ContainerLog, e
 		for _, v := range sv.Values {
 			logTime, err := v.time()
 			if err != nil {
-				return nil, errors.Wrap(err, "decoding response time")
+				return nil, oops.Wrapf(err, "decoding response time")
 			}
 			logs = append(logs, &domain.ContainerLog{
 				Time: logTime,

--- a/pkg/infrastructure/log/victorialogs/streamer.go
+++ b/pkg/infrastructure/log/victorialogs/streamer.go
@@ -10,8 +10,8 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/friendsofgo/errors"
 	"github.com/samber/lo/mutable"
+	"github.com/samber/oops"
 
 	"github.com/traPtitech/neoshowcase/pkg/domain"
 )
@@ -35,7 +35,7 @@ type victoriaLogsStreamer struct {
 func NewVictoriaLogsStreamer(config Config) (domain.ContainerLogger, error) {
 	tmpl, err := template.New("logsQL templater").Parse(config.QueryTemplate)
 	if err != nil {
-		return nil, errors.Wrap(err, "invalid logsQL template")
+		return nil, oops.Wrapf(err, "invalid logsQL template")
 	}
 
 	l := &victoriaLogsStreamer{
@@ -53,7 +53,7 @@ func NewVictoriaLogsStreamer(config Config) (domain.ContainerLogger, error) {
 	var dummy domain.Application
 	_, err = l.logsQL(&dummy)
 	if err != nil {
-		return nil, errors.Wrap(err, "executing logsQL template")
+		return nil, oops.Wrapf(err, "executing logsQL template")
 	}
 
 	return l, nil
@@ -81,11 +81,11 @@ func (l *victoriaLogsStreamer) LogLimit() int {
 func (l *victoriaLogsStreamer) Get(ctx context.Context, app *domain.Application, before time.Time, limit int) ([]*domain.ContainerLog, error) {
 	req, err := http.NewRequestWithContext(ctx, "GET", l.queryEndpoint(), nil)
 	if err != nil {
-		return nil, errors.Wrap(err, "creating http request")
+		return nil, oops.Wrapf(err, "creating http request")
 	}
 	logsQL, err := l.logsQL(app)
 	if err != nil {
-		return nil, errors.Wrap(err, "templating logsQL")
+		return nil, oops.Wrapf(err, "templating logsQL")
 	}
 
 	start := before.Add(-24 * time.Hour)
@@ -96,18 +96,18 @@ func (l *victoriaLogsStreamer) Get(ctx context.Context, app *domain.Application,
 
 	res, err := l.client.Do(req)
 	if err != nil {
-		return nil, errors.Wrap(err, "executing http request")
+		return nil, oops.Wrapf(err, "executing http request")
 	}
 	defer res.Body.Close()
 	if res.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(res.Body)
-		return nil, errors.Errorf("request failed with status %d: %s", res.StatusCode, string(body))
+		return nil, oops.Errorf("request failed with status %d: %s", res.StatusCode, string(body))
 	}
 
 	var lines []*domain.ContainerLog
 	for line, err := range decodeQuery(res.Body) {
 		if err != nil {
-			return nil, errors.Wrap(err, "decoding query response")
+			return nil, oops.Wrapf(err, "decoding query response")
 		}
 		lines = append(lines, line)
 	}
@@ -118,11 +118,11 @@ func (l *victoriaLogsStreamer) Get(ctx context.Context, app *domain.Application,
 func (l *victoriaLogsStreamer) Stream(ctx context.Context, app *domain.Application, begin time.Time) (<-chan *domain.ContainerLog, error) {
 	req, err := http.NewRequestWithContext(ctx, "GET", l.tailEndpoint(), nil)
 	if err != nil {
-		return nil, errors.Wrap(err, "creating http request")
+		return nil, oops.Wrapf(err, "creating http request")
 	}
 	logsQL, err := l.logsQL(app)
 	if err != nil {
-		return nil, errors.Wrap(err, "templating logsQL")
+		return nil, oops.Wrapf(err, "templating logsQL")
 	}
 
 	q := req.URL.Query()
@@ -130,11 +130,11 @@ func (l *victoriaLogsStreamer) Stream(ctx context.Context, app *domain.Applicati
 	req.URL.RawQuery = q.Encode()
 	res, err := l.client.Do(req)
 	if err != nil {
-		return nil, errors.Wrap(err, "executing http request")
+		return nil, oops.Wrapf(err, "executing http request")
 	}
 	if res.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(res.Body)
-		return nil, errors.Errorf("request failed with status %d: %s", res.StatusCode, string(body))
+		return nil, oops.Errorf("request failed with status %d: %s", res.StatusCode, string(body))
 	}
 
 	ch := make(chan *domain.ContainerLog, 100)

--- a/pkg/infrastructure/log/victorialogs/streamer.go
+++ b/pkg/infrastructure/log/victorialogs/streamer.go
@@ -35,7 +35,7 @@ type victoriaLogsStreamer struct {
 func NewVictoriaLogsStreamer(config Config) (domain.ContainerLogger, error) {
 	tmpl, err := template.New("logsQL templater").Parse(config.QueryTemplate)
 	if err != nil {
-		return nil, oops.Wrapf(err, "invalid logsQL template")
+		return nil, oops.Wrapf(err, "parsing logsQL template")
 	}
 
 	l := &victoriaLogsStreamer{

--- a/pkg/infrastructure/metrics/prometheus/client.go
+++ b/pkg/infrastructure/metrics/prometheus/client.go
@@ -8,10 +8,10 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/friendsofgo/errors"
 	"github.com/prometheus/client_golang/api"
 	promv1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
+	"github.com/samber/oops"
 
 	"github.com/traPtitech/neoshowcase/pkg/domain"
 	"github.com/traPtitech/neoshowcase/pkg/util/ds"
@@ -57,14 +57,14 @@ func NewPromClient(
 	for _, qc := range config.Queries {
 		tmpl, err := template.New(fmt.Sprintf("promQL templater %v", qc.Name)).Parse(qc.Template)
 		if err != nil {
-			return nil, errors.Wrap(err, fmt.Sprintf("invalid promQL template %v", qc.Name))
+			return nil, oops.With("query_name", qc.Name).Wrapf(err, "parsing promQL template")
 		}
 		templates[qc.Name] = tmpl
 	}
 
 	client, err := api.NewClient(api.Config{Address: config.Endpoint})
 	if err != nil {
-		return nil, errors.Wrap(err, "creating prom cleint")
+		return nil, oops.Wrapf(err, "creating prom cleint")
 	}
 	p := &promClient{
 		config:    config,
@@ -77,7 +77,7 @@ func NewPromClient(
 	for _, qc := range config.Queries {
 		_, err = p.promQL(qc.Name, &dummy)
 		if err != nil {
-			return nil, errors.Wrap(err, fmt.Sprintf("executing logQL template %v", qc.Name))
+			return nil, oops.With("query_name", qc.Name).Wrapf(err, "executing logQL template")
 		}
 	}
 
@@ -98,7 +98,7 @@ func templateStr(tmpl *template.Template, data any) (string, error) {
 func (p *promClient) promQL(name string, app *domain.Application) (string, error) {
 	tmpl, ok := p.templates[name]
 	if !ok {
-		return "", errors.Errorf("no such template: %v", name)
+		return "", oops.Errorf("no such template: %v", name)
 	}
 	return templateStr(tmpl, m{"App": app})
 }
@@ -110,7 +110,7 @@ func (p *promClient) AvailableNames() []string {
 func (p *promClient) Get(ctx context.Context, name string, app *domain.Application, before time.Time, limit time.Duration) ([]*domain.AppMetric, error) {
 	promQL, err := p.promQL(name, app)
 	if err != nil {
-		return nil, errors.Wrap(err, "templating promQL")
+		return nil, oops.Wrapf(err, "templating promQL")
 	}
 	v, _, err := p.client.QueryRange(ctx, promQL, promv1.Range{
 		Start: before.Add(-limit),
@@ -118,15 +118,15 @@ func (p *promClient) Get(ctx context.Context, name string, app *domain.Applicati
 		Step:  defaultStep,
 	})
 	if err != nil {
-		return nil, errors.Wrap(err, "executing query")
+		return nil, oops.Wrapf(err, "executing query")
 	}
 
 	if v.Type() != model.ValMatrix {
-		return nil, errors.Errorf("expected result type to be matrix, but got %v", v.Type().String())
+		return nil, oops.Errorf("expected result type to be matrix, but got %v", v.Type().String())
 	}
 	mv, ok := v.(model.Matrix)
 	if !ok {
-		return nil, errors.New("cast value failed")
+		return nil, oops.New("cast value failed")
 	}
 	return toSortedResponse(mv), nil
 }

--- a/pkg/infrastructure/registry/registry.go
+++ b/pkg/infrastructure/registry/registry.go
@@ -3,7 +3,6 @@ package registry
 import (
 	"context"
 
-	"github.com/friendsofgo/errors"
 	"github.com/regclient/regclient"
 	"github.com/regclient/regclient/config"
 	"github.com/regclient/regclient/scheme"
@@ -11,6 +10,7 @@ import (
 	"github.com/regclient/regclient/types/manifest"
 	"github.com/regclient/regclient/types/ref"
 	"github.com/samber/lo"
+	"github.com/samber/oops"
 	"github.com/traPtitech/neoshowcase/pkg/domain/builder"
 )
 
@@ -44,11 +44,11 @@ func NewClient(conf builder.ImageConfig) builder.RegistryClient {
 func (c *client) DeleteImage(ctx context.Context, image, tag string) error {
 	ref, err := ref.New(image + ":" + tag)
 	if err != nil {
-		return errors.Wrap(err, "parsing image reference")
+		return oops.Wrapf(err, "parsing image reference")
 	}
 	err = c.regclient.TagDelete(ctx, ref)
 	if err != nil {
-		return errors.Wrap(err, "deleting image")
+		return oops.Wrapf(err, "deleting image")
 	}
 	return nil
 }
@@ -56,7 +56,7 @@ func (c *client) DeleteImage(ctx context.Context, image, tag string) error {
 func (c *client) GetTags(ctx context.Context, image string) ([]string, error) {
 	ref, err := ref.New(image)
 	if err != nil {
-		return nil, errors.Wrap(err, "parsing image reference")
+		return nil, oops.Wrapf(err, "parsing image reference")
 	}
 
 	const limit = 100
@@ -69,7 +69,7 @@ func (c *client) GetTags(ctx context.Context, image string) ([]string, error) {
 		}
 		tagList, err := c.regclient.TagList(ctx, ref, opts...)
 		if err != nil {
-			return nil, errors.Wrap(err, "listing tags")
+			return nil, oops.Wrapf(err, "listing tags")
 		}
 		tags = append(tags, tagList.Tags...)
 		if len(tagList.Tags) < limit {
@@ -83,19 +83,19 @@ func (c *client) GetTags(ctx context.Context, image string) ([]string, error) {
 func (c *client) GetImageSize(ctx context.Context, image, tag string) (int64, error) {
 	ref, err := ref.New(image + ":" + tag)
 	if err != nil {
-		return 0, errors.Wrap(err, "parsing image reference")
+		return 0, oops.Wrapf(err, "parsing image reference")
 	}
 	m, err := c.regclient.ManifestGet(ctx, ref)
 	if err != nil {
-		return 0, errors.Wrap(err, "getting manifest")
+		return 0, oops.Wrapf(err, "getting manifest")
 	}
 	imager, ok := m.(manifest.Imager)
 	if !ok {
-		return 0, errors.Errorf("manifest %T is not an Imager", m)
+		return 0, oops.Errorf("manifest %T is not an Imager", m)
 	}
 	layers, err := imager.GetLayers()
 	if err != nil {
-		return 0, errors.Wrap(err, "getting image layers")
+		return 0, oops.Wrapf(err, "getting image layers")
 	}
 
 	size := lo.SumBy(layers, func(l descriptor.Descriptor) int64 { return l.Size })

--- a/pkg/infrastructure/repository/application.go
+++ b/pkg/infrastructure/repository/application.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/aarondl/sqlboiler/v4/boil"
 	"github.com/aarondl/sqlboiler/v4/queries/qm"
-	"github.com/friendsofgo/errors"
 	"github.com/samber/lo"
+	"github.com/samber/oops"
 
 	"github.com/traPtitech/neoshowcase/pkg/domain"
 	"github.com/traPtitech/neoshowcase/pkg/infrastructure/repository/models"
@@ -61,7 +61,7 @@ func (r *applicationRepository) GetApplications(ctx context.Context, cond domain
 
 	applications, err := models.Applications(mods...).All(ctx, r.db)
 	if err != nil {
-		return nil, errors.Wrap(err, "getting applications")
+		return nil, oops.Wrapf(err, "getting applications")
 	}
 	return ds.Map(applications, repoconvert.ToDomainApplication), nil
 }
@@ -83,7 +83,7 @@ func (r *applicationRepository) getApplication(ctx context.Context, id string, f
 		if isNoRowsErr(err) {
 			return nil, ErrNotFound
 		}
-		return nil, errors.Wrap(err, "getting application")
+		return nil, oops.Wrapf(err, "getting application")
 	}
 	return app, nil
 }
@@ -99,19 +99,19 @@ func (r *applicationRepository) GetApplication(ctx context.Context, id string) (
 func (r *applicationRepository) CreateApplication(ctx context.Context, app *domain.Application) error {
 	tx, err := r.db.BeginTx(ctx, nil)
 	if err != nil {
-		return errors.Wrap(err, "starting transaction")
+		return oops.Wrapf(err, "starting transaction")
 	}
 	defer tx.Rollback()
 
 	ma := repoconvert.FromDomainApplication(app)
 	if err = ma.Insert(ctx, tx, boil.Blacklist()); err != nil {
-		return errors.Wrap(err, "creating application")
+		return oops.Wrapf(err, "creating application")
 	}
 
 	mc := repoconvert.FromDomainApplicationConfig(app.ID, &app.Config)
 	err = mc.Insert(ctx, tx, boil.Blacklist())
 	if err != nil {
-		return errors.Wrap(err, "creating application config")
+		return oops.Wrapf(err, "creating application config")
 	}
 
 	err = r.setWebsites(ctx, tx, ma, app.Websites)
@@ -130,7 +130,7 @@ func (r *applicationRepository) CreateApplication(ctx context.Context, app *doma
 	}
 
 	if err = tx.Commit(); err != nil {
-		return errors.Wrap(err, "committing transaction")
+		return oops.Wrapf(err, "committing transaction")
 	}
 
 	return nil
@@ -139,7 +139,7 @@ func (r *applicationRepository) CreateApplication(ctx context.Context, app *doma
 func (r *applicationRepository) UpdateApplication(ctx context.Context, id string, args *domain.UpdateApplicationArgs) error {
 	tx, err := r.db.BeginTx(ctx, nil)
 	if err != nil {
-		return errors.Wrap(err, "starting transaction")
+		return oops.Wrapf(err, "starting transaction")
 	}
 	defer tx.Rollback()
 
@@ -191,7 +191,7 @@ func (r *applicationRepository) UpdateApplication(ctx context.Context, id string
 	if len(cols) > 0 {
 		_, err = app.Update(ctx, tx, boil.Whitelist(cols...))
 		if err != nil {
-			return errors.Wrap(err, "updating application")
+			return oops.Wrapf(err, "updating application")
 		}
 	}
 
@@ -199,7 +199,7 @@ func (r *applicationRepository) UpdateApplication(ctx context.Context, id string
 		mac := repoconvert.FromDomainApplicationConfig(app.ID, &args.Config.V)
 		err = mac.Upsert(ctx, tx, boil.Blacklist(), boil.Blacklist())
 		if err != nil {
-			return errors.Wrap(err, "updating config")
+			return oops.Wrapf(err, "updating config")
 		}
 	}
 	if args.Websites.Valid {
@@ -223,7 +223,7 @@ func (r *applicationRepository) UpdateApplication(ctx context.Context, id string
 
 	err = tx.Commit()
 	if err != nil {
-		return errors.Wrap(err, "committing transaction")
+		return oops.Wrapf(err, "committing transaction")
 	}
 
 	return err
@@ -242,7 +242,7 @@ func (r *applicationRepository) BulkUpdateState(ctx context.Context, states []*d
 			models.ApplicationColumns.ContainerMessage,
 		))
 		if err != nil {
-			return errors.Wrap(err, "updating container state")
+			return oops.Wrapf(err, "updating container state")
 		}
 	}
 	return nil
@@ -255,23 +255,23 @@ func (r *applicationRepository) DeleteApplication(ctx context.Context, id string
 	}
 	err = app.SetUsers(ctx, r.db, false)
 	if err != nil {
-		return errors.Wrap(err, "deleting application owners")
+		return oops.Wrapf(err, "deleting application owners")
 	}
 	_, err = app.R.PortPublications.DeleteAll(ctx, r.db)
 	if err != nil {
-		return errors.Wrap(err, "deleting port publications")
+		return oops.Wrapf(err, "deleting port publications")
 	}
 	_, err = app.R.Websites.DeleteAll(ctx, r.db)
 	if err != nil {
-		return errors.Wrap(err, "deleting websites")
+		return oops.Wrapf(err, "deleting websites")
 	}
 	_, err = app.R.ApplicationConfig.Delete(ctx, r.db)
 	if err != nil {
-		return errors.Wrap(err, "deleting application config")
+		return oops.Wrapf(err, "deleting application config")
 	}
 	_, err = app.Delete(ctx, r.db)
 	if err != nil {
-		return errors.Wrap(err, "deleting application")
+		return oops.Wrapf(err, "deleting application")
 	}
 	return nil
 }
@@ -280,14 +280,14 @@ func (r *applicationRepository) setWebsites(ctx context.Context, ex boil.Context
 	if app.R != nil && app.R.Websites != nil {
 		_, err := app.R.Websites.DeleteAll(ctx, ex)
 		if err != nil {
-			return errors.Wrap(err, "deleting existing app websites")
+			return oops.Wrapf(err, "deleting existing app websites")
 		}
 	}
 	for _, w := range websites {
 		mw := repoconvert.FromDomainWebsite(app.ID, w)
 		err := mw.Insert(ctx, ex, boil.Blacklist())
 		if err != nil {
-			return errors.Wrap(err, "inserting website")
+			return oops.Wrapf(err, "inserting website")
 		}
 	}
 	return nil
@@ -297,14 +297,14 @@ func (r *applicationRepository) setPortPublications(ctx context.Context, ex boil
 	if app.R != nil && app.R.PortPublications != nil {
 		_, err := app.R.PortPublications.DeleteAll(ctx, ex)
 		if err != nil {
-			return errors.Wrap(err, "deleting existing port publications")
+			return oops.Wrapf(err, "deleting existing port publications")
 		}
 	}
 	for _, p := range ports {
 		mp := repoconvert.FromDomainPortPublication(app.ID, p)
 		err := mp.Insert(ctx, ex, boil.Blacklist())
 		if err != nil {
-			return errors.Wrap(err, "inserting port publication")
+			return oops.Wrapf(err, "inserting port publication")
 		}
 	}
 	return nil
@@ -314,14 +314,14 @@ func (r *applicationRepository) setOwners(ctx context.Context, ex boil.ContextEx
 	ownerIDs = lo.Uniq(ownerIDs)
 	users, err := models.Users(models.UserWhere.ID.IN(ownerIDs)).All(ctx, ex)
 	if err != nil {
-		return errors.Wrap(err, "getting owners")
+		return oops.Wrapf(err, "getting owners")
 	}
 	if len(users) < len(ownerIDs) {
 		return ErrNotFound
 	}
 	err = app.SetUsers(ctx, ex, false, users...)
 	if err != nil {
-		return errors.Wrap(err, "adding owners")
+		return oops.Wrapf(err, "adding owners")
 	}
 	return nil
 }

--- a/pkg/infrastructure/repository/artifact.go
+++ b/pkg/infrastructure/repository/artifact.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/aarondl/sqlboiler/v4/boil"
 	"github.com/aarondl/sqlboiler/v4/queries/qm"
-	"github.com/friendsofgo/errors"
+	"github.com/samber/oops"
 
 	"github.com/traPtitech/neoshowcase/pkg/domain"
 	"github.com/traPtitech/neoshowcase/pkg/infrastructure/repository/models"
@@ -52,7 +52,7 @@ func (r *artifactRepository) buildMods(cond domain.GetArtifactCondition) []qm.Qu
 func (r *artifactRepository) GetArtifact(ctx context.Context, id string) (*domain.Artifact, error) {
 	artifact, err := models.Artifacts(models.ArtifactWhere.ID.EQ(id)).One(ctx, r.db)
 	if err != nil {
-		return nil, errors.Wrap(err, "getting artifact")
+		return nil, oops.Wrapf(err, "getting artifact")
 	}
 	return repoconvert.ToDomainArtifact(artifact), nil
 }
@@ -60,7 +60,7 @@ func (r *artifactRepository) GetArtifact(ctx context.Context, id string) (*domai
 func (r *artifactRepository) GetArtifacts(ctx context.Context, cond domain.GetArtifactCondition) ([]*domain.Artifact, error) {
 	artifacts, err := models.Artifacts(r.buildMods(cond)...).All(ctx, r.db)
 	if err != nil {
-		return nil, errors.Wrap(err, "getting artifacts")
+		return nil, oops.Wrapf(err, "getting artifacts")
 	}
 	return ds.Map(artifacts, repoconvert.ToDomainArtifact), nil
 }
@@ -68,7 +68,7 @@ func (r *artifactRepository) GetArtifacts(ctx context.Context, cond domain.GetAr
 func (r *artifactRepository) CreateArtifact(ctx context.Context, artifact *domain.Artifact) error {
 	ma := repoconvert.FromDomainArtifact(artifact)
 	if err := ma.Insert(ctx, r.db, boil.Blacklist()); err != nil {
-		return errors.Wrap(err, "inserting artifact")
+		return oops.Wrapf(err, "inserting artifact")
 	}
 	return nil
 }
@@ -76,7 +76,7 @@ func (r *artifactRepository) CreateArtifact(ctx context.Context, artifact *domai
 func (r *artifactRepository) UpdateArtifact(ctx context.Context, id string, args domain.UpdateArtifactArgs) error {
 	artifact, err := models.Artifacts(models.ArtifactWhere.ID.EQ(id)).One(ctx, r.db)
 	if err != nil {
-		return errors.Wrap(err, "getting artifact")
+		return oops.Wrapf(err, "getting artifact")
 	}
 
 	var cols []string
@@ -88,7 +88,7 @@ func (r *artifactRepository) UpdateArtifact(ctx context.Context, id string, args
 	if len(cols) > 0 {
 		_, err = artifact.Update(ctx, r.db, boil.Whitelist(cols...))
 		if err != nil {
-			return errors.Wrap(err, "updating artifact")
+			return oops.Wrapf(err, "updating artifact")
 		}
 	}
 
@@ -98,11 +98,11 @@ func (r *artifactRepository) UpdateArtifact(ctx context.Context, id string, args
 func (r *artifactRepository) HardDeleteArtifacts(ctx context.Context, cond domain.GetArtifactCondition) error {
 	artifacts, err := models.Artifacts(r.buildMods(cond)...).All(ctx, r.db)
 	if err != nil {
-		return errors.Wrap(err, "getting artifacts")
+		return oops.Wrapf(err, "getting artifacts")
 	}
 	_, err = artifacts.DeleteAll(ctx, r.db)
 	if err != nil {
-		return errors.Wrap(err, "deleting artifacts")
+		return oops.Wrapf(err, "deleting artifacts")
 	}
 	return nil
 }

--- a/pkg/infrastructure/repository/build.go
+++ b/pkg/infrastructure/repository/build.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/aarondl/sqlboiler/v4/boil"
 	"github.com/aarondl/sqlboiler/v4/queries/qm"
-	"github.com/friendsofgo/errors"
+	"github.com/samber/oops"
 
 	"github.com/traPtitech/neoshowcase/pkg/domain"
 	"github.com/traPtitech/neoshowcase/pkg/infrastructure/repository/models"
@@ -73,7 +73,7 @@ func (r *buildRepository) GetBuilds(ctx context.Context, cond domain.GetBuildCon
 	mods = append(mods, r.buildMods(cond)...)
 	builds, err := models.Builds(mods...).All(ctx, r.db)
 	if err != nil {
-		return nil, errors.Wrap(err, "getting builds")
+		return nil, oops.Wrapf(err, "getting builds")
 	}
 	return ds.Map(builds, repoconvert.ToDomainBuild), nil
 }
@@ -95,7 +95,7 @@ FROM builds b1
 WHERE b2.application_id IS NULL AND b1.application_id IN (`+inClause+`)`),
 	).All(ctx, r.db)
 	if err != nil {
-		return nil, errors.Wrap(err, "listing latest builds")
+		return nil, oops.Wrapf(err, "listing latest builds")
 	}
 	return ds.Map(builds, repoconvert.ToDomainBuild), nil
 }
@@ -110,7 +110,7 @@ func (r *buildRepository) GetBuild(ctx context.Context, buildID string) (*domain
 		if isNoRowsErr(err) {
 			return nil, ErrNotFound
 		}
-		return nil, errors.Wrap(err, "finding build")
+		return nil, oops.Wrapf(err, "finding build")
 	}
 	return repoconvert.ToDomainBuild(build), nil
 }
@@ -119,7 +119,7 @@ func (r *buildRepository) CreateBuild(ctx context.Context, build *domain.Build) 
 	mb := repoconvert.FromDomainBuild(build)
 	err := mb.Insert(ctx, r.db, boil.Blacklist())
 	if err != nil {
-		return errors.Wrap(err, "inserting build")
+		return oops.Wrapf(err, "inserting build")
 	}
 	return nil
 }
@@ -144,7 +144,7 @@ func (r *buildRepository) UpdateBuild(ctx context.Context, cond domain.GetBuildC
 
 	n, err := models.Builds(r.buildMods(cond)...).UpdateAll(ctx, r.db, cols)
 	if err != nil {
-		return 0, errors.Wrap(err, "updating build")
+		return 0, oops.Wrapf(err, "updating build")
 	}
 	return n, nil
 }
@@ -157,7 +157,7 @@ func (r *buildRepository) MarkCommitAsRetriable(ctx context.Context, application
 		models.BuildColumns.Retriable: true,
 	})
 	if err != nil {
-		return errors.Wrap(err, "marking commit as retriable")
+		return oops.Wrapf(err, "marking commit as retriable")
 	}
 	return nil
 }
@@ -165,11 +165,11 @@ func (r *buildRepository) MarkCommitAsRetriable(ctx context.Context, application
 func (r *buildRepository) DeleteBuilds(ctx context.Context, cond domain.GetBuildCondition) error {
 	builds, err := models.Builds(r.buildMods(cond)...).All(ctx, r.db)
 	if err != nil {
-		return errors.Wrap(err, "getting builds")
+		return oops.Wrapf(err, "getting builds")
 	}
 	_, err = builds.DeleteAll(ctx, r.db)
 	if err != nil {
-		return errors.Wrap(err, "deleting builds")
+		return oops.Wrapf(err, "deleting builds")
 	}
 	return nil
 }

--- a/pkg/infrastructure/repository/environment.go
+++ b/pkg/infrastructure/repository/environment.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/aarondl/sqlboiler/v4/boil"
 	"github.com/aarondl/sqlboiler/v4/queries/qm"
-	"github.com/friendsofgo/errors"
+	"github.com/samber/oops"
 
 	"github.com/traPtitech/neoshowcase/pkg/domain"
 	"github.com/traPtitech/neoshowcase/pkg/infrastructure/repository/models"
@@ -48,7 +48,7 @@ func (r *environmentRepository) SetEnv(ctx context.Context, env *domain.Environm
 	// NOTE: sqlboiler does not recognize multiple column unique keys: https://github.com/aarondl/sqlboiler/issues/328
 	tx, err := r.db.BeginTx(ctx, nil)
 	if err != nil {
-		return errors.Wrap(err, "starting transaction")
+		return oops.Wrapf(err, "starting transaction")
 	}
 	defer tx.Rollback()
 
@@ -58,7 +58,7 @@ func (r *environmentRepository) SetEnv(ctx context.Context, env *domain.Environm
 		qm.For("UPDATE"),
 	).One(ctx, tx)
 	if err != nil {
-		return errors.Wrap(err, "getting application")
+		return oops.Wrapf(err, "getting application")
 	}
 
 	exists, err := models.Environments(
@@ -66,7 +66,7 @@ func (r *environmentRepository) SetEnv(ctx context.Context, env *domain.Environm
 		models.EnvironmentWhere.Key.EQ(env.Key),
 	).Exists(ctx, tx)
 	if err != nil && !isNoRowsErr(err) {
-		return errors.Wrap(err, "getting environment")
+		return oops.Wrapf(err, "getting environment")
 	}
 
 	me := repoconvert.FromDomainEnvironment(env)
@@ -77,12 +77,12 @@ func (r *environmentRepository) SetEnv(ctx context.Context, env *domain.Environm
 		err = me.Insert(ctx, tx, boil.Blacklist())
 	}
 	if err != nil {
-		return errors.Wrap(err, "upserting environment")
+		return oops.Wrapf(err, "upserting environment")
 	}
 
 	err = tx.Commit()
 	if err != nil {
-		return errors.Wrap(err, "committing")
+		return oops.Wrapf(err, "committing")
 	}
 
 	return nil
@@ -91,11 +91,11 @@ func (r *environmentRepository) SetEnv(ctx context.Context, env *domain.Environm
 func (r *environmentRepository) DeleteEnv(ctx context.Context, cond domain.GetEnvCondition) error {
 	envs, err := models.Environments(r.buildMods(cond)...).All(ctx, r.db)
 	if err != nil {
-		return errors.Wrap(err, "getting env")
+		return oops.Wrapf(err, "getting env")
 	}
 	_, err = envs.DeleteAll(ctx, r.db)
 	if err != nil {
-		return errors.Wrap(err, "deleting env")
+		return oops.Wrapf(err, "deleting env")
 	}
 	return nil
 }

--- a/pkg/infrastructure/repository/error.go
+++ b/pkg/infrastructure/repository/error.go
@@ -3,12 +3,10 @@ package repository
 import (
 	"database/sql"
 	"errors"
-
-	"github.com/samber/oops"
 )
 
 var (
-	ErrNotFound = oops.New("not found")
+	ErrNotFound = errors.New("not found")
 )
 
 func isNoRowsErr(err error) bool {

--- a/pkg/infrastructure/repository/error.go
+++ b/pkg/infrastructure/repository/error.go
@@ -2,12 +2,13 @@ package repository
 
 import (
 	"database/sql"
+	"errors"
 
-	"github.com/friendsofgo/errors"
+	"github.com/samber/oops"
 )
 
 var (
-	ErrNotFound = errors.New("not found")
+	ErrNotFound = oops.New("not found")
 )
 
 func isNoRowsErr(err error) bool {

--- a/pkg/infrastructure/repository/git_repository.go
+++ b/pkg/infrastructure/repository/git_repository.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/aarondl/sqlboiler/v4/boil"
 	"github.com/aarondl/sqlboiler/v4/queries/qm"
-	"github.com/friendsofgo/errors"
 	"github.com/samber/lo"
+	"github.com/samber/oops"
 
 	"github.com/traPtitech/neoshowcase/pkg/domain"
 	"github.com/traPtitech/neoshowcase/pkg/infrastructure/repository/models"
@@ -55,7 +55,7 @@ func (r *gitRepositoryRepository) GetRepositories(ctx context.Context, cond doma
 
 	modelRepos, err := models.Repositories(mods...).All(ctx, r.db)
 	if err != nil {
-		return nil, errors.Wrap(err, "getting repositories")
+		return nil, oops.Wrapf(err, "getting repositories")
 	}
 
 	repos := ds.Map(modelRepos, repoconvert.ToDomainRepository)
@@ -97,7 +97,7 @@ func (r *gitRepositoryRepository) GetRepository(ctx context.Context, id string) 
 		if isNoRowsErr(err) {
 			return nil, ErrNotFound
 		}
-		return nil, errors.Wrap(err, "getting repository")
+		return nil, oops.Wrapf(err, "getting repository")
 	}
 	return repoconvert.ToDomainRepository(repo), nil
 }
@@ -105,21 +105,21 @@ func (r *gitRepositoryRepository) GetRepository(ctx context.Context, id string) 
 func (r *gitRepositoryRepository) CreateRepository(ctx context.Context, repo *domain.Repository) error {
 	tx, err := r.db.BeginTx(ctx, nil)
 	if err != nil {
-		return errors.Wrap(err, "starting transaction")
+		return oops.Wrapf(err, "starting transaction")
 	}
 	defer tx.Rollback()
 
 	mr := repoconvert.FromDomainRepository(repo)
 	err = mr.Insert(ctx, tx, boil.Blacklist())
 	if err != nil {
-		return errors.Wrap(err, "inserting repository")
+		return oops.Wrapf(err, "inserting repository")
 	}
 
 	if repo.Auth.Valid {
 		mra := repoconvert.FromDomainRepositoryAuth(repo.ID, &repo.Auth.V)
 		err = mra.Insert(ctx, tx, boil.Blacklist())
 		if err != nil {
-			return errors.Wrap(err, "inserting repository auth")
+			return oops.Wrapf(err, "inserting repository auth")
 		}
 	}
 
@@ -130,7 +130,7 @@ func (r *gitRepositoryRepository) CreateRepository(ctx context.Context, repo *do
 
 	err = tx.Commit()
 	if err != nil {
-		return errors.Wrap(err, "committing transaction")
+		return oops.Wrapf(err, "committing transaction")
 	}
 
 	return nil
@@ -139,13 +139,13 @@ func (r *gitRepositoryRepository) CreateRepository(ctx context.Context, repo *do
 func (r *gitRepositoryRepository) UpdateRepository(ctx context.Context, id string, args *domain.UpdateRepositoryArgs) error {
 	tx, err := r.db.BeginTx(ctx, nil)
 	if err != nil {
-		return errors.Wrap(err, "beginning transaction")
+		return oops.Wrapf(err, "beginning transaction")
 	}
 	defer tx.Rollback()
 
 	repo, err := r.getRepository(ctx, tx, id)
 	if err != nil {
-		return errors.Wrap(err, "getting repository")
+		return oops.Wrapf(err, "getting repository")
 	}
 	var cols []string
 
@@ -161,7 +161,7 @@ func (r *gitRepositoryRepository) UpdateRepository(ctx context.Context, id strin
 	if len(cols) > 0 {
 		_, err = repo.Update(ctx, tx, boil.Whitelist(cols...))
 		if err != nil {
-			return errors.Wrap(err, "updating repository")
+			return oops.Wrapf(err, "updating repository")
 		}
 	}
 
@@ -169,14 +169,14 @@ func (r *gitRepositoryRepository) UpdateRepository(ctx context.Context, id strin
 		if repo.R != nil && repo.R.RepositoryAuth != nil {
 			_, err = repo.R.RepositoryAuth.Delete(ctx, tx)
 			if err != nil {
-				return errors.Wrap(err, "deleting existing repository auth")
+				return oops.Wrapf(err, "deleting existing repository auth")
 			}
 		}
 		if args.Auth.V.Valid {
 			mra := repoconvert.FromDomainRepositoryAuth(repo.ID, &args.Auth.V.V)
 			err = repo.SetRepositoryAuth(ctx, tx, true, mra)
 			if err != nil {
-				return errors.Wrap(err, "setting repository auth")
+				return oops.Wrapf(err, "setting repository auth")
 			}
 		}
 	}
@@ -190,7 +190,7 @@ func (r *gitRepositoryRepository) UpdateRepository(ctx context.Context, id strin
 
 	err = tx.Commit()
 	if err != nil {
-		return errors.Wrap(err, "committing transaction")
+		return oops.Wrapf(err, "committing transaction")
 	}
 	return nil
 }
@@ -199,14 +199,14 @@ func (r *gitRepositoryRepository) setOwners(ctx context.Context, ex boil.Context
 	ownerIDs = lo.Uniq(ownerIDs)
 	users, err := models.Users(models.UserWhere.ID.IN(ownerIDs)).All(ctx, ex)
 	if err != nil {
-		return errors.Wrap(err, "getting users")
+		return oops.Wrapf(err, "getting users")
 	}
 	if len(users) < len(ownerIDs) {
 		return ErrNotFound
 	}
 	err = repo.SetUsers(ctx, ex, false, users...)
 	if err != nil {
-		return errors.Wrap(err, "setting repository owners")
+		return oops.Wrapf(err, "setting repository owners")
 	}
 	return nil
 }
@@ -218,17 +218,17 @@ func (r *gitRepositoryRepository) DeleteRepository(ctx context.Context, id strin
 	}
 	err = repo.SetUsers(ctx, r.db, false)
 	if err != nil {
-		return errors.Wrap(err, "deleting repository owners")
+		return oops.Wrapf(err, "deleting repository owners")
 	}
 	if repo.R.RepositoryAuth != nil {
 		_, err = repo.R.RepositoryAuth.Delete(ctx, r.db)
 		if err != nil {
-			return errors.Wrap(err, "deleting repository auth")
+			return oops.Wrapf(err, "deleting repository auth")
 		}
 	}
 	_, err = repo.Delete(ctx, r.db)
 	if err != nil {
-		return errors.Wrap(err, "deleting repository")
+		return oops.Wrapf(err, "deleting repository")
 	}
 	return nil
 }

--- a/pkg/infrastructure/repository/repository_commit.go
+++ b/pkg/infrastructure/repository/repository_commit.go
@@ -5,7 +5,7 @@ import (
 	"database/sql"
 
 	"github.com/aarondl/sqlboiler/v4/boil"
-	"github.com/friendsofgo/errors"
+	"github.com/samber/oops"
 
 	"github.com/traPtitech/neoshowcase/pkg/domain"
 	"github.com/traPtitech/neoshowcase/pkg/infrastructure/repository/models"
@@ -30,7 +30,7 @@ func (r *repositoryCommitRepository) GetCommits(ctx context.Context, hashes []st
 		models.RepositoryCommitWhere.Hash.IN(hashes),
 	).All(ctx, r.db)
 	if err != nil {
-		return nil, errors.Wrap(err, "querying repository commits")
+		return nil, oops.Wrapf(err, "querying repository commits")
 	}
 
 	return ds.Map(commits, repoconvert.ToDomainRepositoryCommit), nil
@@ -40,7 +40,7 @@ func (r *repositoryCommitRepository) RecordCommit(ctx context.Context, commit *d
 	m := repoconvert.FromDomainRepositoryCommit(commit)
 	err := m.Insert(ctx, r.db, boil.Blacklist())
 	if err != nil {
-		return errors.Wrap(err, "inserting repository commit")
+		return oops.Wrapf(err, "inserting repository commit")
 	}
 	return nil
 }

--- a/pkg/infrastructure/repository/runtime_image.go
+++ b/pkg/infrastructure/repository/runtime_image.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/aarondl/sqlboiler/v4/boil"
 	"github.com/aarondl/sqlboiler/v4/queries/qm"
-	"github.com/friendsofgo/errors"
+	"github.com/samber/oops"
 
 	"github.com/traPtitech/neoshowcase/pkg/domain"
 	"github.com/traPtitech/neoshowcase/pkg/infrastructure/repository/models"
@@ -28,7 +28,7 @@ func (r *runtimeImageRepository) CreateRuntimeImage(ctx context.Context, image *
 	ri := repoconvert.FromDomainRuntimeImage(image)
 	err := ri.Insert(ctx, r.db, boil.Infer())
 	if err != nil {
-		return errors.Wrap(err, "inserting runtime image")
+		return oops.Wrapf(err, "inserting runtime image")
 	}
 	return nil
 }
@@ -44,11 +44,11 @@ func (r *runtimeImageRepository) DeleteRuntimeImagesByAppID(ctx context.Context,
 		models.BuildWhere.ApplicationID.EQ(appID),
 	).All(ctx, r.db)
 	if err != nil {
-		return errors.Wrap(err, "getting runtime images")
+		return oops.Wrapf(err, "getting runtime images")
 	}
 	_, err = images.DeleteAll(ctx, r.db)
 	if err != nil {
-		return errors.Wrap(err, "deleting runtime images")
+		return oops.Wrapf(err, "deleting runtime images")
 	}
 	return nil
 }

--- a/pkg/infrastructure/repository/user.go
+++ b/pkg/infrastructure/repository/user.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/aarondl/sqlboiler/v4/boil"
 	"github.com/aarondl/sqlboiler/v4/queries/qm"
-	"github.com/friendsofgo/errors"
 	"github.com/samber/lo"
+	"github.com/samber/oops"
 
 	"github.com/traPtitech/neoshowcase/pkg/domain"
 	"github.com/traPtitech/neoshowcase/pkg/infrastructure/repository/models"
@@ -34,7 +34,7 @@ func (r *userRepository) GetUsers(ctx context.Context, cond domain.GetUserCondit
 
 	users, err := models.Users(mods...).All(ctx, r.db)
 	if err != nil {
-		return nil, errors.Wrap(err, "getting users")
+		return nil, oops.Wrapf(err, "getting users")
 	}
 	return ds.Map(users, repoconvert.ToDomainUser), nil
 }
@@ -42,7 +42,7 @@ func (r *userRepository) GetUsers(ctx context.Context, cond domain.GetUserCondit
 func (r *userRepository) EnsureUser(ctx context.Context, name string) (*domain.User, error) {
 	tx, err := r.db.BeginTx(ctx, nil)
 	if err != nil {
-		return nil, errors.Wrap(err, "beginning transaction")
+		return nil, oops.Wrapf(err, "beginning transaction")
 	}
 	defer tx.Rollback()
 
@@ -51,7 +51,7 @@ func (r *userRepository) EnsureUser(ctx context.Context, name string) (*domain.U
 		qm.For("UPDATE"),
 	).One(ctx, tx)
 	if err != nil && !isNoRowsErr(err) {
-		return nil, errors.Wrap(err, "getting user")
+		return nil, oops.Wrapf(err, "getting user")
 	}
 
 	if isNoRowsErr(err) {
@@ -59,13 +59,13 @@ func (r *userRepository) EnsureUser(ctx context.Context, name string) (*domain.U
 		mu = repoconvert.FromDomainUser(user)
 		err = mu.Insert(ctx, tx, boil.Blacklist())
 		if err != nil {
-			return nil, errors.Wrap(err, "inserting user")
+			return nil, oops.Wrapf(err, "inserting user")
 		}
 	}
 
 	err = tx.Commit()
 	if err != nil {
-		return nil, errors.Wrap(err, "committing")
+		return nil, oops.Wrapf(err, "committing")
 	}
 
 	return repoconvert.ToDomainUser(mu), nil
@@ -74,7 +74,7 @@ func (r *userRepository) EnsureUser(ctx context.Context, name string) (*domain.U
 func (r *userRepository) EnsureUsers(ctx context.Context, names []string) ([]*domain.User, error) {
 	tx, err := r.db.BeginTx(ctx, nil)
 	if err != nil {
-		return nil, errors.Wrap(err, "beginning transaction")
+		return nil, oops.Wrapf(err, "beginning transaction")
 	}
 	defer tx.Rollback()
 
@@ -83,7 +83,7 @@ func (r *userRepository) EnsureUsers(ctx context.Context, names []string) ([]*do
 		qm.For("UPDATE"),
 	).All(ctx, tx)
 	if err != nil {
-		return nil, errors.Wrap(err, "getting users")
+		return nil, oops.Wrapf(err, "getting users")
 	}
 
 	modelUsers := lo.SliceToMap(mus, func(mu *models.User) (string, *models.User) { return mu.Name, mu })
@@ -95,14 +95,14 @@ func (r *userRepository) EnsureUsers(ctx context.Context, names []string) ([]*do
 		mu := repoconvert.FromDomainUser(user)
 		err = mu.Insert(ctx, tx, boil.Blacklist())
 		if err != nil {
-			return nil, errors.Wrap(err, "inserting user")
+			return nil, oops.Wrapf(err, "inserting user")
 		}
 		modelUsers[name] = mu
 	}
 
 	err = tx.Commit()
 	if err != nil {
-		return nil, errors.Wrap(err, "committing")
+		return nil, oops.Wrapf(err, "committing")
 	}
 
 	return lo.MapToSlice(modelUsers, func(name string, mu *models.User) *domain.User {
@@ -119,7 +119,7 @@ func (r *userRepository) GetUserKeys(ctx context.Context, cond domain.GetUserKey
 
 	keys, err := models.UserKeys(mods...).All(ctx, r.db)
 	if err != nil {
-		return nil, errors.Wrap(err, "getting user keys")
+		return nil, oops.Wrapf(err, "getting user keys")
 	}
 	return ds.Map(keys, repoconvert.ToDomainUserKey), nil
 }
@@ -128,7 +128,7 @@ func (r *userRepository) CreateUserKey(ctx context.Context, key *domain.UserKey)
 	mk := repoconvert.FromDomainUserKey(key)
 	err := mk.Insert(ctx, r.db, boil.Blacklist())
 	if err != nil {
-		return errors.Wrap(err, "inserting user key")
+		return oops.Wrapf(err, "inserting user key")
 	}
 	return nil
 }
@@ -139,7 +139,7 @@ func (r *userRepository) DeleteUserKey(ctx context.Context, keyID string, userID
 		models.UserKeyWhere.UserID.EQ(userID),
 	).DeleteAll(ctx, r.db)
 	if err != nil {
-		return errors.Wrap(err, "deleting user key")
+		return oops.Wrapf(err, "deleting user key")
 	}
 	return nil
 }

--- a/pkg/infrastructure/repository/website.go
+++ b/pkg/infrastructure/repository/website.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"database/sql"
 
-	"github.com/friendsofgo/errors"
+	"github.com/samber/oops"
 
 	"github.com/traPtitech/neoshowcase/pkg/domain"
 	"github.com/traPtitech/neoshowcase/pkg/infrastructure/repository/models"
@@ -25,7 +25,7 @@ func NewWebsiteRepository(db *sql.DB) domain.WebsiteRepository {
 func (w *websiteRepository) GetWebsites(ctx context.Context) ([]*domain.Website, error) {
 	websites, err := models.Websites().All(ctx, w.db)
 	if err != nil {
-		return nil, errors.Wrap(err, "getting websites")
+		return nil, oops.Wrapf(err, "getting websites")
 	}
 	return ds.Map(websites, repoconvert.ToDomainWebsite), nil
 }

--- a/pkg/infrastructure/staticserver/caddy/server.go
+++ b/pkg/infrastructure/staticserver/caddy/server.go
@@ -8,8 +8,8 @@ import (
 	"net/http"
 	"path/filepath"
 
-	"github.com/friendsofgo/errors"
 	"github.com/samber/lo"
+	"github.com/samber/oops"
 
 	"github.com/traPtitech/neoshowcase/pkg/domain"
 	"github.com/traPtitech/neoshowcase/pkg/domain/web"
@@ -115,7 +115,7 @@ func (s *server) postConfig(b []byte) error {
 	defer res.Body.Close()
 	if res.StatusCode < 200 || 300 <= res.StatusCode {
 		resBody, _ := io.ReadAll(res.Body)
-		return errors.Errorf("expected 2xx, invalid status code %v: %v", res.StatusCode, string(resBody))
+		return oops.Errorf("expected 2xx, invalid status code %v: %v", res.StatusCode, string(resBody))
 	}
 	return nil
 }

--- a/pkg/infrastructure/storage/local.go
+++ b/pkg/infrastructure/storage/local.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/friendsofgo/errors"
+	"github.com/samber/oops"
 
 	"github.com/traPtitech/neoshowcase/pkg/domain"
 )
@@ -19,10 +19,10 @@ type LocalStorage struct {
 func NewLocalStorage(dir string) (*LocalStorage, error) {
 	fi, err := os.Stat(dir)
 	if err != nil {
-		return &LocalStorage{}, errors.Wrapf(err, "checking dir %s", dir)
+		return &LocalStorage{}, oops.With("dir", dir).Wrapf(err, "checking dir")
 	}
 	if !fi.IsDir() {
-		return &LocalStorage{}, errors.Errorf("dir %s is not a directory", dir)
+		return &LocalStorage{}, oops.Errorf("dir %s is not a directory", dir)
 	}
 
 	return &LocalStorage{localDir: dir}, nil

--- a/pkg/infrastructure/storage/s3.go
+++ b/pkg/infrastructure/storage/s3.go
@@ -9,7 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
-	"github.com/friendsofgo/errors"
+	"github.com/samber/oops"
 
 	"github.com/traPtitech/neoshowcase/pkg/domain"
 )
@@ -28,7 +28,7 @@ func NewS3Storage(bucket, accessKey, accessSecret, region, endpoint string) (*S3
 		config.WithRegion(region),
 	)
 	if err != nil {
-		return nil, errors.Wrap(err, "loading AWS config")
+		return nil, oops.Wrapf(err, "loading AWS config")
 	}
 
 	client := s3.NewFromConfig(cfg, func(o *s3.Options) {

--- a/pkg/usecase/apiserver/app_build_service.go
+++ b/pkg/usecase/apiserver/app_build_service.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/friendsofgo/errors"
+	"github.com/samber/oops"
 
 	"github.com/traPtitech/neoshowcase/pkg/domain"
 	"github.com/traPtitech/neoshowcase/pkg/infrastructure/grpc/pb"
@@ -41,7 +41,7 @@ func (s *Service) RetryCommitBuild(ctx context.Context, applicationID string, co
 	// NOTE: requires the app to be running for builds to register
 	err = s.controller.RegisterBuild(ctx, applicationID)
 	if err != nil {
-		return errors.Wrap(err, "requesting new build registration")
+		return oops.Wrapf(err, "requesting new build registration")
 	}
 	return nil
 }
@@ -54,7 +54,7 @@ func (s *Service) CancelBuild(ctx context.Context, buildID string) error {
 
 	err = s.controller.CancelBuild(ctx, buildID)
 	if err != nil {
-		return errors.Wrap(err, "requesting cancel build")
+		return oops.Wrapf(err, "requesting cancel build")
 	}
 	return nil
 }
@@ -83,14 +83,14 @@ func (s *Service) GetBuildLogStream(ctx context.Context, buildID string) (<-chan
 
 	addr, err := s.controller.DiscoverBuildLogInstance(ctx, buildID)
 	if err != nil {
-		return nil, errors.Wrap(err, "discovering build log instance")
+		return nil, oops.Wrapf(err, "discovering build log instance")
 	}
 	if addr.Address == nil {
 		return nil, newError(ErrorTypeBadRequest, "build log instance not found", nil)
 	}
 	ch, err := s.controller.StreamBuildLog(ctx, *addr.Address, buildID)
 	if err != nil {
-		return nil, errors.Wrap(err, "connecting to build log stream")
+		return nil, oops.Wrapf(err, "connecting to build log stream")
 	}
 	return ch, nil
 }

--- a/pkg/usecase/apiserver/app_config_service.go
+++ b/pkg/usecase/apiserver/app_config_service.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/friendsofgo/errors"
+	"github.com/samber/oops"
 
 	"github.com/traPtitech/neoshowcase/pkg/domain"
 	"github.com/traPtitech/neoshowcase/pkg/util/optional"
@@ -58,20 +58,20 @@ func (s *Service) StartApplication(ctx context.Context, id string) error {
 		UpdatedAt: optional.From(time.Now()),
 	})
 	if err != nil {
-		return errors.Wrap(err, "marking application as running")
+		return oops.Wrapf(err, "marking application as running")
 	}
 
 	app, err := s.appRepo.GetApplication(ctx, id)
 	if err != nil {
-		return errors.Wrap(err, "getting application")
+		return oops.Wrapf(err, "getting application")
 	}
 	err = s.controller.FetchRepository(ctx, app.RepositoryID)
 	if err != nil {
-		return errors.Wrap(err, "requesting repository fetch")
+		return oops.Wrapf(err, "requesting repository fetch")
 	}
 	err = s.controller.SyncDeployments(ctx)
 	if err != nil {
-		return errors.Wrap(err, "requesting sync deployment")
+		return oops.Wrapf(err, "requesting sync deployment")
 	}
 	return nil
 }
@@ -87,12 +87,12 @@ func (s *Service) StopApplication(ctx context.Context, id string) error {
 		UpdatedAt: optional.From(time.Now()),
 	})
 	if err != nil {
-		return errors.Wrap(err, "marking application as not running")
+		return oops.Wrapf(err, "marking application as not running")
 	}
 
 	err = s.controller.SyncDeployments(ctx)
 	if err != nil {
-		return errors.Wrap(err, "requesting sync deployment")
+		return oops.Wrapf(err, "requesting sync deployment")
 	}
 	return nil
 }

--- a/pkg/usecase/apiserver/app_info_service.go
+++ b/pkg/usecase/apiserver/app_info_service.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/friendsofgo/errors"
+	"github.com/samber/oops"
 
 	"github.com/traPtitech/neoshowcase/pkg/domain"
 )
@@ -59,18 +59,18 @@ func (s *Service) GetOutputStream(ctx context.Context, id string, begin time.Tim
 
 	ch, err := s.containerLogger.Stream(ctx, app, begin)
 	if err != nil {
-		return errors.Wrap(err, "connecting to stream")
+		return oops.Wrapf(err, "connecting to stream")
 	}
 
 	for {
 		select {
 		case d, ok := <-ch:
 			if !ok {
-				return errors.Wrap(err, "log stream closed")
+				return oops.Wrapf(err, "log stream closed")
 			}
 			err = send(d)
 			if err != nil {
-				return errors.Wrap(err, "sending log")
+				return oops.Wrapf(err, "sending log")
 			}
 		case <-ctx.Done():
 			return nil

--- a/pkg/usecase/apiserver/app_service.go
+++ b/pkg/usecase/apiserver/app_service.go
@@ -6,8 +6,8 @@ import (
 	"log/slog"
 	"strconv"
 
-	"github.com/friendsofgo/errors"
 	"github.com/samber/lo"
+	"github.com/samber/oops"
 
 	"github.com/traPtitech/neoshowcase/pkg/domain"
 	"github.com/traPtitech/neoshowcase/pkg/domain/web"
@@ -20,11 +20,11 @@ func (s *Service) validateApp(ctx context.Context, app *domain.Application) erro
 	// Validate app fields and conflict
 	existingApps, err := s.appRepo.GetApplications(ctx, domain.GetApplicationCondition{})
 	if err != nil {
-		return errors.Wrap(err, "getting existing applications")
+		return oops.Wrapf(err, "getting existing applications")
 	}
 	si, err := s.systemInfo.Get(ctx, struct{}{})
 	if err != nil {
-		return errors.Wrap(err, "getting system info")
+		return oops.Wrapf(err, "getting system info")
 	}
 	err = app.Validate(web.GetUser(ctx), existingApps, si.AvailableDomains, si.AvailablePorts)
 	if err != nil {
@@ -49,7 +49,7 @@ func (s *Service) validateApp(ctx context.Context, app *domain.Application) erro
 func (s *Service) CreateApplication(ctx context.Context, app *domain.Application) (*domain.Application, error) {
 	repo, err := s.gitRepo.GetRepository(ctx, app.RepositoryID)
 	if err != nil {
-		return nil, errors.Wrap(err, "getting repository metadata")
+		return nil, oops.Wrapf(err, "getting repository metadata")
 	}
 
 	for _, website := range app.Websites {
@@ -80,7 +80,7 @@ func (s *Service) CreateApplication(ctx context.Context, app *domain.Application
 	s.systemInfo.Purge()
 	err = s.controller.FetchRepository(ctx, app.RepositoryID)
 	if err != nil {
-		return nil, errors.Wrap(err, "requesting repository fetch")
+		return nil, oops.Wrapf(err, "requesting repository fetch")
 	}
 
 	return handleRepoError(s.appRepo.GetApplication(ctx, app.ID))
@@ -174,11 +174,11 @@ func (s *Service) GetApplications(ctx context.Context, scope GetAppScope) ([]*To
 		// No scope
 	case GetAppScopeRepository:
 		if !scope.RepositoryID.Valid {
-			return nil, errors.New("repository id not set")
+			return nil, oops.New("repository id not set")
 		}
 		cond.RepositoryID = scope.RepositoryID
 	default:
-		return nil, errors.New("unexpected scope type")
+		return nil, oops.New("unexpected scope type")
 	}
 
 	// Fetch apps
@@ -261,18 +261,18 @@ func (s *Service) UpdateApplication(ctx context.Context, id string, args *domain
 	// Update
 	err = s.appRepo.UpdateApplication(ctx, id, args)
 	if err != nil {
-		return errors.Wrap(err, "updating application")
+		return oops.Wrapf(err, "updating application")
 	}
 
 	// Sync
 	s.systemInfo.Purge()
 	err = s.controller.FetchRepository(ctx, app.RepositoryID)
 	if err != nil {
-		return errors.Wrap(err, "requesting fetch repository")
+		return oops.Wrapf(err, "requesting fetch repository")
 	}
 	err = s.controller.SyncDeployments(ctx)
 	if err != nil {
-		return errors.Wrap(err, "requesting sync deployments")
+		return oops.Wrapf(err, "requesting sync deployments")
 	}
 
 	return nil
@@ -282,7 +282,7 @@ func (s *Service) deleteApplicationDatabase(ctx context.Context, app *domain.App
 	if app.Config.BuildConfig.MariaDB() {
 		dbKey, ok := lo.Find(envs, func(e *domain.Environment) bool { return e.Key == domain.EnvMariaDBDatabaseKey })
 		if !ok {
-			return errors.New("mariadb name not found in env key")
+			return oops.New("mariadb name not found in env key")
 		}
 		err := s.mariaDBManager.Delete(ctx, domain.DeleteArgs{Database: dbKey.Value})
 		if err != nil {
@@ -293,7 +293,7 @@ func (s *Service) deleteApplicationDatabase(ctx context.Context, app *domain.App
 	if app.Config.BuildConfig.MongoDB() {
 		dbKey, ok := lo.Find(envs, func(e *domain.Environment) bool { return e.Key == domain.EnvMongoDBDatabaseKey })
 		if !ok {
-			return errors.New("mongodb name not found in env key")
+			return oops.New("mongodb name not found in env key")
 		}
 		err := s.mongoDBManager.Delete(ctx, domain.DeleteArgs{Database: dbKey.Value})
 		if err != nil {

--- a/pkg/usecase/apiserver/app_service.go
+++ b/pkg/usecase/apiserver/app_service.go
@@ -174,7 +174,7 @@ func (s *Service) GetApplications(ctx context.Context, scope GetAppScope) ([]*To
 		// No scope
 	case GetAppScopeRepository:
 		if !scope.RepositoryID.Valid {
-			return nil, oops.New("repository id not set")
+			return nil, newError(ErrorTypeBadRequest, "repository id is required", nil)
 		}
 		cond.RepositoryID = scope.RepositoryID
 	default:

--- a/pkg/usecase/apiserver/errors.go
+++ b/pkg/usecase/apiserver/errors.go
@@ -1,34 +1,48 @@
 package apiserver
 
 import (
-	"github.com/friendsofgo/errors"
+	"github.com/samber/oops"
 )
 
-type ErrorType int
+// ErrorType is the business meaning attached to an error at the usecase layer.
+// It travels with the error as the oops error code, and the transport boundary
+// maps it to a Connect code. An error without one is Internal by definition.
+type ErrorType string
 
 const (
-	ErrorTypeBadRequest ErrorType = iota
-	ErrorTypeNotFound
-	ErrorTypeAlreadyExists
-	ErrorTypeForbidden
+	ErrorTypeBadRequest    ErrorType = "bad_request"
+	ErrorTypeNotFound      ErrorType = "not_found"
+	ErrorTypeAlreadyExists ErrorType = "already_exists"
+	ErrorTypeForbidden     ErrorType = "forbidden"
 )
 
-type customError struct {
-	error
-	typ ErrorType
-}
-
+// newError tags err with a business meaning and with the message the client is
+// allowed to see.
+//
+// message is attached as the oops "public" message: it is the only thing the
+// boundary returns to the client. The wrap chain underneath stays internal and
+// reaches the single boundary log instead.
 func newError(typ ErrorType, message string, err error) error {
+	b := oops.Code(string(typ)).Public(message)
 	if err == nil {
-		return customError{error: errors.New(message), typ: typ}
+		return b.New(message)
 	}
-	return customError{error: errors.Wrap(err, message), typ: typ}
+	return b.Wrapf(err, "%s", message)
 }
 
-func DecomposeError(err error) (underlying error, typ ErrorType, ok bool) { //nolint:staticcheck
-	var cErr customError
-	if errors.As(err, &cErr) {
-		return cErr.error, cErr.typ, true
+// DecomposeError reports the business meaning a usecase attached to err, along
+// with the client-facing message.
+//
+// It searches the whole error chain, so an error stays classified even after an
+// outer layer wraps it with more context.
+func DecomposeError(err error) (publicMessage string, typ ErrorType, ok bool) {
+	oopsErr, found := oops.AsOops(err)
+	if !found {
+		return "", "", false
 	}
-	return
+	code, isString := oopsErr.Code().(string)
+	if !isString || code == "" {
+		return "", "", false
+	}
+	return oopsErr.Public(), ErrorType(code), true
 }

--- a/pkg/usecase/apiserver/errors.go
+++ b/pkg/usecase/apiserver/errors.go
@@ -33,16 +33,21 @@ func newError(typ ErrorType, message string, err error) error {
 // DecomposeError reports the business meaning a usecase attached to err, along
 // with the client-facing message.
 //
-// It searches the whole error chain, so an error stays classified even after an
-// outer layer wraps it with more context.
+// It reads the classification from the outermost layer that carries one, not from
+// oopsErr.Code()/Public() directly: those resolve to the *deepest* value in the
+// chain, so a classified error wrapped as the cause of another would otherwise
+// hijack the tag and public message. Walking Layers() (outermost to innermost)
+// keeps the classification the top-most newError set.
 func DecomposeError(err error) (publicMessage string, typ ErrorType, ok bool) {
 	oopsErr, found := oops.AsOops(err)
 	if !found {
 		return "", "", false
 	}
-	code, isString := oopsErr.Code().(string)
-	if !isString || code == "" {
-		return "", "", false
+	for _, layer := range oopsErr.Layers() {
+		code, isString := layer.Code.(string)
+		if isString && code != "" {
+			return layer.Public, ErrorType(code), true
+		}
 	}
-	return oopsErr.Public(), ErrorType(code), true
+	return "", "", false
 }

--- a/pkg/usecase/apiserver/repository_service.go
+++ b/pkg/usecase/apiserver/repository_service.go
@@ -48,7 +48,7 @@ func (s *Service) convertRepositoryAuth(a CreateRepositoryAuth) (domain.Reposito
 			SSHKey: pem,
 		}, nil
 	default:
-		return domain.RepositoryAuth{}, oops.Errorf("unknown auth method: %v", a.Method)
+		return domain.RepositoryAuth{}, newError(ErrorTypeBadRequest, fmt.Sprintf("unknown auth method: %v", a.Method), nil)
 	}
 }
 

--- a/pkg/usecase/apiserver/repository_service.go
+++ b/pkg/usecase/apiserver/repository_service.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/friendsofgo/errors"
 	"github.com/samber/lo"
+	"github.com/samber/oops"
 
 	"github.com/traPtitech/neoshowcase/pkg/domain"
 	"github.com/traPtitech/neoshowcase/pkg/domain/web"
@@ -48,7 +48,7 @@ func (s *Service) convertRepositoryAuth(a CreateRepositoryAuth) (domain.Reposito
 			SSHKey: pem,
 		}, nil
 	default:
-		return domain.RepositoryAuth{}, errors.Errorf("unknown auth method: %v", a.Method)
+		return domain.RepositoryAuth{}, oops.Errorf("unknown auth method: %v", a.Method)
 	}
 }
 
@@ -168,7 +168,7 @@ func (s *Service) UpdateRepository(ctx context.Context, id string, args *UpdateR
 func (s *Service) RefreshRepository(ctx context.Context, id string) error {
 	err := s.controller.FetchRepository(ctx, id)
 	if err != nil {
-		return errors.Wrap(err, "requesting controller")
+		return oops.Wrapf(err, "requesting controller")
 	}
 	return nil
 }
@@ -181,7 +181,7 @@ func (s *Service) DeleteRepository(ctx context.Context, id string) error {
 
 	apps, err := s.appRepo.GetApplications(ctx, domain.GetApplicationCondition{RepositoryID: optional.From(id)})
 	if err != nil {
-		return errors.Wrap(err, "getting related applications")
+		return oops.Wrapf(err, "getting related applications")
 	}
 	if len(apps) > 0 {
 		return newError(ErrorTypeBadRequest, "all related applications must be deleted first", nil)

--- a/pkg/usecase/apiserver/service.go
+++ b/pkg/usecase/apiserver/service.go
@@ -2,11 +2,12 @@ package apiserver
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/motoki317/sc"
 
-	"github.com/friendsofgo/errors"
+	"github.com/samber/oops"
 
 	"github.com/traPtitech/neoshowcase/pkg/domain"
 	"github.com/traPtitech/neoshowcase/pkg/domain/builder"
@@ -94,7 +95,7 @@ func (s *Service) isRepositoryOwner(ctx context.Context, repoID string) error {
 	user := web.GetUser(ctx)
 	repo, err := s.gitRepo.GetRepository(ctx, repoID)
 	if err != nil {
-		return errors.Wrap(err, "getting repository")
+		return oops.Wrapf(err, "getting repository")
 	}
 	if !repo.IsOwner(user) {
 		return newError(ErrorTypeForbidden, "you do not have permission for this repository", nil)
@@ -106,7 +107,7 @@ func (s *Service) isApplicationOwner(ctx context.Context, appID string) error {
 	user := web.GetUser(ctx)
 	app, err := s.appRepo.GetApplication(ctx, appID)
 	if err != nil {
-		return errors.Wrap(err, "getting application")
+		return oops.Wrapf(err, "getting application")
 	}
 	if !app.IsOwner(user) {
 		return newError(ErrorTypeForbidden, "you do not have permission for this application", nil)
@@ -118,11 +119,11 @@ func (s *Service) isBuildOwner(ctx context.Context, buildID string) error {
 	user := web.GetUser(ctx)
 	build, err := s.buildRepo.GetBuild(ctx, buildID)
 	if err != nil {
-		return errors.Wrap(err, "getting build")
+		return oops.Wrapf(err, "getting build")
 	}
 	app, err := s.appRepo.GetApplication(ctx, build.ApplicationID)
 	if err != nil {
-		return errors.Wrap(err, "getting application")
+		return oops.Wrapf(err, "getting application")
 	}
 	if !app.IsOwner(user) {
 		return newError(ErrorTypeForbidden, "you do not have permission for this application", nil)

--- a/pkg/usecase/apiserver/system_service.go
+++ b/pkg/usecase/apiserver/system_service.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"time"
 
-	"github.com/friendsofgo/errors"
 	"github.com/motoki317/sc"
+	"github.com/samber/oops"
 	"golang.org/x/crypto/ed25519"
 	"golang.org/x/crypto/ssh"
 
@@ -36,11 +36,11 @@ func (s *Service) GenerateKeyPair(ctx context.Context) (keyID string, publicKey 
 	keyID = domain.NewID()
 	privKey, err := s.tmpKeys.Get(ctx, keyID)
 	if err != nil {
-		return "", "", errors.Wrap(err, "generating ed25519 key")
+		return "", "", oops.Wrapf(err, "generating ed25519 key")
 	}
 	pubKey, err := ssh.NewPublicKey(privKey.Public())
 	if err != nil {
-		return "", "", errors.Wrap(err, "creating public key")
+		return "", "", oops.Wrapf(err, "creating public key")
 	}
 	encoded := domain.Base64EncodedPublicKey(pubKey)
 	return keyID, encoded + " neoshowcase", nil

--- a/pkg/usecase/apiserver/user_service.go
+++ b/pkg/usecase/apiserver/user_service.go
@@ -3,7 +3,7 @@ package apiserver
 import (
 	"context"
 
-	"github.com/friendsofgo/errors"
+	"github.com/samber/oops"
 
 	"github.com/traPtitech/neoshowcase/pkg/domain"
 	"github.com/traPtitech/neoshowcase/pkg/domain/web"
@@ -26,7 +26,7 @@ func (s *Service) CreateUserKey(ctx context.Context, publicKey string, name stri
 	}
 	err = s.userRepo.CreateUserKey(ctx, key)
 	if err != nil {
-		return nil, errors.Wrap(err, "creating user key")
+		return nil, oops.Wrapf(err, "creating user key")
 	}
 	return key, nil
 }
@@ -37,7 +37,7 @@ func (s *Service) GetUserKeys(ctx context.Context) ([]*domain.UserKey, error) {
 		UserIDs: optional.From([]string{user.ID}),
 	})
 	if err != nil {
-		return nil, errors.Wrap(err, "getting user keys")
+		return nil, oops.Wrapf(err, "getting user keys")
 	}
 	return keys, nil
 }

--- a/pkg/usecase/builder/build.go
+++ b/pkg/usecase/builder/build.go
@@ -2,12 +2,13 @@ package builder
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"time"
 
-	"github.com/friendsofgo/errors"
 	buildkit "github.com/moby/buildkit/client"
+	"github.com/samber/oops"
 
 	"github.com/traPtitech/neoshowcase/pkg/domain"
 	"github.com/traPtitech/neoshowcase/pkg/infrastructure/grpc/pb"
@@ -137,7 +138,7 @@ func (s *ServiceImpl) buildSteps(st *state) ([]buildStep, error) {
 			return s.saveArtifact(ctx, st)
 		}})
 	default:
-		return nil, errors.New("unknown build config type")
+		return nil, oops.New("unknown build config type")
 	}
 
 	return steps, nil
@@ -230,7 +231,7 @@ func (s *ServiceImpl) finalize(ctx context.Context, st *state, status domain.Bui
 func (s *ServiceImpl) fetchImageSize(ctx context.Context, st *state) (int64, error) {
 	size, err := s.regclient.GetImageSize(ctx, s.imageConfig.ImageName(st.app.ID), s.imageTag(st.build))
 	if err != nil {
-		return 0, errors.Wrap(err, "getting image size")
+		return 0, oops.Wrapf(err, "getting image size")
 	}
 
 	return size, nil

--- a/pkg/usecase/builder/build_buildkit.go
+++ b/pkg/usecase/builder/build_buildkit.go
@@ -127,11 +127,11 @@ func (s *ServiceImpl) solveDockerfile(
 
 	ctxMount, err := fsutil.NewFS(contextDir)
 	if err != nil {
-		return oops.Wrapf(err, "invalid context mount dir")
+		return oops.Wrapf(err, "creating context mount")
 	}
 	dockerfileMount, err := fsutil.NewFS(dockerfileDir)
 	if err != nil {
-		return oops.Wrapf(err, "invalid dockerfile mount dir")
+		return oops.Wrapf(err, "creating dockerfile mount")
 	}
 
 	opts := buildkit.SolveOpt{

--- a/pkg/usecase/builder/build_buildkit.go
+++ b/pkg/usecase/builder/build_buildkit.go
@@ -11,12 +11,12 @@ import (
 
 	"github.com/docker/cli/cli/config/configfile"
 	"github.com/docker/cli/cli/config/types"
-	"github.com/friendsofgo/errors"
 	buildkit "github.com/moby/buildkit/client"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/session/auth/authprovider"
 	"github.com/moby/buildkit/util/progress/progressui"
 	"github.com/samber/lo"
+	"github.com/samber/oops"
 	"github.com/tonistiigi/fsutil"
 	"golang.org/x/sync/errgroup"
 
@@ -54,7 +54,7 @@ func withBuildkitProgress(ctx context.Context, logger io.Writer, buildFn func(ct
 func createTempFile(pattern string, content string) (name string, cleanup func(), err error) {
 	f, err := os.CreateTemp("", pattern)
 	if err != nil {
-		return "", nil, errors.Wrap(err, "creating temp "+pattern+" file")
+		return "", nil, oops.With("pattern", pattern).Wrapf(err, "creating temp file")
 	}
 	defer f.Close()
 	cleanup = func() {
@@ -66,7 +66,7 @@ func createTempFile(pattern string, content string) (name string, cleanup func()
 	_, err = f.WriteString(content)
 	if err != nil {
 		cleanup()
-		return "", nil, errors.Wrap(err, "writing to temp file "+f.Name())
+		return "", nil, oops.With("file", f.Name()).Wrapf(err, "writing to temp file")
 	}
 	return f.Name(), cleanup, nil
 }
@@ -127,11 +127,11 @@ func (s *ServiceImpl) solveDockerfile(
 
 	ctxMount, err := fsutil.NewFS(contextDir)
 	if err != nil {
-		return errors.Wrap(err, "invalid context mount dir")
+		return oops.Wrapf(err, "invalid context mount dir")
 	}
 	dockerfileMount, err := fsutil.NewFS(dockerfileDir)
 	if err != nil {
-		return errors.Wrap(err, "invalid dockerfile mount dir")
+		return oops.Wrapf(err, "invalid dockerfile mount dir")
 	}
 
 	opts := buildkit.SolveOpt{
@@ -179,7 +179,7 @@ func (s *ServiceImpl) buildRuntimeCmd(
 	if dockerignoreExists {
 		err := os.Rename(filepath.Join(st.repositoryTempDir, ".dockerignore"), filepath.Join(st.repositoryTempDir, temporaryDockerignoreName))
 		if err != nil {
-			return errors.Wrap(err, "renaming .dockerignore")
+			return oops.Wrapf(err, "renaming .dockerignore")
 		}
 	}
 
@@ -258,7 +258,7 @@ func (s *ServiceImpl) buildStaticCmd(
 	if dockerignoreExists {
 		err := os.Rename(filepath.Join(st.repositoryTempDir, ".dockerignore"), filepath.Join(st.repositoryTempDir, temporaryDockerignoreName))
 		if err != nil {
-			return errors.Wrap(err, "renaming .dockerignore")
+			return oops.Wrapf(err, "renaming .dockerignore")
 		}
 	}
 

--- a/pkg/usecase/builder/build_save_artifact.go
+++ b/pkg/usecase/builder/build_save_artifact.go
@@ -7,7 +7,7 @@ import (
 	"io"
 	"os"
 
-	"github.com/friendsofgo/errors"
+	"github.com/samber/oops"
 
 	"github.com/traPtitech/neoshowcase/pkg/domain"
 )
@@ -17,7 +17,7 @@ func (s *ServiceImpl) saveArtifact(ctx context.Context, st *state) error {
 	filename := st.artifactTempFile.Name()
 	stat, err := os.Stat(filename)
 	if err != nil {
-		return errors.Wrap(err, "opening artifact")
+		return oops.Wrapf(err, "opening artifact")
 	}
 
 	// Create artifact meta
@@ -26,7 +26,7 @@ func (s *ServiceImpl) saveArtifact(ctx context.Context, st *state) error {
 	// Create artifact .tar.gz
 	file, err := os.Open(filename)
 	if err != nil {
-		return errors.Wrap(err, "opening artifact")
+		return oops.Wrapf(err, "opening artifact")
 	}
 	defer file.Close()
 
@@ -34,17 +34,17 @@ func (s *ServiceImpl) saveArtifact(ctx context.Context, st *state) error {
 	gzipWriter := gzip.NewWriter(&artifactBytes)
 	_, err = io.Copy(gzipWriter, file)
 	if err != nil {
-		return errors.Wrap(err, "copying file to gzip write")
+		return oops.Wrapf(err, "copying file to gzip write")
 	}
 	err = gzipWriter.Close()
 	if err != nil {
-		return errors.Wrap(err, "flushing gzip write")
+		return oops.Wrapf(err, "flushing gzip write")
 	}
 
 	// Save artifact by requesting to controller
 	err = s.client.SaveArtifact(ctx, artifact, artifactBytes.Bytes())
 	if err != nil {
-		return errors.Wrap(err, "saving artifact")
+		return oops.Wrapf(err, "saving artifact")
 	}
 
 	return nil

--- a/pkg/usecase/builder/build_static.go
+++ b/pkg/usecase/builder/build_static.go
@@ -30,7 +30,7 @@ func (s *ServiceImpl) buildStaticExtract(
 	}
 	mount, err := fsutil.NewFS(st.repositoryTempDir)
 	if err != nil {
-		return oops.Wrapf(err, "invalid mount dir")
+		return oops.Wrapf(err, "creating mount")
 	}
 	_, err = s.buildkit.Solve(ctx, def, buildkit.SolveOpt{
 		Exports: []buildkit.ExportEntry{{

--- a/pkg/usecase/builder/build_static.go
+++ b/pkg/usecase/builder/build_static.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"io"
 
-	"github.com/friendsofgo/errors"
 	buildkit "github.com/moby/buildkit/client"
 	"github.com/moby/buildkit/client/llb"
+	"github.com/samber/oops"
 	"github.com/tonistiigi/fsutil"
 )
 
@@ -26,11 +26,11 @@ func (s *ServiceImpl) buildStaticExtract(
 		})).
 		Marshal(ctx)
 	if err != nil {
-		return errors.Wrap(err, "marshaling llb")
+		return oops.Wrapf(err, "marshaling llb")
 	}
 	mount, err := fsutil.NewFS(st.repositoryTempDir)
 	if err != nil {
-		return errors.Wrap(err, "invalid mount dir")
+		return oops.Wrapf(err, "invalid mount dir")
 	}
 	_, err = s.buildkit.Solve(ctx, def, buildkit.SolveOpt{
 		Exports: []buildkit.ExportEntry{{

--- a/pkg/usecase/builder/service.go
+++ b/pkg/usecase/builder/service.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/friendsofgo/errors"
+	"github.com/samber/oops"
 
 	buildkit "github.com/moby/buildkit/client"
 
@@ -54,14 +54,14 @@ func NewService(
 ) (*ServiceImpl, error) {
 	systemInfo, err := client.GetBuilderSystemInfo(context.Background())
 	if err != nil {
-		return nil, errors.Wrap(err, "getting builder system info")
+		return nil, oops.Wrapf(err, "getting builder system info")
 	}
 	// FIXME: git service should be injected via DI,
 	// but it's currently created here because it requires a public key
 	// derived from a runtime value (SSHKey from systemInfo).
 	pubKey, err := domain.IntoPublicKey(systemInfo.SSHKey)
 	if err != nil {
-		return nil, errors.Wrap(err, "converting into public key")
+		return nil, oops.Wrapf(err, "converting into public key")
 	}
 	gitsvc := git.NewService(pubKey)
 	return &ServiceImpl{

--- a/pkg/usecase/builder/state.go
+++ b/pkg/usecase/builder/state.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/samber/lo"
 
-	"github.com/friendsofgo/errors"
+	"github.com/samber/oops"
 
 	"github.com/traPtitech/neoshowcase/pkg/domain"
 )
@@ -85,11 +85,11 @@ func newState(app *domain.Application, envs []*domain.Environment, build *domain
 	var err error
 	st.repositoryTempDir, err = os.MkdirTemp("", "repository-")
 	if err != nil {
-		return nil, errors.Wrap(err, "creating tmp repository dir")
+		return nil, oops.Wrapf(err, "creating tmp repository dir")
 	}
 	st.artifactTempFile, err = os.CreateTemp("", "artifacts-")
 	if err != nil {
-		return nil, errors.Wrap(err, "creating tmp artifact file")
+		return nil, oops.Wrapf(err, "creating tmp artifact file")
 	}
 	return st, nil
 }

--- a/pkg/usecase/cdservice/container_state_mutator.go
+++ b/pkg/usecase/cdservice/container_state_mutator.go
@@ -5,9 +5,9 @@ import (
 	"log/slog"
 	"sync"
 
-	"github.com/friendsofgo/errors"
 	"github.com/motoki317/sc"
 	"github.com/samber/lo"
+	"github.com/samber/oops"
 
 	"github.com/traPtitech/neoshowcase/pkg/domain"
 	"github.com/traPtitech/neoshowcase/pkg/util/discovery"
@@ -57,14 +57,14 @@ func (m *ContainerStateMutator) _updateOne(ctx context.Context, appID string) (s
 
 	container, err := m.backend.GetContainer(ctx, appID)
 	if err != nil {
-		return struct{}{}, errors.Wrapf(err, "getting container state (app_id=%s)", appID)
+		return struct{}{}, oops.With("app_id", appID).Wrapf(err, "getting container state")
 	}
 	err = m.appRepo.UpdateApplication(ctx, appID, &domain.UpdateApplicationArgs{
 		Container:        optional.From(container.State),
 		ContainerMessage: optional.From(container.Message),
 	})
 	if err != nil {
-		return struct{}{}, errors.Wrapf(err, "updating application (app_id=%s)", appID)
+		return struct{}{}, oops.With("app_id", appID).Wrapf(err, "updating application")
 	}
 
 	return struct{}{}, nil
@@ -77,7 +77,7 @@ func (m *ContainerStateMutator) updateAll(ctx context.Context) error {
 	// Fetch all runtime apps
 	allRuntimeApps, err := m.appRepo.GetApplications(ctx, domain.GetApplicationCondition{DeployType: optional.From(domain.DeployTypeRuntime)})
 	if err != nil {
-		return errors.Wrap(err, "getting all runtime applications")
+		return oops.Wrapf(err, "getting all runtime applications")
 	}
 	// Shard by app ID
 	allRuntimeApps = lo.Filter(allRuntimeApps, func(app *domain.Application, _ int) bool {
@@ -87,7 +87,7 @@ func (m *ContainerStateMutator) updateAll(ctx context.Context) error {
 	// Fetch actual states
 	containers, err := m.backend.ListContainers(ctx)
 	if err != nil {
-		return errors.Wrap(err, "listing containers")
+		return oops.Wrapf(err, "listing containers")
 	}
 
 	// If actual state is not found, update state as "missing"
@@ -106,7 +106,7 @@ func (m *ContainerStateMutator) updateAll(ctx context.Context) error {
 	// Update
 	err = m.appRepo.BulkUpdateState(ctx, containers)
 	if err != nil {
-		return errors.Wrap(err, "bulk-updating container state")
+		return oops.Wrapf(err, "bulk-updating container state")
 	}
 	return nil
 }

--- a/pkg/usecase/cdservice/service.go
+++ b/pkg/usecase/cdservice/service.go
@@ -8,8 +8,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/friendsofgo/errors"
 	"github.com/samber/lo"
+	"github.com/samber/oops"
 
 	"github.com/traPtitech/neoshowcase/pkg/domain"
 	"github.com/traPtitech/neoshowcase/pkg/infrastructure/grpc"
@@ -248,7 +248,7 @@ func (cd *service) detectBuildCrash(ctx context.Context) error {
 
 	builds, err := cd.buildRepo.GetBuilds(ctx, domain.GetBuildCondition{Status: optional.From(domain.BuildStatusBuilding)})
 	if err != nil {
-		return errors.Wrap(err, "getting running builds")
+		return oops.Wrapf(err, "getting running builds")
 	}
 	crashed := lo.Filter(builds, func(build *domain.Build, _ int) bool {
 		return now.Sub(build.UpdatedAt.ValueOrZero()) > crashDetectThreshold
@@ -317,7 +317,7 @@ func (cd *service) _syncAppFields(ctx context.Context) error {
 				UpdatedAt:    optional.From(nextBuild.FinishedAt.V),
 			})
 			if err != nil {
-				return errors.Wrapf(err, "syncing application commit (app_id=%s)", app.ID)
+				return oops.With("app_id", app.ID).Wrapf(err, "syncing application commit")
 			}
 		}
 	}
@@ -334,7 +334,7 @@ func (cd *service) syncDeployments(ctx context.Context) error {
 	// Synchronize
 	err = cd.deployer.synchronize(ctx)
 	if err != nil {
-		return errors.Wrap(err, "synchronizing deployments")
+		return oops.Wrapf(err, "synchronizing deployments")
 	}
 
 	// Update container states

--- a/pkg/usecase/cleaner/service.go
+++ b/pkg/usecase/cleaner/service.go
@@ -2,13 +2,14 @@ package cleaner
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"sync"
 	"time"
 
-	"github.com/friendsofgo/errors"
 	"github.com/regclient/regclient/types/errs"
 	"github.com/samber/lo"
+	"github.com/samber/oops"
 
 	"github.com/traPtitech/neoshowcase/pkg/domain"
 	"github.com/traPtitech/neoshowcase/pkg/domain/builder"
@@ -122,7 +123,7 @@ func (c *cleanerService) pruneImage(ctx context.Context, r builder.RegistryClien
 		return nil
 	}
 	if err != nil {
-		return errors.Wrap(err, "getting tags")
+		return oops.Wrapf(err, "getting tags")
 	}
 
 	// compare by queued_at time, then delete any older builds
@@ -156,7 +157,7 @@ func (c *cleanerService) getOlderBuilds(ctx context.Context, appID string, targe
 	}
 	current, ok := lo.Find(builds, func(b *domain.Build) bool { return b.ID == targetBuildID })
 	if !ok {
-		return nil, errors.Errorf("build %v not found in retrieved builds", targetBuildID)
+		return nil, oops.Errorf("build %v not found in retrieved builds", targetBuildID)
 	}
 	return lo.Filter(builds, func(b *domain.Build, _ int) bool { return b.QueuedAt.Before(current.QueuedAt) }), nil
 }
@@ -164,17 +165,17 @@ func (c *cleanerService) getOlderBuilds(ctx context.Context, appID string, targe
 func (c *cleanerService) pruneArtifacts(ctx context.Context) error {
 	notInUse, err := c.getArtifactsNoLongerInUse(ctx)
 	if err != nil {
-		return errors.Wrap(err, "getting artifacts in use")
+		return oops.Wrapf(err, "getting artifacts in use")
 	}
 
 	for _, artifact := range notInUse {
 		err = domain.DeleteArtifact(c.storage, artifact.ID)
 		if err != nil {
-			return errors.Wrapf(err, "deleting artifact %v", artifact.ID)
+			return oops.With("artifact_id", artifact.ID).Wrapf(err, "deleting artifact")
 		}
 		err = c.artifactRepo.UpdateArtifact(ctx, artifact.ID, domain.UpdateArtifactArgs{DeletedAt: optional.From(time.Now())})
 		if err != nil {
-			return errors.Wrapf(err, "marking artifact as deleted (artifact_id=%s)", artifact.ID)
+			return oops.With("artifact_id", artifact.ID).Wrapf(err, "marking artifact as deleted")
 		}
 	}
 	return nil

--- a/pkg/usecase/commit-fetcher/service.go
+++ b/pkg/usecase/commit-fetcher/service.go
@@ -7,8 +7,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/friendsofgo/errors"
 	"github.com/samber/lo"
+	"github.com/samber/oops"
 
 	"github.com/traPtitech/neoshowcase/pkg/domain"
 	"github.com/traPtitech/neoshowcase/pkg/util/discovery"
@@ -141,7 +141,7 @@ func (s *service) fetchOne(ctx context.Context, repositoryID string, hashes []st
 	// Check if we have already tried
 	recordedCommits, err := s.commitsRepo.GetCommits(ctx, hashes)
 	if err != nil {
-		return errors.Wrap(err, "getting recorded commits")
+		return oops.Wrapf(err, "getting recorded commits")
 	}
 	recordedCommitMap := lo.SliceToMap(recordedCommits, func(c *domain.RepositoryCommit) (string, bool) {
 		return c.Hash, true
@@ -155,24 +155,24 @@ func (s *service) fetchOne(ctx context.Context, repositoryID string, hashes []st
 
 	repo, err := s.gitRepo.GetRepository(ctx, repositoryID)
 	if err != nil {
-		return errors.Wrapf(err, "getting repository (repository_id=%s)", repositoryID)
+		return oops.With("repository_id", repositoryID).Wrapf(err, "getting repository")
 	}
 
 	// Init local git directory
 	tmpDir, err := os.MkdirTemp("", "commit-fetcher-")
 	if err != nil {
-		return errors.Wrap(err, "creating temp dir")
+		return oops.Wrapf(err, "creating temp dir")
 	}
 	defer os.RemoveAll(tmpDir)
 
 	localRepo, err := s.gitsvc.CreateBareRepository(tmpDir, repo)
 	if err != nil {
-		return errors.Wrap(err, "initializing git repo")
+		return oops.Wrapf(err, "initializing git repo")
 	}
 
 	err = localRepo.Fetch(ctx, hashes)
 	if err != nil {
-		return errors.Wrap(err, "fetching commits")
+		return oops.Wrapf(err, "fetching commits")
 	}
 
 	// Get commit objects and record, in a *fail-safe* manner -
@@ -186,7 +186,7 @@ func (s *service) fetchOne(ctx context.Context, repositoryID string, hashes []st
 
 		err = s.commitsRepo.RecordCommit(ctx, commit)
 		if err != nil {
-			return errors.Wrap(err, "recording commit")
+			return oops.Wrapf(err, "recording commit")
 		}
 	}
 

--- a/pkg/usecase/gitea-integration/integration.go
+++ b/pkg/usecase/gitea-integration/integration.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"code.gitea.io/sdk/gitea"
-	"github.com/friendsofgo/errors"
+	"github.com/samber/oops"
 
 	"github.com/traPtitech/neoshowcase/pkg/domain"
 	"github.com/traPtitech/neoshowcase/pkg/util/loop"
@@ -22,13 +22,13 @@ type Config struct {
 
 func (c *Config) Validate() error {
 	if c.Token == "" {
-		return errors.New("provide admin gitea token (got empty string)")
+		return oops.New("provide admin gitea token (got empty string)")
 	}
 	if c.IntervalSeconds <= 0 {
-		return errors.Errorf("provide positive interval seconds (got %v)", c.IntervalSeconds)
+		return oops.Errorf("provide positive interval seconds (got %v)", c.IntervalSeconds)
 	}
 	if c.Concurrency <= 0 {
-		return errors.Errorf("provide positive concurrency (got %v)", c.Concurrency)
+		return oops.Errorf("provide positive concurrency (got %v)", c.Concurrency)
 	}
 	return nil
 }
@@ -65,7 +65,7 @@ func NewIntegration(
 		gitea.SetGiteaVersion(""),
 	)
 	if err != nil {
-		return nil, errors.Wrap(err, "creating gitea client")
+		return nil, oops.Wrapf(err, "creating gitea client")
 	}
 
 	i := &Integration{

--- a/pkg/usecase/gitea-integration/sync.go
+++ b/pkg/usecase/gitea-integration/sync.go
@@ -8,8 +8,8 @@ import (
 	"time"
 
 	"code.gitea.io/sdk/gitea"
-	"github.com/friendsofgo/errors"
 	"github.com/samber/lo"
+	"github.com/samber/oops"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/traPtitech/neoshowcase/pkg/domain"
@@ -49,7 +49,7 @@ func (i *Integration) sync(ctx context.Context) error {
 		return users, err
 	})
 	if err != nil {
-		return errors.Wrap(err, "listing users")
+		return oops.Wrapf(err, "listing users")
 	}
 	userNames := ds.Map(giteaUsers, func(user *gitea.User) string { return user.UserName })
 
@@ -75,7 +75,7 @@ func (i *Integration) sync(ctx context.Context) error {
 		return repos, err
 	})
 	if err != nil {
-		return errors.Wrap(err, "listing repositories")
+		return oops.Wrapf(err, "listing repositories")
 	}
 
 	// Sync repositories
@@ -88,7 +88,7 @@ func (i *Integration) sync(ctx context.Context) error {
 			// Get users with write access
 			members, _, err := i.c.GetAssignees(repo.Owner.UserName, repo.Name)
 			if err != nil {
-				return errors.Wrapf(err, "getting assignees (repo=%v/%v)", repo.Owner.UserName, repo.Name)
+				return oops.With("repo_owner", repo.Owner.UserName, "repo_name", repo.Name).Wrapf(err, "getting assignees")
 			}
 			memberIDs := lo.Flatten(ds.Map(members, func(member *gitea.User) []string {
 				user, ok := usersMap[member.UserName]
@@ -110,7 +110,7 @@ func (i *Integration) syncRepository(ctx context.Context, username string, gitea
 	// NOTE: no transaction, creating repository is assumed rare
 	repos, err := i.gitRepo.GetRepositories(ctx, domain.GetRepositoryCondition{URLs: optional.From([]string{giteaRepo.SSHURL})})
 	if err != nil {
-		return errors.Wrapf(err, "getting repository (ssh_url=%s)", giteaRepo.SSHURL)
+		return oops.With("ssh_url", giteaRepo.SSHURL).Wrapf(err, "getting repository")
 	}
 
 	if len(repos) == 0 {
@@ -123,7 +123,7 @@ func (i *Integration) syncRepository(ctx context.Context, username string, gitea
 		)
 		slog.InfoContext(ctx, "New repository found", "name", repo.Name, "id", repo.ID)
 		if err := i.gitRepo.CreateRepository(ctx, repo); err != nil {
-			return errors.Wrapf(err, "creating repository (name=%s)", repo.Name)
+			return oops.With("name", repo.Name).Wrapf(err, "creating repository")
 		}
 		return nil
 	}
@@ -139,14 +139,14 @@ func (i *Integration) syncRepository(ctx context.Context, username string, gitea
 		slog.InfoContext(ctx, "Syncing repository owners", "repo_name", repo.Name, "repo_id", repo.ID, "old_count", len(repo.OwnerIDs), "new_count", len(newOwners))
 		err = i.gitRepo.UpdateRepository(ctx, repo.ID, &domain.UpdateRepositoryArgs{OwnerIDs: optional.From(newOwners)})
 		if err != nil {
-			return errors.Wrapf(err, "updating repository owners (repo_id=%s)", repo.ID)
+			return oops.With("repo_id", repo.ID).Wrapf(err, "updating repository owners")
 		}
 	}
 
 	// Sync owners of generated applications
 	apps, err := i.appRepo.GetApplications(ctx, domain.GetApplicationCondition{RepositoryID: optional.From(repo.ID)})
 	if err != nil {
-		return errors.Wrapf(err, "getting applications (repo_id=%s)", repo.ID)
+		return oops.With("repo_id", repo.ID).Wrapf(err, "getting applications")
 	}
 	for _, app := range apps {
 		err = i.syncApplication(ctx, app, giteaOwnerIDs)
@@ -166,7 +166,7 @@ func (i *Integration) syncApplication(ctx context.Context, app *domain.Applicati
 		slog.InfoContext(ctx, "Syncing application owners", "app_name", app.Name, "app_id", app.ID, "old_count", len(app.OwnerIDs), "new_count", len(newOwners))
 		err := i.appRepo.UpdateApplication(ctx, app.ID, &domain.UpdateApplicationArgs{OwnerIDs: optional.From(newOwners)})
 		if err != nil {
-			return errors.Wrapf(err, "updating application owners (app_id=%s)", app.ID)
+			return oops.With("app_id", app.ID).Wrapf(err, "updating application owners")
 		}
 	}
 	return nil

--- a/pkg/usecase/repofetcher/service.go
+++ b/pkg/usecase/repofetcher/service.go
@@ -6,8 +6,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/friendsofgo/errors"
 	"github.com/samber/lo"
+	"github.com/samber/oops"
 	"github.com/sourcegraph/conc/pool"
 
 	"github.com/traPtitech/neoshowcase/pkg/domain"
@@ -210,7 +210,7 @@ func (r *service) updateApps(ctx context.Context, repo *domain.Repository, apps 
 
 		err = r.appRepo.UpdateApplication(ctx, app.ID, &domain.UpdateApplicationArgs{Commit: optional.From(commit)})
 		if err != nil {
-			return errors.Wrapf(err, "updating application (app_id=%s)", app.ID)
+			return oops.With("app_id", app.ID).Wrapf(err, "updating application")
 		}
 		// Notify builds
 		r.cd.RegisterBuild(app.ID)

--- a/pkg/usecase/ssgen/generator.go
+++ b/pkg/usecase/ssgen/generator.go
@@ -9,8 +9,8 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/friendsofgo/errors"
 	"github.com/samber/lo"
+	"github.com/samber/oops"
 
 	"github.com/traPtitech/neoshowcase/pkg/domain"
 	"github.com/traPtitech/neoshowcase/pkg/infrastructure/grpc/pb"
@@ -141,7 +141,7 @@ func (s *generatorService) _reload(ctx context.Context) error {
 func (s *generatorService) syncArtifacts(sites []*domain.StaticSite) error {
 	entries, err := os.ReadDir(s.docsRoot)
 	if err != nil {
-		return errors.Wrap(err, "reading docs root")
+		return oops.Wrapf(err, "reading docs root")
 	}
 	artifactsOnDisk := make(map[string]struct{}, len(entries))
 	for _, e := range entries {
@@ -171,7 +171,7 @@ func (s *generatorService) syncArtifacts(sites []*domain.StaticSite) error {
 		artifactDir := filepath.Join(s.docsRoot, artifactID)
 		err = os.RemoveAll(artifactDir)
 		if err != nil {
-			return errors.Wrapf(err, "deleting unused artifact directory (artifact_id=%s)", artifactID)
+			return oops.With("artifact_id", artifactID).Wrapf(err, "deleting unused artifact directory")
 		}
 	}
 
@@ -182,17 +182,17 @@ func (s *generatorService) extractArtifact(artifactID string) error {
 	destDir := filepath.Join(s.docsRoot, artifactID)
 	r, err := domain.GetArtifact(s.storage, artifactID)
 	if err != nil {
-		return errors.Wrap(err, "getting artifact")
+		return oops.Wrapf(err, "getting artifact")
 	}
 	defer r.Close()
 	tarReader, err := gzip.NewReader(r)
 	if err != nil {
-		return errors.Wrap(err, "preparing gzip reader")
+		return oops.Wrapf(err, "preparing gzip reader")
 	}
 	defer tarReader.Close()
 	err = tarfs.Extract(tarReader, destDir)
 	if err != nil {
-		return errors.Wrap(err, "extracting artifact tar")
+		return oops.Wrapf(err, "extracting artifact tar")
 	}
 	return nil
 }

--- a/pkg/usecase/sshserver/ssh_server.go
+++ b/pkg/usecase/sshserver/ssh_server.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"log/slog"
 
-	"github.com/friendsofgo/errors"
 	"github.com/gliderlabs/ssh"
 	ssh2 "github.com/go-git/go-git/v5/plumbing/transport/ssh"
 	"github.com/samber/lo"
+	"github.com/samber/oops"
 
 	"github.com/traPtitech/neoshowcase/pkg/domain"
 	"github.com/traPtitech/neoshowcase/pkg/util/ds"
@@ -138,7 +138,7 @@ func (s *sshServer) handle(sess ssh.Session) error {
 
 	app, err := s.appRepo.GetApplication(sess.Context(), appID)
 	if err != nil {
-		return errors.Wrapf(err, "retrieving app with id %v", appID)
+		return oops.With("app_id", appID).Wrapf(err, "retrieving app")
 	}
 
 	_, _ = sess.Write([]byte(figWelcome))
@@ -163,7 +163,7 @@ func (s *sshServer) handle(sess ssh.Session) error {
 		var resp [1]byte
 		_, err = sess.Read(resp[:])
 		if err != nil {
-			return errors.Wrap(err, "reading response")
+			return oops.Wrapf(err, "reading response")
 		}
 
 		_, _ = sess.Write(resp[:])

--- a/pkg/util/discovery/discoverer.go
+++ b/pkg/util/discovery/discoverer.go
@@ -3,7 +3,7 @@ package discovery
 import (
 	"context"
 
-	"github.com/friendsofgo/errors"
+	"github.com/samber/oops"
 )
 
 type Target struct {
@@ -28,11 +28,11 @@ func validateTargets(targets []Target) error {
 	}
 	// Note that it is possible there are no targets marked as "me".
 	if meCnt > 1 {
-		return errors.Errorf("too many targets marked as \"me\": %d", meCnt)
+		return oops.Errorf("too many targets marked as \"me\": %d", meCnt)
 	}
 	for i := 0; i < len(targets)-1; i++ {
 		if targets[i].IP == targets[i+1].IP {
-			return errors.Errorf("duplicate target: %s", targets[i].IP)
+			return oops.Errorf("duplicate target: %s", targets[i].IP)
 		}
 	}
 	return nil

--- a/pkg/util/discovery/discoverer_k8s.go
+++ b/pkg/util/discovery/discoverer_k8s.go
@@ -56,7 +56,7 @@ func NewK8sDiscoverer(svcName string) (Discoverer, error) {
 	}
 	_, err = d.discover()
 	if err != nil {
-		return nil, oops.Wrapf(err, "discovering targets")
+		return nil, oops.With("service_name", d.svcName).Wrapf(err, "discovering targets")
 	}
 
 	return d, nil
@@ -134,7 +134,7 @@ func (k *k8sDiscoverer) watch(ctx context.Context, updates chan<- []Target) erro
 	// Send initial state
 	targets, err := k.discover()
 	if err != nil {
-		return oops.Wrapf(err, "discovering targets")
+		return oops.With("service_name", k.svcName).Wrapf(err, "discovering targets")
 	}
 	if len(targets) > 0 {
 		updates <- targets
@@ -143,7 +143,7 @@ func (k *k8sDiscoverer) watch(ctx context.Context, updates chan<- []Target) erro
 	for range watcher.ResultChan() {
 		targets, err = k.discover()
 		if err != nil {
-			return oops.Wrapf(err, "discovering targets")
+			return oops.With("service_name", k.svcName).Wrapf(err, "discovering targets")
 		}
 		if len(targets) > 0 {
 			updates <- targets

--- a/pkg/util/discovery/discoverer_k8s.go
+++ b/pkg/util/discovery/discoverer_k8s.go
@@ -8,7 +8,7 @@ import (
 	"slices"
 	"time"
 
-	"github.com/friendsofgo/errors"
+	"github.com/samber/oops"
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -52,11 +52,11 @@ func NewK8sDiscoverer(svcName string) (Discoverer, error) {
 	// sanity check
 	_, err = d.findService()
 	if err != nil {
-		return nil, errors.Wrapf(err, "finding service (service_name=%s)", svcName)
+		return nil, oops.With("service_name", svcName).Wrapf(err, "finding service")
 	}
 	_, err = d.discover()
 	if err != nil {
-		return nil, errors.Wrap(err, "discovering targets")
+		return nil, oops.Wrapf(err, "discovering targets")
 	}
 
 	return d, nil
@@ -134,7 +134,7 @@ func (k *k8sDiscoverer) watch(ctx context.Context, updates chan<- []Target) erro
 	// Send initial state
 	targets, err := k.discover()
 	if err != nil {
-		return errors.Wrap(err, "discovering targets")
+		return oops.Wrapf(err, "discovering targets")
 	}
 	if len(targets) > 0 {
 		updates <- targets
@@ -143,7 +143,7 @@ func (k *k8sDiscoverer) watch(ctx context.Context, updates chan<- []Target) erro
 	for range watcher.ResultChan() {
 		targets, err = k.discover()
 		if err != nil {
-			return errors.Wrap(err, "discovering targets")
+			return oops.Wrapf(err, "discovering targets")
 		}
 		if len(targets) > 0 {
 			updates <- targets

--- a/pkg/util/fig/color.go
+++ b/pkg/util/fig/color.go
@@ -6,7 +6,7 @@ import (
 	"encoding/hex"
 	"fmt"
 
-	"github.com/friendsofgo/errors"
+	"github.com/samber/oops"
 )
 
 // Escape char
@@ -69,7 +69,7 @@ func (tc TrueColor) GetSuffix() string {
 func NewTrueColorFromHexString(c string) (*TrueColor, error) {
 	rgb, err := hex.DecodeString(c)
 	if err != nil {
-		return nil, errors.Errorf("invalid color given (%s)", c)
+		return nil, oops.Errorf("invalid color given (%s)", c)
 	}
 
 	return &TrueColor{

--- a/pkg/util/fig/fonts.go
+++ b/pkg/util/fig/fonts.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"path/filepath"
 
-	"github.com/friendsofgo/errors"
+	"github.com/samber/oops"
 )
 
 //go:embed fonts/*
@@ -16,7 +16,7 @@ const fontsDir = "fonts"
 func readFontBytes(font string) ([]byte, error) {
 	f, err := fs.Open(filepath.Join(fontsDir, font+".flf"))
 	if err != nil {
-		return nil, errors.Wrap(err, "opening font file")
+		return nil, oops.Wrapf(err, "opening font file")
 	}
 	defer f.Close()
 	return io.ReadAll(f)

--- a/pkg/util/fig/render.go
+++ b/pkg/util/fig/render.go
@@ -3,8 +3,8 @@ package fig
 import (
 	"strings"
 
-	"github.com/friendsofgo/errors"
 	"github.com/lukesampson/figlet/figletlib"
+	"github.com/samber/oops"
 )
 
 type Builder struct {
@@ -18,13 +18,13 @@ func (b *Builder) Append(msg string, font string, color Color) error {
 	}
 	f, err := figletlib.ReadFontFromBytes(by)
 	if err != nil {
-		return errors.Wrap(err, "reading font from bytes")
+		return oops.Wrapf(err, "reading font from bytes")
 	}
 	words := figletlib.GetLines(msg, f, 1000, f.Settings())
 	for _, word := range words {
 		art := word.Art()
 		if len(b.lines) > 0 && len(b.lines) != len(art) {
-			return errors.New("line height mismatch")
+			return oops.New("line height mismatch")
 		}
 		if len(b.lines) == 0 {
 			b.lines = make([]string, len(art))

--- a/pkg/util/mapper/mapper.go
+++ b/pkg/util/mapper/mapper.go
@@ -1,8 +1,8 @@
 package mapper
 
 import (
-	"github.com/friendsofgo/errors"
 	"github.com/samber/lo"
+	"github.com/samber/oops"
 )
 
 func reverse[V1, V2 comparable](m map[V1]V2) map[V2]V1 {
@@ -28,7 +28,7 @@ type ValueMapper[V1, V2 comparable] struct {
 func NewValueMapper[V1, V2 comparable](m map[V1]V2) (*ValueMapper[V1, V2], error) {
 	m2 := reverse(m)
 	if len(m2) != len(m) {
-		return nil, errors.New("reverse map len does not match: possible typo")
+		return nil, oops.New("reverse map len does not match: possible typo")
 	}
 	return &ValueMapper[V1, V2]{
 		m1: m,

--- a/pkg/util/slogutil/handler.go
+++ b/pkg/util/slogutil/handler.go
@@ -6,7 +6,12 @@ import (
 	"log/slog"
 )
 
-// CustomHandler adds trace_id and user_id from context
+// CustomHandler adds trace_id and user_id from the context to every record.
+//
+// Rendering errors is deliberately not its job. Errors created with
+// github.com/samber/oops implement slog.LogValuer, so the base handler expands
+// their wrap chain, code, attached attributes and stack trace by itself — for any
+// output format.
 type CustomHandler struct {
 	baseHandler slog.Handler
 }
@@ -23,17 +28,20 @@ func (h *CustomHandler) Enabled(ctx context.Context, level slog.Level) bool {
 }
 
 func (h *CustomHandler) Handle(ctx context.Context, record slog.Record) error {
-	// Extract trace_id from context
-	if traceID := ctx.Value(TraceIDKey); traceID != nil {
-		if traceIDStr, ok := traceID.(string); ok && traceIDStr != "" {
-			record.AddAttrs(slog.String("trace_id", traceIDStr))
-		}
-	}
+	traceID, hasTrace := ctx.Value(TraceIDKey).(string)
+	userID, hasUser := ctx.Value(UserIDKey).(string)
+	hasTrace = hasTrace && traceID != ""
+	hasUser = hasUser && userID != ""
 
-	// Extract user_id from context
-	if userID := ctx.Value(UserIDKey); userID != nil {
-		if userIDStr, ok := userID.(string); ok && userIDStr != "" {
-			record.AddAttrs(slog.String("user_id", userIDStr))
+	if hasTrace || hasUser {
+		// Clone before adding: the record's attributes may share backing storage
+		// with the caller's.
+		record = record.Clone()
+		if hasTrace {
+			record.AddAttrs(slog.String("trace_id", traceID))
+		}
+		if hasUser {
+			record.AddAttrs(slog.String("user_id", userID))
 		}
 	}
 

--- a/pkg/util/tarfs/compress.go
+++ b/pkg/util/tarfs/compress.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/friendsofgo/errors"
+	"github.com/samber/oops"
 )
 
 func Compress(srcPath string) io.Reader {
@@ -55,10 +55,10 @@ func Compress(srcPath string) io.Reader {
 			return nil
 		})
 		if err != nil {
-			_ = pw.CloseWithError(errors.Wrap(err, "walking srcPath"))
+			_ = pw.CloseWithError(oops.Wrapf(err, "walking srcPath"))
 		}
 		if err = tw.Close(); err != nil {
-			_ = pw.CloseWithError(errors.Wrap(err, "closing tar writer"))
+			_ = pw.CloseWithError(oops.Wrapf(err, "closing tar writer"))
 		}
 	}()
 

--- a/pkg/util/tarfs/extract.go
+++ b/pkg/util/tarfs/extract.go
@@ -2,13 +2,14 @@ package tarfs
 
 import (
 	"archive/tar"
+	"errors"
 	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
 
-	"github.com/friendsofgo/errors"
+	"github.com/samber/oops"
 )
 
 func isValidRelPath(relPath string) bool {
@@ -31,33 +32,33 @@ func Extract(tarStream io.Reader, destPath string) error {
 			break
 		}
 		if err != nil {
-			return errors.Wrap(err, "bad tar file")
+			return oops.Wrapf(err, "bad tar file")
 		}
 
 		if !isValidRelPath(header.Name) {
-			return errors.Errorf("invalid path %v", header.Name)
+			return oops.Errorf("invalid path %v", header.Name)
 		}
 
 		path := filepath.Join(destPath, header.Name)
 		switch header.Typeflag {
 		case tar.TypeDir:
 			if err = os.MkdirAll(path, header.FileInfo().Mode()); err != nil {
-				return errors.Wrap(err, "creating directory")
+				return oops.Wrapf(err, "creating directory")
 			}
 
 		case tar.TypeReg:
 			if err = os.MkdirAll(filepath.Dir(path), header.FileInfo().Mode()|os.ModeDir|100); err != nil {
-				return errors.Wrap(err, "creating directory")
+				return oops.Wrapf(err, "creating directory")
 			}
 
 			file, err := os.OpenFile(path, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, header.FileInfo().Mode())
 			if err != nil {
-				return errors.Wrap(err, "creating file")
+				return oops.Wrapf(err, "creating file")
 			}
 			_, err = io.Copy(file, tr)
 			_ = file.Close()
 			if err != nil {
-				return errors.Wrap(err, "writing file")
+				return oops.Wrapf(err, "writing file")
 			}
 
 		default:

--- a/pkg/util/tarfs/extract.go
+++ b/pkg/util/tarfs/extract.go
@@ -32,7 +32,7 @@ func Extract(tarStream io.Reader, destPath string) error {
 			break
 		}
 		if err != nil {
-			return oops.Wrapf(err, "bad tar file")
+			return oops.Wrapf(err, "reading tar file")
 		}
 
 		if !isValidRelPath(header.Name) {


### PR DESCRIPTION
## なぜやるか

現在エラーハンドリングに使っている `github.com/friendsofgo/errors` が実質メンテナンス停止しているため（最終リリースは2019年、fork元の `pkg/errors` もメンテナンスモード）。

代替を調査し、`github.com/samber/oops` を採用した。決め手は以下:

- **活発にメンテされている**（v1.23.0 / 2026年時点で継続更新）
- **スタックトレースを保持**しつつ、`With()` で識別子を**構造化フィールド**として持ち回れる → slogと相性がいい
- 新規依存は `oklog/ulid` のみ（`samber/lo` は導入済み）で軽量
- `errors.Is` / `errors.As` は標準ライブラリでそのまま貫通し、移行が機械的

## やったこと

手書きコード全体（95ファイル）を `friendsofgo/errors` から `samber/oops` へ移行。

- `errors.Wrap`/`New`/`Errorf` → `oops.Wrapf`/`New`/`Errorf`、`Is`/`As` は標準 `errors` へ
- **usecase層の分類**を `oops.Code()` / `Public()` で再実装。`ErrorType` を `int` → `string` にし、ログに `code=not_found` と意味が出るように（呼び出し側は無変更）
- **境界（`handleUseCaseError`）**: クライアントには公開文言のみを返し、内部wrapチェーンはログにのみ残す。`*connect.Error` 越しでも `oops.AsOops` でペイロードを復元してログ展開できることを確認済み
- **`slogutil.CustomHandler`** をエラー展開ロジックごと削除し、trace_id/user_id 注入のみの薄いハンドラに（oops が `slog.LogValuer` を実装するため）
- 操作に付随する識別子25箇所を `With()` の構造化フィールドへ展開
- `docs/guidelines/error-handling.md` と `CLAUDE.md` を oops 前提に改訂

## やらなかったこと

- **識別子の `With()` 展開は一部のみ**。バリデーション/設定エラー（値が文の主語でクライアントにも見えるもの）は補間のまま据え置き、その線引きをガイドラインに明記した

## 資料

- [samber/oops](https://github.com/samber/oops)
- 前段の移行: #1314 (friendsofgo/errors への移行とガイドライン整備)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * エラー情報の扱いを統一し、障害発生時の原因追跡や診断がしやすくなりました。
  * ログに関連情報やエラーチェーンがより適切に記録され、運用時の調査性が向上しました。
  * クライアントには分類済みの公開メッセージのみを返し、内部情報を含む詳細は表示されないよう改善しました。
  * 未分類の内部エラーでは、汎用的なメッセージを返すことで情報漏えいを防止します。

* **Documentation**
  * エラー分類、ログ出力、クライアント向けメッセージの運用ルールを更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->