### PR TITLE
chore: update mysqldef to v3

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -93,7 +93,7 @@ jobs:
           go-version-file: ./go.mod
       - name: Run migration
         run: |
-          go install github.com/sqldef/sqldef/cmd/mysqldef@latest
+          go install github.com/sqldef/sqldef/v3/cmd/mysqldef@v3.11.16
           DB_PORT=5004 ./migrations/entrypoint.sh ./migrations/schema.sql
       - name: Run tests
         run: go test ./... -v ${{ matrix.race }} -coverprofile=coverage.out -covermode=atomic -vet=off
@@ -165,7 +165,7 @@ jobs:
           go-version-file: ./go.mod
       - name: Run migration
         run: |
-          go install github.com/sqldef/sqldef/cmd/mysqldef@latest
+          go install github.com/sqldef/sqldef/v3/cmd/mysqldef@v3.11.16
           DB_PORT=5004 ./migrations/entrypoint.sh ./migrations/schema.sql
       - uses: k1low/setup-tbls@f25e3d013a596865b2db90dac7ee19e9f15b5780 # v1.4.0
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -91,9 +91,11 @@ jobs:
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: ./go.mod
+      - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+        with:
+          install_args: go:github.com/sqldef/sqldef/v3/cmd/mysqldef
       - name: Run migration
         run: |
-          go install github.com/sqldef/sqldef/v3/cmd/mysqldef@v3.11.16
           DB_PORT=5004 ./migrations/entrypoint.sh ./migrations/schema.sql
       - name: Run tests
         run: go test ./... -v ${{ matrix.race }} -coverprofile=coverage.out -covermode=atomic -vet=off
@@ -163,9 +165,11 @@ jobs:
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: ./go.mod
+      - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+        with:
+          install_args: go:github.com/sqldef/sqldef/v3/cmd/mysqldef
       - name: Run migration
         run: |
-          go install github.com/sqldef/sqldef/v3/cmd/mysqldef@v3.11.16
           DB_PORT=5004 ./migrations/entrypoint.sh ./migrations/schema.sql
       - uses: k1low/setup-tbls@f25e3d013a596865b2db90dac7ee19e9f15b5780 # v1.4.0
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,9 +19,9 @@ ENV GOOS=$TARGETOS
 ENV GOARCH=$TARGETARCH
 
 FROM --platform=$BUILDPLATFORM builder AS builder-ns-migrate
-ARG SQLDEF_VERSION=v0.16.12
+ARG SQLDEF_VERSION=v3.11.16
 RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build \
-    go install -ldflags "-s -w -X main.version=$SQLDEF_VERSION" github.com/sqldef/sqldef/cmd/mysqldef@$SQLDEF_VERSION
+    go install -ldflags "-s -w -X main.version=$SQLDEF_VERSION" github.com/sqldef/sqldef/v3/cmd/mysqldef@$SQLDEF_VERSION
 # keep output directory the same between platforms; workaround for https://github.com/golang/go/issues/57485
 RUN cp /go/bin/mysqldef /mysqldef || cp /go/bin/"$GOOS"_"$GOARCH"/mysqldef /mysqldef
 

--- a/mise.toml
+++ b/mise.toml
@@ -13,6 +13,7 @@ tbls = "1.94.5"
 buf = "1.70.0"
 "go:github.com/aarondl/sqlboiler/v4" = "4.19.7"
 "go:github.com/aarondl/sqlboiler/v4/drivers/sqlboiler-mysql" = "4.19.7"
+"go:github.com/sqldef/sqldef/v3/cmd/mysqldef" = "3.11.16"
 
 [env]
 APP_VERSION = "dev"


### PR DESCRIPTION
## なぜやるか
古くなっていたので

## やったこと
- mysqldefをv3にアップデート
- mysqldefをmise.tomlで管理
  - テスト実行時に必要

## やらなかったこと
Dockerfileとmise.tomlでのバージョン管理の統合はしていない

## 資料


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * データベース移行ツールを mysqldef v3.11.16 に統一し、移行処理の安定性と再現性を向上しました。
  * CI およびビルド環境で使用するツールのバージョンを固定しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->