### PR TITLE
fix(apiserver): ライブビルドログが無い場合をエラーではなく状態として扱う

### DIFF
--- a/pkg/infrastructure/grpc/api_service.go
+++ b/pkg/infrastructure/grpc/api_service.go
@@ -20,10 +20,11 @@ func (e publicError) Error() string { return e.public }
 func (e publicError) Unwrap() error { return e.cause }
 
 var connectCodes = map[apiserver.ErrorType]connect.Code{
-	apiserver.ErrorTypeBadRequest:    connect.CodeInvalidArgument,
-	apiserver.ErrorTypeNotFound:      connect.CodeNotFound,
-	apiserver.ErrorTypeAlreadyExists: connect.CodeAlreadyExists,
-	apiserver.ErrorTypeForbidden:     connect.CodePermissionDenied,
+	apiserver.ErrorTypeBadRequest:         connect.CodeInvalidArgument,
+	apiserver.ErrorTypeNotFound:           connect.CodeNotFound,
+	apiserver.ErrorTypeAlreadyExists:      connect.CodeAlreadyExists,
+	apiserver.ErrorTypeForbidden:          connect.CodePermissionDenied,
+	apiserver.ErrorTypeFailedPrecondition: connect.CodeFailedPrecondition,
 }
 
 func handleUseCaseError(err error) error {

--- a/pkg/infrastructure/grpc/controller_service.go
+++ b/pkg/infrastructure/grpc/controller_service.go
@@ -126,7 +126,8 @@ func (s *ControllerService) DiscoverBuildLogInstance(ctx context.Context, c *con
 		return r.Address != nil
 	})
 	if !ok {
-		return nil, oops.New("build log not available")
+		// No instance holds the log: not an error, the caller decides what that means.
+		return connect.NewResponse(&pb.AddressInfo{}), nil
 	}
 	return connect.NewResponse(neighborResult), nil
 }

--- a/pkg/infrastructure/grpc/log_interceptor.go
+++ b/pkg/infrastructure/grpc/log_interceptor.go
@@ -35,6 +35,25 @@ func logError(err error) any {
 	return err
 }
 
+// errorLevel maps err to the level the boundary logs it at.
+//
+// A client error means the server behaved correctly and rejected the request, so
+// only failures on our side reach Error. Unclassified codes are ours by default.
+func errorLevel(err error) slog.Level {
+	if errors.Is(err, context.Canceled) {
+		return slog.LevelWarn
+	}
+	switch connect.CodeOf(err) {
+	case connect.CodeCanceled, connect.CodeInvalidArgument, connect.CodeNotFound,
+		connect.CodeAlreadyExists, connect.CodePermissionDenied, connect.CodeFailedPrecondition,
+		connect.CodeAborted, connect.CodeOutOfRange, connect.CodeUnauthenticated,
+		connect.CodeResourceExhausted:
+		return slog.LevelWarn
+	default:
+		return slog.LevelError
+	}
+}
+
 func (l *LogInterceptor) WrapUnary(next connect.UnaryFunc) connect.UnaryFunc {
 	return func(ctx context.Context, request connect.AnyRequest) (connect.AnyResponse, error) {
 		// Add trace_id to context if available
@@ -63,23 +82,12 @@ func (l *LogInterceptor) WrapUnary(next connect.UnaryFunc) connect.UnaryFunc {
 			if errors.Is(err, context.Canceled) {
 				err = connect.NewError(connect.CodeCanceled, err)
 			}
-			switch connect.CodeOf(err) {
-			case connect.CodeUnknown, connect.CodeInternal, connect.CodeUnavailable, connect.CodeDeadlineExceeded, connect.CodeUnimplemented, connect.CodeDataLoss:
-				slog.ErrorContext(ctx, "unary request failed with server error",
-					"procedure", request.Spec().Procedure,
-					"duration_sec", elapsed,
-					"error", logError(err),
-					"status", connect.CodeOf(err).String(),
-				)
-
-			case connect.CodeCanceled, connect.CodeInvalidArgument, connect.CodeNotFound, connect.CodeAlreadyExists, connect.CodePermissionDenied, connect.CodeFailedPrecondition, connect.CodeAborted, connect.CodeOutOfRange, connect.CodeUnauthenticated, connect.CodeResourceExhausted:
-				slog.WarnContext(ctx, "unary request failed with client error",
-					"procedure", request.Spec().Procedure,
-					"duration_sec", elapsed,
-					"error", logError(err),
-					"status", connect.CodeOf(err).String(),
-				)
-			}
+			slog.Log(ctx, errorLevel(err), "unary request failed",
+				"procedure", request.Spec().Procedure,
+				"duration_sec", elapsed,
+				"error", logError(err),
+				"status", connect.CodeOf(err).String(),
+			)
 		}
 
 		return response, err
@@ -121,7 +129,7 @@ func (l *LogInterceptor) WrapStreamingHandler(next connect.StreamingHandlerFunc)
 				"duration_sec", elapsed,
 			)
 		} else {
-			slog.ErrorContext(ctx, "stream closed",
+			slog.Log(ctx, errorLevel(err), "stream closed",
 				"stream_id", streamID,
 				"procedure", shc.Spec().Procedure,
 				"duration_sec", elapsed,

--- a/pkg/usecase/apiserver/app_build_service.go
+++ b/pkg/usecase/apiserver/app_build_service.go
@@ -81,12 +81,25 @@ func (s *Service) GetBuildLogStream(ctx context.Context, buildID string) (<-chan
 		return nil, err
 	}
 
+	build, err := s.buildRepo.GetBuild(ctx, buildID)
+	if err != nil {
+		return nil, err
+	}
+	if build.Status.IsFinished() {
+		return nil, newError(ErrorTypeFailedPrecondition, "build already finished", nil)
+	}
+
 	addr, err := s.controller.DiscoverBuildLogInstance(ctx, buildID)
 	if err != nil {
-		return nil, oops.Wrapf(err, "discovering build log instance")
+		return nil, oops.With("build_id", buildID).Wrapf(err, "discovering build log instance")
 	}
 	if addr.Address == nil {
-		return nil, newError(ErrorTypeBadRequest, "build log instance not found", nil)
+		if build.Status == domain.BuildStatusQueued {
+			return nil, newError(ErrorTypeFailedPrecondition, "build not started yet", nil)
+		}
+		// Marked as building, yet no instance streams it: the controller holding the
+		// in-memory log restarted, so it is gone for good.
+		return nil, newError(ErrorTypeFailedPrecondition, "build log stream no longer available", nil)
 	}
 	ch, err := s.controller.StreamBuildLog(ctx, *addr.Address, buildID)
 	if err != nil {

--- a/pkg/usecase/apiserver/errors.go
+++ b/pkg/usecase/apiserver/errors.go
@@ -10,10 +10,11 @@ import (
 type ErrorType string
 
 const (
-	ErrorTypeBadRequest    ErrorType = "bad_request"
-	ErrorTypeNotFound      ErrorType = "not_found"
-	ErrorTypeAlreadyExists ErrorType = "already_exists"
-	ErrorTypeForbidden     ErrorType = "forbidden"
+	ErrorTypeBadRequest         ErrorType = "bad_request"
+	ErrorTypeNotFound           ErrorType = "not_found"
+	ErrorTypeAlreadyExists      ErrorType = "already_exists"
+	ErrorTypeForbidden          ErrorType = "forbidden"
+	ErrorTypeFailedPrecondition ErrorType = "failed_precondition"
 )
 
 // newError tags err with a business meaning and with the message the client is


### PR DESCRIPTION
## なぜやるか

本番で `GetBuildLogStream` が ERROR ログを吐いていた。

```
stream closed
Oops: discovering build log instance
  --- at /work/pkg/usecase/apiserver/app_build_service.go:86 Service.GetBuildLogStream()
  ...
内側: discovering build log instance: unknown: build log not available
```

原因は「そのビルドのライブログを持っている controller インスタンスが無い」ケースをエラーとして扱っていたこと。これは以下のいずれかで、どれもサーバのバグではなく正常系。

- ビルドが Queued でまだ払い出されていない（dashboard は `finishedAt` が無ければストリームを要求するので、キューが詰まっているときほど踏む）
- ビルド情報の取得〜ストリーム要求の間にビルドが終了した
- Building 中に controller が再起動し、インメモリのログストリームが失われた

結果として、

- 監視上は 5xx 相当の ERROR ログとしてノイズになる
- クライアントには `internal` + `internal server error` が返り、何が起きたか分からない
- `app_build_service.go` 側の「アドレスが空なら 4xx」という分岐が一度も実行されない死んだコードになっていた

## やったこと

**ライブログが無いことをエラーではなく状態として扱う**

- `ControllerService.DiscoverBuildLogInstance`: どのインスタンスも持っていない場合は空の `AddressInfo` を返す。`DiscoverBuildLogLocal` が既にやっている形に揃えた
- `ErrorTypeFailedPrecondition` を追加し、`connect.CodeFailedPrecondition` にマップ。`build_id` は正当で、拒否の理由が状態のみなので `InvalidArgument` ではなくこちらを使っている
- `GetBuildLogStream` で `build.Status` を見て 3 ケースを出し分け。クライアントは再試行が有効かどうか判断できる

| build.Status | 返るもの |
| --- | --- |
| 終了済み | `failed_precondition` / `build already finished` |
| Queued | `failed_precondition` / `build not started yet` |
| Building だがインスタンス無し | `failed_precondition` / `build log stream no longer available` |

- discovery RPC が本当に失敗した場合（neighbor 到達不能など）は従来通り Internal + ERROR で残す。この経路のログには `build_id` が載っていなくて DB と突き合わせられなかったので `oops.With("build_id", ...)` を追加した

**LogInterceptor のレベル分類**

- ストリーム側は code を見ずに `err != nil` だけで ERROR を出していたため、上記だけではログノイズが止まらない。unary 側にあった分類を `errorLevel()` として切り出して両方から使うようにした
- 併せて、unary の switch に `default` が無く**未分類の code だとログが 1 行も出ない**穴も塞いだ

⚠️ unary のログメッセージを `"unary request failed with server error"` / `"...with client error"` の 2 種類から `"unary request failed"` に一本化している（レベルと `status` フィールドで区別できるため）。旧メッセージで grep しているアラートやダッシュボードがあれば追従が必要。分けたままにしたければ戻せます。

### 変更後のログ

Queued のビルドを開いた場合:

```
WARN stream closed procedure=/neoshowcase.protobuf.APIService/GetBuildLogStream
     status=failed_precondition error="build not started yet" duration_sec=0.0xx
```

## やらなかったこと

**dashboard の改善（別 PR 予定）**

このPRではサーバが理由を返せるようになっただけで、ユーザーの見た目は変わらない（空のログ欄のまま）。`BuildLog.tsx` は構造上ストリームのエラーを扱えていない:

- `getBuildLogStream()` は AsyncIterable を同期的に返すので `createResource` は常に成功扱いになり、resource の `error` 状態が使われない。実エラーは for-await 内で `console.trace` されるだけ
- resource のキーが `!finished && buildID` なので Queued → Building でも再購読されない（リロードするまで空のまま）
- エラー時に `props.refetch()` が呼ばれず、逆にアンマウント時には呼ばれている

方針としては、ストリームを `createResource` から外して bounded backoff のリトライループにし、`failed_precondition` を「再試行可」の合図として扱う。表示文言はサーバのメッセージ文字列ではなく dashboard が既に持っている `build.status` から決める（サーバとクライアントを文字列で結合しないため）。

**その他**

- `GetBuildLog` の逆ケース（`ErrorTypeBadRequest` / `build not finished`）はそのまま。揃えるなら別途
- `isBuildOwner` が `handleRepoError` を通しておらず、存在しない build ID が Internal になる問題も別件として残した
- `ContainerLog.tsx` も同じ「console.trace するだけ」のパターンだが、あちらは「ログが無い」が正常系ではないのでスコープ外

## 資料

- `docs/guidelines/error-handling.md`
- 状態依存の拒否に `FAILED_PRECONDITION` を使う根拠: [gRPC の code 定義](https://grpc.github.io/grpc/core/md_doc_statuscodes.html)（`INVALID_ARGUMENT` は引数がシステム状態と無関係に不正な場合、`FAILED_PRECONDITION` は状態のため拒否＝状態が変われば再試行可）
- この経路が入ったのは 98b15836 "feat: Shard controller"

## 動作確認

- `go vet` / `golangci-lint run`（`pkg/infrastructure/grpc/...`, `pkg/usecase/apiserver/...`）: 各コミット時点で通過
- `go test ./pkg/usecase/apiserver/` は**未実行**。手元で Docker を起動できておらず、testcontainers が init で落ちるため。CI での結果を確認したい

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * ビルドログ取得時のエラー内容を改善し、ビルドの状態やログの利用可否に応じて、より適切な情報を返すようになりました。
  * 完了済みビルドのログストリーム取得を適切に拒否するようになりました。
  * ビルドログがまだ準備中の場合は、不要なエラーを返さず空の情報を返すようになりました。
  * 通信エラーの分類とログ記録を改善し、原因を確認しやすくしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->