### PR TITLE
ConflictsWith の引数を一つにした

### DIFF
--- a/pkg/domain/app.go
+++ b/pkg/domain/app.go
@@ -120,7 +120,7 @@ func (a *Application) Validate(
 	// resource conflict check
 	// exclude self if contained
 	existingApps = lo.Filter(existingApps, func(app *Application, _ int) bool { return app.ID != a.ID })
-	if a.WebsiteConflicts(existingApps, actor) {
+	if a.WebsiteConflicts(existingApps) {
 		return oops.New("website conflict")
 	}
 	for _, p := range a.PortPublications {

--- a/pkg/domain/app.go
+++ b/pkg/domain/app.go
@@ -93,7 +93,6 @@ func (a *Application) SelfValidate() error {
 }
 
 func (a *Application) Validate(
-	actor *User,
 	existingApps []*Application,
 	domains AvailableDomainSlice,
 	ports AvailablePortSlice,

--- a/pkg/domain/app_website.go
+++ b/pkg/domain/app_website.go
@@ -215,7 +215,7 @@ func (w *Website) overlapsWith(target *Website) bool {
 	return w.pathContainedBy(target) || target.pathContainedBy(w)
 }
 
-func (a *Application) WebsiteConflicts(existing []*Application, actor *User) bool {
+func (a *Application) WebsiteConflicts(existing []*Application) bool {
 	for _, w := range a.Websites {
 		// check with all other websites
 		for _, other := range append(existing, a) {
@@ -226,7 +226,7 @@ func (a *Application) WebsiteConflicts(existing []*Application, actor *User) boo
 				if w.Equals(w2) {
 					return true
 				}
-				if w.overlapsWith(w2) && !other.IsOwner(actor) {
+				if w.overlapsWith(w2) {
 					return true
 				}
 			}

--- a/pkg/domain/app_website_test.go
+++ b/pkg/domain/app_website_test.go
@@ -451,7 +451,7 @@ func TestApplication_WebsiteConflicts(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := tt.target.WebsiteConflicts([]*Application{tt.existing}, tt.actor)
+			got := tt.target.WebsiteConflicts([]*Application{tt.existing})
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/pkg/usecase/apiserver/app_service.go
+++ b/pkg/usecase/apiserver/app_service.go
@@ -26,7 +26,7 @@ func (s *Service) validateApp(ctx context.Context, app *domain.Application) erro
 	if err != nil {
 		return oops.Wrapf(err, "getting system info")
 	}
-	err = app.Validate(web.GetUser(ctx), existingApps, si.AvailableDomains, si.AvailablePorts)
+	err = app.Validate(existingApps, si.AvailableDomains, si.AvailablePorts)
 	if err != nil {
 		return newError(ErrorTypeBadRequest, "invalid application", err)
 	}


### PR DESCRIPTION
## なぜやるか
ref: #1170 

## やったこと
1. ConflictsWith から actor を消しました
2. テストを直しました ← NEW!

## 資料
https://github.com/traPtitech/NeoShowcase/issues/1170


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **不具合修正**
  * 同じ所有者がいるアプリケーション間のウェブサイト重複を、競合として検出しないようになりました。
  * ウェブサイトの重複チェックが、操作を行うユーザーに依存せず、アプリケーションの所有者情報に基づいて判定されるようになりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->