### PR TITLE
chore(dashboard): ignore the .pnpm-store fallback directory

### DIFF
--- a/dashboard/.dockerignore
+++ b/dashboard/.dockerignore
@@ -1,5 +1,6 @@
 dist
 node_modules
+.pnpm-store
 
 .dockerignore
 .gitignore

--- a/dashboard/.gitignore
+++ b/dashboard/.gitignore
@@ -1,4 +1,5 @@
 node_modules
 dist
+.pnpm-store
 
 !.vscode


### PR DESCRIPTION
## なぜやるか
コンテナの中で`pnpm install`を実行すると`.pnpm-store`ディレクトリが作られる
gitで管理したくない + docker buildが遅くなるので.gitignoreと.dockerignoreに追加

## やったこと
タイトル通り

## やらなかったこと

## 資料

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - 開発環境で生成されるパッケージストア関連ファイルが、不要な追跡・Dockerビルド対象から除外されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->