### PR TITLE
Go 1.27

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.26-alpine@sha256:f23e8b227fb4493eabe03bede4d5a32d04092da71962f1fb79b5f7d1e6c2a17f AS builder
+FROM --platform=$BUILDPLATFORM golang:1.27-alpine@sha256:4c9fe60190a2a3350ddc51de80d0224b8a6698d12bdfc999fee45ea9d6c46dbc AS builder
 
 WORKDIR /work
 ENV CGO_ENABLED=0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/traPtitech/neoshowcase
 
-go 1.26.3
+go 1.27.0
 
 require (
 	code.gitea.io/sdk/gitea v0.25.1

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,5 @@
 [tools]
-go = "1.26"
+go = "1.27"
 node = "24"
 pnpm = "10.34.5"
 
@@ -8,7 +8,7 @@ kubectl = "1.36.3"
 kustomize = "5.8.1"
 helm = "4.2.3"
 
-golangci-lint = "2.12.2"
+golangci-lint = "2.13.1"
 tbls = "1.95.0"
 buf = "1.72.0"
 "go:github.com/aarondl/sqlboiler/v4" = "4.19.7"

--- a/pkg/domain/app_test.go
+++ b/pkg/domain/app_test.go
@@ -30,11 +30,9 @@ func TestApplicationConfig_Validate(t *testing.T) {
 			deployType: DeployTypeRuntime,
 			config: ApplicationConfig{
 				BuildConfig: &BuildConfigRuntimeCmd{
-					RuntimeConfig: RuntimeConfig{
-						Entrypoint: "./main",
-					},
-					BaseImage: "golang:1.20",
-					BuildCmd:  "go build -o main",
+					Entrypoint: "./main",
+					BaseImage:  "golang:1.20",
+					BuildCmd:   "go build -o main",
 				},
 			},
 			wantErr: false,
@@ -44,11 +42,9 @@ func TestApplicationConfig_Validate(t *testing.T) {
 			deployType: DeployTypeRuntime,
 			config: ApplicationConfig{
 				BuildConfig: &BuildConfigRuntimeCmd{
-					RuntimeConfig: RuntimeConfig{
-						Entrypoint: "python3 main.py",
-					},
-					BaseImage: "python:3",
-					BuildCmd:  "",
+					Entrypoint: "python3 main.py",
+					BaseImage:  "python:3",
+					BuildCmd:   "",
 				},
 			},
 			wantErr: false,
@@ -58,11 +54,9 @@ func TestApplicationConfig_Validate(t *testing.T) {
 			deployType: DeployTypeRuntime,
 			config: ApplicationConfig{
 				BuildConfig: &BuildConfigRuntimeCmd{
-					RuntimeConfig: RuntimeConfig{
-						Entrypoint: "./my-binary",
-					},
-					BaseImage: "",
-					BuildCmd:  "",
+					Entrypoint: "./my-binary",
+					BaseImage:  "",
+					BuildCmd:   "",
 				},
 			},
 			wantErr: false,
@@ -72,11 +66,9 @@ func TestApplicationConfig_Validate(t *testing.T) {
 			deployType: DeployTypeRuntime,
 			config: ApplicationConfig{
 				BuildConfig: &BuildConfigRuntimeCmd{
-					RuntimeConfig: RuntimeConfig{
-						Entrypoint: "",
-					},
-					BaseImage: "php:7-apache",
-					BuildCmd:  "",
+					Entrypoint: "",
+					BaseImage:  "php:7-apache",
+					BuildCmd:   "",
 				},
 			},
 			wantErr: false,
@@ -86,11 +78,9 @@ func TestApplicationConfig_Validate(t *testing.T) {
 			deployType: DeployTypeRuntime,
 			config: ApplicationConfig{
 				BuildConfig: &BuildConfigRuntimeCmd{
-					RuntimeConfig: RuntimeConfig{
-						Entrypoint: "",
-					},
-					BaseImage: "",
-					BuildCmd:  "",
+					Entrypoint: "",
+					BaseImage:  "",
+					BuildCmd:   "",
 				},
 			},
 			wantErr: true,
@@ -100,10 +90,8 @@ func TestApplicationConfig_Validate(t *testing.T) {
 			deployType: DeployTypeStatic,
 			config: ApplicationConfig{
 				BuildConfig: &BuildConfigStaticBuildpack{
-					StaticConfig: StaticConfig{
-						ArtifactPath: "./dist",
-					},
-					Context: "",
+					ArtifactPath: "./dist",
+					Context:      "",
 				},
 			},
 			wantErr: false,
@@ -113,10 +101,8 @@ func TestApplicationConfig_Validate(t *testing.T) {
 			deployType: DeployTypeStatic,
 			config: ApplicationConfig{
 				BuildConfig: &BuildConfigStaticBuildpack{
-					StaticConfig: StaticConfig{
-						ArtifactPath: "",
-					},
-					Context: "",
+					ArtifactPath: "",
+					Context:      "",
 				},
 			},
 			wantErr: true,
@@ -126,9 +112,7 @@ func TestApplicationConfig_Validate(t *testing.T) {
 			deployType: DeployTypeStatic,
 			config: ApplicationConfig{
 				BuildConfig: &BuildConfigStaticDockerfile{
-					StaticConfig: StaticConfig{
-						ArtifactPath: "./dist",
-					},
+					ArtifactPath:   "./dist",
 					DockerfileName: "Dockerfile",
 				},
 			},
@@ -139,9 +123,7 @@ func TestApplicationConfig_Validate(t *testing.T) {
 			deployType: DeployTypeStatic,
 			config: ApplicationConfig{
 				BuildConfig: &BuildConfigStaticDockerfile{
-					StaticConfig: StaticConfig{
-						ArtifactPath: "",
-					},
+					ArtifactPath:   "",
 					DockerfileName: "Dockerfile",
 				},
 			},
@@ -152,11 +134,9 @@ func TestApplicationConfig_Validate(t *testing.T) {
 			deployType: DeployTypeStatic,
 			config: ApplicationConfig{
 				BuildConfig: &BuildConfigStaticCmd{
-					StaticConfig: StaticConfig{
-						ArtifactPath: "./dist",
-					},
-					BaseImage: "node:18",
-					BuildCmd:  "yarn build",
+					ArtifactPath: "./dist",
+					BaseImage:    "node:18",
+					BuildCmd:     "yarn build",
 				},
 			},
 			wantErr: false,
@@ -166,11 +146,9 @@ func TestApplicationConfig_Validate(t *testing.T) {
 			deployType: DeployTypeStatic,
 			config: ApplicationConfig{
 				BuildConfig: &BuildConfigStaticCmd{
-					StaticConfig: StaticConfig{
-						ArtifactPath: "./dist",
-					},
-					BaseImage: "alpine:latest",
-					BuildCmd:  "",
+					ArtifactPath: "./dist",
+					BaseImage:    "alpine:latest",
+					BuildCmd:     "",
 				},
 			},
 			wantErr: false,
@@ -180,11 +158,9 @@ func TestApplicationConfig_Validate(t *testing.T) {
 			deployType: DeployTypeStatic,
 			config: ApplicationConfig{
 				BuildConfig: &BuildConfigStaticCmd{
-					StaticConfig: StaticConfig{
-						ArtifactPath: "./dist",
-					},
-					BaseImage: "",
-					BuildCmd:  "",
+					ArtifactPath: "./dist",
+					BaseImage:    "",
+					BuildCmd:     "",
 				},
 			},
 			wantErr: false,
@@ -194,11 +170,9 @@ func TestApplicationConfig_Validate(t *testing.T) {
 			deployType: DeployTypeStatic,
 			config: ApplicationConfig{
 				BuildConfig: &BuildConfigStaticCmd{
-					StaticConfig: StaticConfig{
-						ArtifactPath: "",
-					},
-					BaseImage: "",
-					BuildCmd:  "",
+					ArtifactPath: "",
+					BaseImage:    "",
+					BuildCmd:     "",
 				},
 			},
 			wantErr: true,

--- a/pkg/infrastructure/backend/dockerimpl/backend_test.go
+++ b/pkg/infrastructure/backend/dockerimpl/backend_test.go
@@ -25,9 +25,10 @@ func prepareManager(t *testing.T) (*Backend, *client.Client) {
 		t.Fatal(err)
 	}
 
-	config := Config{}
-	config.ConfDir = "../../../../.local-dev/traefik"
-	config.Network = "neoshowcase_apps"
+	config := Config{
+		ConfDir: "../../../../.local-dev/traefik",
+		Network: "neoshowcase_apps",
+	}
 	config.Routing.Type = routingTypeTraefik
 	m, err := NewDockerBackend(c, config, builder.ImageConfig{})
 	require.NoError(t, err)

--- a/pkg/infrastructure/backend/k8simpl/config.go
+++ b/pkg/infrastructure/backend/k8simpl/config.go
@@ -305,7 +305,7 @@ func (c *Config) serviceIPFamilyPolicy() *v1.IPFamilyPolicy {
 	if c.Service.IPFamilyPolicy == "" {
 		return nil
 	}
-	return lo.ToPtr(c.Service.IPFamilyPolicy)
+	return new(c.Service.IPFamilyPolicy)
 }
 
 var tolerationOperatorMapper = mapper.MustNewValueMapper(map[string]v1.TolerationOperator{

--- a/pkg/infrastructure/backend/k8simpl/helper.go
+++ b/pkg/infrastructure/backend/k8simpl/helper.go
@@ -114,7 +114,7 @@ func syncResources[T apiResource](ctx context.Context, cluster *discovery.Cluste
 		if err != nil {
 			return err
 		}
-		_, err = s.Patch(ctx, rc.GetName(), types.ApplyPatchType, b, metav1.PatchOptions{Force: lo.ToPtr(true), FieldManager: fieldManager})
+		_, err = s.Patch(ctx, rc.GetName(), types.ApplyPatchType, b, metav1.PatchOptions{Force: new(true), FieldManager: fieldManager})
 		if err != nil {
 			slog.WarnContext(ctx, "failed to patch", "resource", rcName+"/"+rc.GetName(), "error", err)
 			continue // skip this resource if patch fails
@@ -191,7 +191,7 @@ func syncResourcesWithReplace[T apiResource](
 		}
 		// For StatefulSets, delete the resource before applying again - StatefulSet has many immutable fields
 		// Example: StatefulSet.apps "nsapp-add177a080c4c78936e192" is invalid: spec: Forbidden: updates to statefulset spec for fields other than 'replicas', 'ordinals', 'template', 'updateStrategy', 'revisionHistoryLimit', 'persistentVolumeClaimRetentionPolicy' and 'minReadySeconds' are forbidden
-		_, err = s.Patch(ctx, rc.GetName(), types.ApplyPatchType, b, metav1.PatchOptions{Force: lo.ToPtr(true), FieldManager: fieldManager})
+		_, err = s.Patch(ctx, rc.GetName(), types.ApplyPatchType, b, metav1.PatchOptions{Force: new(true), FieldManager: fieldManager})
 		if err != nil {
 			// Try to replace the resource if patch fails.
 			// This may take a while, so run it in a goroutine.
@@ -228,7 +228,7 @@ func pruneResources[T apiResource](ctx context.Context, cluster *discovery.Clust
 		if ok && cluster.AssignedShardIndex(appID) != cluster.MyShardIndex() {
 			continue
 		}
-		err := s.Delete(ctx, rc.GetName(), metav1.DeleteOptions{PropagationPolicy: lo.ToPtr(metav1.DeletePropagationForeground)})
+		err := s.Delete(ctx, rc.GetName(), metav1.DeleteOptions{PropagationPolicy: new(metav1.DeletePropagationForeground)})
 		if err != nil {
 			slog.WarnContext(ctx, "failed to delete resource", "resource", rcName+"/"+rc.GetName(), "error", err)
 			continue // skip this resource if delete fails
@@ -246,9 +246,9 @@ func replaceResource[T apiResource](
 	notifier *deletionNotifier,
 ) error {
 	ch := notifier.add(rc.GetName())
-	err := s.Delete(ctx, rc.GetName(), metav1.DeleteOptions{PropagationPolicy: lo.ToPtr(metav1.DeletePropagationForeground)})
+	err := s.Delete(ctx, rc.GetName(), metav1.DeleteOptions{PropagationPolicy: new(metav1.DeletePropagationForeground)})
 	if apierrors.IsNotFound(err) {
-		_, err = s.Patch(ctx, rc.GetName(), types.ApplyPatchType, data, metav1.PatchOptions{Force: lo.ToPtr(true), FieldManager: fieldManager})
+		_, err = s.Patch(ctx, rc.GetName(), types.ApplyPatchType, data, metav1.PatchOptions{Force: new(true), FieldManager: fieldManager})
 		return err
 	}
 
@@ -263,6 +263,6 @@ func replaceResource[T apiResource](
 		return ctx.Err()
 	}
 
-	_, err = s.Patch(ctx, rc.GetName(), types.ApplyPatchType, data, metav1.PatchOptions{Force: lo.ToPtr(true), FieldManager: fieldManager})
+	_, err = s.Patch(ctx, rc.GetName(), types.ApplyPatchType, data, metav1.PatchOptions{Force: new(true), FieldManager: fieldManager})
 	return err
 }

--- a/pkg/infrastructure/backend/k8simpl/ingress.go
+++ b/pkg/infrastructure/backend/k8simpl/ingress.go
@@ -21,10 +21,8 @@ import (
 
 func (b *Backend) stripMiddleware(app *domain.Application, website *domain.Website) *traefikv1alpha1.Middleware {
 	return &traefikv1alpha1.Middleware{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Middleware",
-			APIVersion: "traefik.io/v1alpha1",
-		},
+		Kind:       "Middleware",
+		APIVersion: "traefik.io/v1alpha1",
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      stripMiddlewareName(website),
 			Namespace: b.config.Namespace,
@@ -40,10 +38,8 @@ func (b *Backend) stripMiddleware(app *domain.Application, website *domain.Websi
 
 func (b *Backend) certificate(targetDomain string) *certmanagerv1.Certificate {
 	return &certmanagerv1.Certificate{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "cert-manager.io/v1",
-			Kind:       "Certificate",
-		},
+		APIVersion: "cert-manager.io/v1",
+		Kind:       "Certificate",
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      certificateName(targetDomain),
 			Namespace: b.config.Namespace,
@@ -108,10 +104,8 @@ func (b *Backend) jsonSablierConfig(app *domain.Application) []byte {
 func (b *Backend) sablierMiddleware(app *domain.Application) *traefikv1alpha1.Middleware {
 	configData := b.jsonSablierConfig(app)
 	return &traefikv1alpha1.Middleware{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Middleware",
-			APIVersion: "traefik.io/v1alpha1",
-		},
+		Kind:       "Middleware",
+		APIVersion: "traefik.io/v1alpha1",
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      sablierMiddlewareName(app.ID),
 			Namespace: b.config.Namespace,
@@ -199,10 +193,8 @@ func (b *Backend) ingressRoute(
 	}
 
 	ingressRoute := &traefikv1alpha1.IngressRoute{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "IngressRoute",
-			APIVersion: "traefik.io/v1alpha1",
-		},
+		Kind:       "IngressRoute",
+		APIVersion: "traefik.io/v1alpha1",
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      serviceName(website),
 			Namespace: b.config.Namespace,

--- a/pkg/infrastructure/backend/k8simpl/synchronize_runtime.go
+++ b/pkg/infrastructure/backend/k8simpl/synchronize_runtime.go
@@ -28,10 +28,8 @@ func (b *Backend) runtimeSpec(app *domain.RuntimeDesiredState) (*appsv1.Stateful
 	var envs []v1.EnvVar
 	if len(app.Envs) > 0 {
 		secret = &v1.Secret{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       "Secret",
-				APIVersion: "v1",
-			},
+			Kind:       "Secret",
+			APIVersion: "v1",
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      deploymentName(app.App.ID),
 				Namespace: b.config.Namespace,
@@ -45,8 +43,8 @@ func (b *Backend) runtimeSpec(app *domain.RuntimeDesiredState) (*appsv1.Stateful
 
 		envs = lo.MapToSlice(app.Envs, func(key string, value string) v1.EnvVar {
 			return v1.EnvVar{Name: key, ValueFrom: &v1.EnvVarSource{SecretKeyRef: &v1.SecretKeySelector{
-				LocalObjectReference: v1.LocalObjectReference{Name: secret.Name},
-				Key:                  key,
+				Name: secret.Name,
+				Key:  key,
 			}}}
 		})
 		// make sure computed result is stable
@@ -94,10 +92,8 @@ func (b *Backend) runtimeSpec(app *domain.RuntimeDesiredState) (*appsv1.Stateful
 	}
 
 	ss := &appsv1.StatefulSet{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "StatefulSet",
-			APIVersion: "apps/v1",
-		},
+		Kind:       "StatefulSet",
+		APIVersion: "apps/v1",
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      deploymentName(app.App.ID),
 			Namespace: b.config.Namespace,
@@ -119,15 +115,15 @@ func (b *Backend) runtimeSpec(app *domain.RuntimeDesiredState) (*appsv1.Stateful
 					},
 				},
 				Spec: v1.PodSpec{
-					AutomountServiceAccountToken: lo.ToPtr(false),
-					EnableServiceLinks:           lo.ToPtr(false),
+					AutomountServiceAccountToken: new(false),
+					EnableServiceLinks:           new(false),
 					Containers:                   []v1.Container{cont},
 					NodeSelector:                 b.config.podSchedulingNodeSelector(app.App.ID),
 					Tolerations:                  b.config.podSchedulingTolerations(),
 					TopologySpreadConstraints:    b.config.podSpreadConstraints(),
 				},
 			},
-			RevisionHistoryLimit: lo.ToPtr(int32(0)),
+			RevisionHistoryLimit: new(int32(0)),
 		},
 	}
 
@@ -138,10 +134,8 @@ func (b *Backend) runtimeSpec(app *domain.RuntimeDesiredState) (*appsv1.Stateful
 	var svc *v1.Service
 	if len(cont.Ports) > 0 {
 		svc = &v1.Service{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       "Service",
-				APIVersion: "v1",
-			},
+			Kind:       "Service",
+			APIVersion: "v1",
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      deploymentName(app.App.ID),
 				Namespace: b.config.Namespace,
@@ -169,13 +163,11 @@ func (b *Backend) runtimeSpec(app *domain.RuntimeDesiredState) (*appsv1.Stateful
 
 func (b *Backend) runtimeServiceRef(app *domain.Application, website *domain.Website) []traefikv1alpha1.Service {
 	return []traefikv1alpha1.Service{{
-		LoadBalancerSpec: traefikv1alpha1.LoadBalancerSpec{
-			Name:      deploymentName(app.ID),
-			Kind:      "Service",
-			Namespace: b.config.Namespace,
-			Port:      intstr.FromInt(website.HTTPPort),
-			Scheme:    lo.Ternary(website.H2C, "h2c", "http"),
-		},
+		Name:      deploymentName(app.ID),
+		Kind:      "Service",
+		Namespace: b.config.Namespace,
+		Port:      intstr.FromInt(website.HTTPPort),
+		Scheme:    lo.Ternary(website.H2C, "h2c", "http"),
 	}}
 }
 
@@ -186,10 +178,8 @@ var protocolMapper = mapper.MustNewValueMapper(map[domain.PortPublicationProtoco
 
 func (b *Backend) runtimePortService(app *domain.Application, port *domain.PortPublication) *v1.Service {
 	return &v1.Service{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Service",
-			APIVersion: "v1",
-		},
+		Kind:       "Service",
+		APIVersion: "v1",
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      portServiceName(port),
 			Namespace: b.config.Namespace,

--- a/pkg/infrastructure/backend/k8simpl/synchronize_ss.go
+++ b/pkg/infrastructure/backend/k8simpl/synchronize_ss.go
@@ -12,22 +12,18 @@ import (
 
 func (b *Backend) ssServiceRef() []traefikv1alpha1.Service {
 	return []traefikv1alpha1.Service{{
-		LoadBalancerSpec: traefikv1alpha1.LoadBalancerSpec{
-			Name:      b.config.SS.Name,
-			Kind:      b.config.SS.Kind,
-			Namespace: b.config.SS.Namespace,
-			Port:      intstr.FromInt(b.config.SS.Port),
-			Scheme:    b.config.SS.Scheme,
-		},
+		Name:      b.config.SS.Name,
+		Kind:      b.config.SS.Kind,
+		Namespace: b.config.SS.Namespace,
+		Port:      intstr.FromInt(b.config.SS.Port),
+		Scheme:    b.config.SS.Scheme,
 	}}
 }
 
 func (b *Backend) ssHeaderMiddleware(ss *domain.StaticSite) *traefikv1alpha1.Middleware {
 	return &traefikv1alpha1.Middleware{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Middleware",
-			APIVersion: "traefik.io/v1alpha1",
-		},
+		Kind:       "Middleware",
+		APIVersion: "traefik.io/v1alpha1",
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      ssHeaderMiddlewareName(ss),
 			Namespace: b.config.Namespace,

--- a/pkg/infrastructure/grpc/api_app_service.go
+++ b/pkg/infrastructure/grpc/api_app_service.go
@@ -86,10 +86,10 @@ func (s *APIService) UpdateApplication(ctx context.Context, req *connect.Request
 		Name:             optional.FromPtr(msg.Name),
 		RefName:          optional.FromPtr(msg.RefName),
 		UpdatedAt:        optional.From(time.Now()),
-		Config:           optional.Map(optional.FromNonZero(msg.Config), pbconvert.FromPBApplicationConfig),
-		Websites:         optional.Map(optional.FromNonZero(msg.Websites), pbconvert.FromPBUpdateWebsites),
-		PortPublications: optional.Map(optional.FromNonZero(msg.PortPublications), pbconvert.FromPBUpdatePorts),
-		OwnerIDs:         optional.Map(optional.FromNonZero(msg.OwnerIds), pbconvert.FromPBUpdateOwners),
+		Config:           optional.FromNonZero(msg.Config).Map(pbconvert.FromPBApplicationConfig),
+		Websites:         optional.FromNonZero(msg.Websites).Map(pbconvert.FromPBUpdateWebsites),
+		PortPublications: optional.FromNonZero(msg.PortPublications).Map(pbconvert.FromPBUpdatePorts),
+		OwnerIDs:         optional.FromNonZero(msg.OwnerIds).Map(pbconvert.FromPBUpdateOwners),
 	})
 	if err != nil {
 		return nil, handleUseCaseError(err)

--- a/pkg/infrastructure/grpc/api_repository_service.go
+++ b/pkg/infrastructure/grpc/api_repository_service.go
@@ -81,8 +81,8 @@ func (s *APIService) UpdateRepository(ctx context.Context, req *connect.Request[
 	args := &apiserver.UpdateRepositoryArgs{
 		Name:     optional.FromPtr(msg.Name),
 		URL:      optional.FromPtr(msg.Url),
-		Auth:     optional.Map(optional.FromNonZero(msg.Auth), pbconvert.FromPBRepositoryAuth),
-		OwnerIDs: optional.Map(optional.FromNonZero(msg.OwnerIds), pbconvert.FromPBUpdateRepositoryOwners),
+		Auth:     optional.FromNonZero(msg.Auth).Map(pbconvert.FromPBRepositoryAuth),
+		OwnerIDs: optional.FromNonZero(msg.OwnerIds).Map(pbconvert.FromPBUpdateRepositoryOwners),
 	}
 	err := s.svc.UpdateRepository(ctx, msg.Id, args)
 	if err != nil {

--- a/pkg/infrastructure/grpc/buildpack_helper_service.go
+++ b/pkg/infrastructure/grpc/buildpack_helper_service.go
@@ -81,8 +81,7 @@ func (b *BuildpackHelperService) Exec(ctx context.Context, req *connect.Request[
 	}
 
 	// Check exit code
-	var exitError *exec.ExitError
-	if errors.As(cmdErr, &exitError) {
+	if exitError, ok := errors.AsType[*exec.ExitError](cmdErr); ok {
 		return st.Send(&pb.HelperExecResponse{
 			Type: pb.HelperExecResponse_EXIT_CODE,
 			Body: &pb.HelperExecResponse_ExitCode{ExitCode: int32(exitError.ExitCode())},

--- a/pkg/usecase/apiserver/app_service_test.go
+++ b/pkg/usecase/apiserver/app_service_test.go
@@ -91,10 +91,8 @@ func TestCreateApplication(t *testing.T) {
 				DeployType:   domain.DeployTypeRuntime,
 				Config: domain.ApplicationConfig{
 					BuildConfig: &domain.BuildConfigRuntimeBuildpack{
-						RuntimeConfig: domain.RuntimeConfig{
-							UseMariaDB: tt.useMariaDB,
-						},
-						Context: ".",
+						UseMariaDB: tt.useMariaDB,
+						Context:    ".",
 					},
 				},
 				Websites: []*domain.Website{
@@ -217,10 +215,8 @@ func TestCreateApplication_DuplicateURL(t *testing.T) {
 				DeployType:   domain.DeployTypeRuntime,
 				Config: domain.ApplicationConfig{
 					BuildConfig: &domain.BuildConfigRuntimeBuildpack{
-						RuntimeConfig: domain.RuntimeConfig{
-							UseMariaDB: false,
-						},
-						Context: ".",
+						UseMariaDB: false,
+						Context:    ".",
 					},
 				},
 				Websites: []*domain.Website{
@@ -253,10 +249,8 @@ func TestCreateApplication_DuplicateURL(t *testing.T) {
 				DeployType:   domain.DeployTypeRuntime,
 				Config: domain.ApplicationConfig{
 					BuildConfig: &domain.BuildConfigRuntimeBuildpack{
-						RuntimeConfig: domain.RuntimeConfig{
-							UseMariaDB: false,
-						},
-						Context: ".",
+						UseMariaDB: false,
+						Context:    ".",
 					},
 				},
 				Websites: []*domain.Website{
@@ -372,10 +366,8 @@ func TestDeleteApplication(t *testing.T) {
 				DeployType:   domain.DeployTypeRuntime,
 				Config: domain.ApplicationConfig{
 					BuildConfig: &domain.BuildConfigRuntimeBuildpack{
-						RuntimeConfig: domain.RuntimeConfig{
-							UseMariaDB: tt.useMariaDB,
-						},
-						Context: ".",
+						UseMariaDB: tt.useMariaDB,
+						Context:    ".",
 					},
 				},
 				Websites: []*domain.Website{
@@ -473,10 +465,8 @@ func TestUpdateApplication(t *testing.T) {
 				DeployType:   domain.DeployTypeRuntime,
 				Config: domain.ApplicationConfig{
 					BuildConfig: &domain.BuildConfigRuntimeBuildpack{
-						RuntimeConfig: domain.RuntimeConfig{
-							UseMariaDB: false,
-						},
-						Context: ".",
+						UseMariaDB: false,
+						Context:    ".",
 					},
 				},
 				Websites: []*domain.Website{
@@ -588,10 +578,8 @@ func TestUpdateApplication_UpdateMariaDBConfigIsNotAllowed(t *testing.T) {
 				Commit:       domain.EmptyCommit,
 				Config: domain.ApplicationConfig{
 					BuildConfig: &domain.BuildConfigRuntimeBuildpack{
-						RuntimeConfig: domain.RuntimeConfig{
-							UseMariaDB: tt.initialUseMariaDB,
-						},
-						Context: ".",
+						UseMariaDB: tt.initialUseMariaDB,
+						Context:    ".",
 					},
 				},
 				Websites: []*domain.Website{
@@ -615,9 +603,7 @@ func TestUpdateApplication_UpdateMariaDBConfigIsNotAllowed(t *testing.T) {
 			err = svc.UpdateApplication(ctx, app.ID, &domain.UpdateApplicationArgs{
 				Config: optional.From(domain.ApplicationConfig{
 					BuildConfig: &domain.BuildConfigRuntimeBuildpack{
-						RuntimeConfig: domain.RuntimeConfig{
-							UseMariaDB: tt.updatedUseMariaDB,
-						},
+						UseMariaDB: tt.updatedUseMariaDB,
 					},
 				}),
 			})

--- a/pkg/usecase/apiserver/repository_service.go
+++ b/pkg/usecase/apiserver/repository_service.go
@@ -53,7 +53,7 @@ func (s *Service) convertRepositoryAuth(a CreateRepositoryAuth) (domain.Reposito
 }
 
 func (s *Service) CreateRepository(ctx context.Context, name, url string, auth optional.Of[CreateRepositoryAuth]) (*domain.Repository, error) {
-	dAuth, err := optional.MapErr(auth, s.convertRepositoryAuth)
+	dAuth, err := auth.MapErr(s.convertRepositoryAuth)
 	if err != nil {
 		return nil, err
 	}
@@ -125,8 +125,8 @@ type UpdateRepositoryArgs struct {
 }
 
 func (s *Service) convertUpdateRepositoryArgs(a *UpdateRepositoryArgs) (*domain.UpdateRepositoryArgs, error) {
-	dAuth, err := optional.MapErr(a.Auth, func(t optional.Of[CreateRepositoryAuth]) (optional.Of[domain.RepositoryAuth], error) {
-		return optional.MapErr(t, s.convertRepositoryAuth)
+	dAuth, err := a.Auth.MapErr(func(t optional.Of[CreateRepositoryAuth]) (optional.Of[domain.RepositoryAuth], error) {
+		return t.MapErr(s.convertRepositoryAuth)
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/usecase/gitea-integration/sync.go
+++ b/pkg/usecase/gitea-integration/sync.go
@@ -44,7 +44,7 @@ func (i *Integration) sync(ctx context.Context) error {
 	slog.InfoContext(ctx, "Retrieving users from Gitea")
 	giteaUsers, err := listAllPages(func(page, perPage int) ([]*gitea.User, error) {
 		users, _, err := i.c.AdminListUsers(gitea.AdminListUsersOptions{
-			ListOptions: gitea.ListOptions{Page: page, PageSize: perPage},
+			Page: page, PageSize: perPage,
 		})
 		return users, err
 	})
@@ -65,12 +65,10 @@ func (i *Integration) sync(ctx context.Context) error {
 	slog.InfoContext(ctx, "Retrieving repositories from Gitea")
 	repos, err := listAllPages(func(page, perPage int) ([]*gitea.Repository, error) {
 		repos, _, err := i.c.SearchRepos(gitea.SearchRepoOptions{
-			ListOptions: gitea.ListOptions{
-				Page:     page,
-				PageSize: perPage,
-			},
-			Sort:  "created",
-			Order: "desc",
+			Page:     page,
+			PageSize: perPage,
+			Sort:     "created",
+			Order:    "desc",
 		})
 		return repos, err
 	})
@@ -83,7 +81,6 @@ func (i *Integration) sync(ctx context.Context) error {
 	var eg errgroup.Group
 	eg.SetLimit(i.concurrency)
 	for _, repo := range repos {
-		repo := repo
 		eg.Go(func() error {
 			// Get users with write access
 			members, _, err := i.c.GetAssignees(repo.Owner.UserName, repo.Name)

--- a/pkg/util/optional/of.go
+++ b/pkg/util/optional/of.go
@@ -27,14 +27,14 @@ func (o Of[T]) ValueOrZero() T {
 	return t
 }
 
-func Map[T, U any](o Of[T], mapper func(T) U) Of[U] {
+func (o Of[T]) Map[U any](mapper func(T) U) Of[U] {
 	if o.Valid {
 		return From(mapper(o.V))
 	}
 	return None[U]()
 }
 
-func MapErr[T, U any](o Of[T], mapper func(T) (U, error)) (Of[U], error) {
+func (o Of[T]) MapErr[U any](mapper func(T) (U, error)) (Of[U], error) {
 	if o.Valid {
 		v, err := mapper(o.V)
 		return From(v), err

--- a/pkg/util/optional/of_test.go
+++ b/pkg/util/optional/of_test.go
@@ -35,7 +35,7 @@ func TestMap(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := Map(tt.o, tt.mapper); !reflect.DeepEqual(got, tt.want) {
+			if got := tt.o.Map(tt.mapper); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("Map() = %v, want %v", got, tt.want)
 			}
 		})


### PR DESCRIPTION
## なぜやるか
Go言語の最新機能を楽しむため

## やったこと
Goのバージョンを1.27に上げる

## 資料
https://go.dev/doc/go1.27


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善**
  - Go 1.27へ更新し、ビルド環境と開発ツールを最新化しました。
  - Kubernetes関連リソースの生成処理を現行仕様に対応させ、互換性と保守性を向上しました。
  - オプショナル値の変換処理を整理し、コードの一貫性を高めました。
  - Gitea連携におけるページネーション処理を更新しました。

- **テスト**
  - アプリケーション設定の変更に合わせてテストを更新し、ランタイム・静的ビルドの検証範囲を維持しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->