### PR TITLE
fix(dashboard/Dockerfile): copy pnpm-workspace.yaml before installing deps

### DIFF
--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -5,7 +5,7 @@ ENV PATH="$PNPM_HOME:$PATH"
 
 WORKDIR /work
 
-COPY package.json pnpm-lock.yaml ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 RUN corepack enable
 RUN --mount=type=cache,target=/pnpm/store \
     pnpm install --frozen-lockfile


### PR DESCRIPTION
## なぜやるか
これをしないとdockerコンテナのpnpm devが起動しない

## やったこと
タイトル通り

## やらなかったこと

## 資料


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * Dockerビルド時にワークスペース設定ファイルを依存関係の対象として扱うよう改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->